### PR TITLE
Fix module-qualified class type mismatch (issue #1)

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -460,6 +460,22 @@ Point p = Point(3, 4);
 f64 d = p.distance();
 ```
 
+### Module Classes
+
+Classes from modules must use module-qualified type names:
+
+```c
+import "models";
+
+// Correct: module-qualified type
+models.Point p = models.Point(3, 4);
+
+// Error: unqualified type doesn't match module class
+Point p = models.Point(3, 4);  // type mismatch
+```
+
+This ensures type safety and prevents ambiguity when multiple modules define classes with the same name.
+
 ### Fallible Construction
 
 If `init` returns `err`, construction uses tuple binding:

--- a/examples/test_programs/module_type_bug/basl.toml
+++ b/examples/test_programs/module_type_bug/basl.toml
@@ -1,0 +1,3 @@
+[project]
+name = "module_type_bug"
+version = "0.1.0"

--- a/examples/test_programs/module_type_bug/lib/mymodule.basl
+++ b/examples/test_programs/module_type_bug/lib/mymodule.basl
@@ -1,0 +1,7 @@
+pub class MyClass {
+    pub string value;
+    
+    fn init() -> void {
+        self.value = "hello";
+    }
+}

--- a/examples/test_programs/module_type_bug/main.basl
+++ b/examples/test_programs/module_type_bug/main.basl
@@ -1,0 +1,10 @@
+import "mymodule";
+import "fmt";
+
+fn main() -> i32 {
+    // This should now work with the fix
+    mymodule.MyClass obj = mymodule.MyClass();
+    
+    fmt.println(obj.value);
+    return 0;
+}

--- a/examples/test_programs/module_type_bug/test/module_type_test.basl
+++ b/examples/test_programs/module_type_bug/test/module_type_test.basl
@@ -1,0 +1,27 @@
+import "t";
+import "mymodule";
+
+fn test_module_class_type_annotation() -> void {
+    // This should work: module-qualified type annotation
+    mymodule.MyClass obj = mymodule.MyClass();
+    
+    t.assert(obj.value == "hello", "Object should be initialized");
+}
+
+fn test_module_class_field_access() -> void {
+    mymodule.MyClass obj = mymodule.MyClass();
+    obj.value = "world";
+    
+    t.assert(obj.value == "world", "Field should be mutable");
+}
+
+fn test_module_class_multiple_instances() -> void {
+    mymodule.MyClass obj1 = mymodule.MyClass();
+    mymodule.MyClass obj2 = mymodule.MyClass();
+    
+    obj1.value = "first";
+    obj2.value = "second";
+    
+    t.assert(obj1.value == "first", "First instance should be independent");
+    t.assert(obj2.value == "second", "Second instance should be independent");
+}

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -397,8 +397,8 @@ class BaslSyntaxIntegrationTests(unittest.TestCase):
             import "models";
 
             fn main() -> i32 {
-                Point p = models.Point(2, 3);
-                Segment s = models.Segment(models.Point(2, 3), models.Point(9, 6));
+                models.Point p = models.Point(2, 3);
+                models.Segment s = models.Segment(models.Point(2, 3), models.Point(9, 6));
                 fmt.print(string(p.x) + ":" + string(s.a.y) + ":" + string(s.dx()));
                 return 0;
             }

--- a/pkg/basl/interp/exprs.go
+++ b/pkg/basl/interp/exprs.go
@@ -1108,8 +1108,14 @@ func (interp *Interpreter) evalIndex(e *ast.IndexExpr, env *Env) (value.Value, e
 
 // constructObject creates a new class instance and calls init if present.
 func (interp *Interpreter) constructObject(cls *value.ClassVal, args []value.Value) (value.Value, error) {
+	// Use fully-qualified name if class is from a module
+	className := cls.Name
+	if cls.ModuleName != "" {
+		className = cls.ModuleName + "." + cls.Name
+	}
+
 	obj := &value.ObjectVal{
-		ClassName:  cls.Name,
+		ClassName:  className,
 		Implements: cls.Implements,
 		Fields:     make(map[string]value.Value),
 		Methods:    cls.Methods,

--- a/pkg/basl/interp/interp_test.go
+++ b/pkg/basl/interp/interp_test.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2138,4 +2139,67 @@ func TestExec_TypeConversionErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExec_ModuleClassTypeQualification(t *testing.T) {
+	// Test that module-qualified class types work correctly
+	// This is a regression test for issue #1
+
+	// Create a temporary module file
+	tmpDir := t.TempDir()
+	modPath := filepath.Join(tmpDir, "lib")
+	if err := os.MkdirAll(modPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write module with a class
+	modFile := filepath.Join(modPath, "testmod.basl")
+	modSrc := `pub class TestClass {
+    pub string value;
+    
+    fn init() -> void {
+        self.value = "initialized";
+    }
+}`
+	if err := os.WriteFile(modFile, []byte(modSrc), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test program that uses module-qualified type annotation
+	mainSrc := `import "testmod";
+import "fmt";
+
+fn main() -> i32 {
+    testmod.TestClass obj = testmod.TestClass();
+    fmt.print(obj.value);
+    return 0;
+}`
+
+	// Parse and execute
+	lex := lexer.New(mainSrc)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := parser.New(tokens)
+	prog, err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	interp := New()
+	interp.AddSearchPath(modPath) // Add the lib directory to search path
+	var lines []string
+	interp.PrintFn = func(s string) { lines = append(lines, strings.TrimRight(s, "\n")) }
+
+	code, err := interp.Exec(prog)
+	if err != nil {
+		t.Fatalf("execution error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+
+	want := []string{"initialized"}
+	checkOutput(t, lines, want)
 }

--- a/pkg/basl/interp/modules.go
+++ b/pkg/basl/interp/modules.go
@@ -241,6 +241,11 @@ func (ml *ModuleLoader) loadSource(name string, src string) (*Env, error) {
 		case *ast.ClassDecl:
 			if d.Pub {
 				if v, ok := modEnv.Get(d.Name); ok {
+					// Set module name for proper namespacing
+					if v.T == value.TypeClass {
+						cls := v.AsClass()
+						cls.ModuleName = name
+					}
 					exports.Define(d.Name, v)
 				}
 			}

--- a/pkg/basl/value/value.go
+++ b/pkg/basl/value/value.go
@@ -119,6 +119,7 @@ type ObjectVal struct {
 // ClassVal is a class descriptor — calling it constructs an instance.
 type ClassVal struct {
 	Name       string
+	ModuleName string   // module this class belongs to (empty for top-level)
 	Implements []string // interface names
 	Fields     []ClassFieldDef
 	Methods    map[string]*FuncVal


### PR DESCRIPTION
Store fully-qualified class names when constructing objects from module classes. This ensures proper type checking and namespacing across module boundaries.

Previously, classes from modules were stored with only their simple name (e.g., "MyClass"), but type annotations used the module-qualified name (e.g., "mymodule.MyClass"), causing runtime type mismatch errors.

Changes:
- Add ModuleName field to ClassVal to track module origin
- Set ModuleName when exporting public classes from modules
- Use fully-qualified name (module.Class) when constructing objects
- Add regression test and update existing test for correct behavior
- Document module-qualified class type requirement in syntax.md

This is a breaking change for code using unqualified type names with module classes, which was incorrect but sometimes worked. Proper usage:

  import "models";
  models.Point p = models.Point(3, 4);  // Correct

Fixes #1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
