### PR TITLE
Fix doc/implementation mismatches (issue #2)

### DIFF
--- a/cmd/basl/new.go
+++ b/cmd/basl/new.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func runNew(args []string) int {
@@ -33,6 +34,10 @@ func runNew(args []string) int {
 		fmt.Fprintln(os.Stderr, "usage: basl new <project-name> [--lib]")
 		return 2
 	}
+
+	// Strip trailing slashes for cleaner output
+	name = strings.TrimSuffix(name, "/")
+	name = strings.TrimSuffix(name, "\\") // Windows
 
 	root, _ := filepath.Abs(name)
 
@@ -75,7 +80,7 @@ func runNew(args []string) int {
 			"import \"fmt\";\n\nfn main() -> i32 {\n    fmt.println(\"hello, world!\");\n    return 0;\n}\n")
 	}
 
-	fmt.Printf("created %s/\n", name)
+	fmt.Printf("created %s\n", name)
 	if lib {
 		fmt.Printf("  basl.toml\n  lib/%s.basl\n  test/%s_test.basl\n  .gitignore\n", baseName, baseName)
 	} else {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -125,12 +125,12 @@ basl test -run sqrt                # Tests matching "sqrt"
 
 Test files must:
 - End with `_test.basl`
-- Import `"test"` module
+- Import `"t"` module
 - Define functions starting with `test_`
 
 Example test:
 ```c
-import "test" as t;
+import "t";
 
 fn test_addition() -> void {
     t.assert(2 + 2 == 4, "addition works");

--- a/pkg/basl/formatter/exprs.go
+++ b/pkg/basl/formatter/exprs.go
@@ -212,6 +212,10 @@ func escapeFStringText(s string) string {
 			sb.WriteString("\\\\")
 		case '"':
 			sb.WriteString("\\\"")
+		case '{':
+			sb.WriteString("{{") // Escape literal { as {{
+		case '}':
+			sb.WriteString("}}") // Escape literal } as }}
 		default:
 			sb.WriteRune(ch)
 		}

--- a/pkg/basl/formatter/stmts.go
+++ b/pkg/basl/formatter/stmts.go
@@ -139,6 +139,13 @@ func (f *formatter) stmt(s ast.Stmt) {
 }
 
 func (f *formatter) varStmt(s *ast.VarStmt) {
+	// Check if this is a local function declaration
+	if fnLit, ok := s.Init.(*ast.FnLitExpr); ok && fnLit.Decl != nil {
+		// Format as: fn name(params) -> ret { body }
+		f.fnDecl(fnLit.Decl, "")
+		return
+	}
+
 	prefix := ""
 	if s.Const {
 		prefix = "const "

--- a/pkg/basl/interp/stdlib_json.go
+++ b/pkg/basl/interp/stdlib_json.go
@@ -134,7 +134,8 @@ func (interp *Interpreter) jsonMethod(obj value.Value, method string, line int) 
 			}
 			arr, ok := data.([]interface{})
 			if !ok {
-				return value.Void, fmt.Errorf("json.Value.at_i32: not an array")
+				// Not an array - return 0 as documented
+				return value.NewI32(0), nil
 			}
 			idx := int(args[0].AsI32())
 			if idx < 0 || idx >= len(arr) {
@@ -152,7 +153,8 @@ func (interp *Interpreter) jsonMethod(obj value.Value, method string, line int) 
 			}
 			arr, ok := data.([]interface{})
 			if !ok {
-				return value.Void, fmt.Errorf("json.Value.at_string: not an array")
+				// Not an array - return "" as documented
+				return value.NewString(""), nil
 			}
 			idx := int(args[0].AsI32())
 			if idx < 0 || idx >= len(arr) {


### PR DESCRIPTION
Fixes 5 confirmed issues found while authoring examples from docs:

## Issues Fixed

### 1. Local functions broken by formatter ✅
- **Problem**: Formatter was rewriting `fn helper() {}` to invalid `fn helper = fn() {}`
- **Fix**: Detect FnLitExpr with FnDecl and preserve local function syntax
- **File**: `pkg/basl/formatter/stmts.go`

### 2. F-string brace escaping broken by formatter ✅
- **Problem**: Formatter wasn't re-escaping literal braces in text parts
- `{{{who}}}` was reformatted to `{{who}}` changing semantics
- **Fix**: Escape `{` and `}` as `{{` and `}}` in escapeFStringText()
- **File**: `pkg/basl/formatter/exprs.go`

### 3. json.Value.at_i32() errors on non-arrays ✅
- **Problem**: Documented to return 0 for non-arrays, but threw error instead
- **Fix**: Return 0 when value is not an array (matches docs)
- Also fixed at_string() for consistency
- **File**: `pkg/basl/interp/stdlib_json.go`

### 4. Test import path inconsistency in docs ✅
- **Problem**: cli.md said `import "test"`, stdlib/test.md said `import "t"`
- **Fix**: Updated cli.md to use correct `import "t"`
- **File**: `docs/cli.md`

### 5. Double slash in 'basl new' output ✅
- **Problem**: `basl new path/` printed `created path//`
- **Fix**: Strip trailing slashes from name and remove / from format string
- **File**: `cmd/basl/new.go`

## Not Reproduced

Issues #2 and #3 from the ticket (const and enum) were not reproducible - they work correctly.

## Testing

✅ All tests pass (59 integration + 11 debugger tests)
✅ Manually verified each fix with reproduction cases

Fixes #2