### PR TITLE
Fix README.md inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ BASL is a statically-typed, C-syntax scripting language that prioritizes readabi
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/basl.git
+git clone https://github.com/bluesentinelsec/basl.git
 cd basl
 
 # Build the binary
@@ -60,6 +60,7 @@ basl hello.basl
 
 ```bash
 basl
+>>> import "fmt";
 >>> i32 x = 42;
 >>> fmt.println(f"x = {x}");
 x = 42
@@ -246,7 +247,7 @@ basl editor vscode            # Install VS Code extension
 
 ### Documentation
 
-See [Doc Command](doc_cli.md) for details.
+See [Doc Command](docs/doc_cli.md) for details.
 
 ```bash
 basl doc lib/utils.basl         # Show module documentation


### PR DESCRIPTION
Fixes 3 documentation issues found during comprehensive audit:

## Issues Fixed

### 1. REPL Example Missing Import Statement ✅
**Problem**: The REPL example showed using `fmt.println()` without importing fmt first, which causes an "undefined variable" error.

**Before**:
```bash
basl
>>> i32 x = 42;
>>> fmt.println(f"x = {x}");
x = 42
```

**After**:
```bash
basl
>>> import "fmt";
>>> i32 x = 42;
>>> fmt.println(f"x = {x}");
x = 42
```

### 2. Broken Doc Command Link ✅
**Problem**: Link was missing `docs/` prefix

**Fixed**: `doc_cli.md` → `docs/doc_cli.md`

### 3. GitHub Clone URL Placeholder ✅
**Problem**: Used placeholder `yourusername` instead of actual repository

**Fixed**: `https://github.com/yourusername/basl.git` → `https://github.com/bluesentinelsec/basl.git`

## Audit Results

✅ All code examples tested and verified working:
- Hello World
- Types (i32, f64, string, bool, array, map)
- Functions (including multi-return error handling)
- Control flow (if/else, for, for-in, switch)
- String interpolation (including format specifiers)
- Classes (with init and methods)

✅ All CLI commands verified:
- `basl fmt`
- `basl new`
- `basl --help`

✅ All example files exist and are referenced correctly

✅ REPL functionality works (with corrected example)