### PR TITLE
Add \r (carriage return) escape sequence

### DIFF
--- a/pkg/basl/lexer/cr_escape_test.go
+++ b/pkg/basl/lexer/cr_escape_test.go
@@ -1,0 +1,94 @@
+package lexer
+
+import (
+	"testing"
+)
+
+func TestCarriageReturnEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected byte
+	}{
+		{
+			name:     "regular string with \\r",
+			input:    `"hello\rworld"`,
+			expected: '\r',
+		},
+		{
+			name:     "f-string with \\r",
+			input:    `f"hello\rworld"`,
+			expected: '\r',
+		},
+		{
+			name:     "CRLF sequence",
+			input:    `"line1\r\nline2"`,
+			expected: '\r',
+		},
+		{
+			name:     "only \\r",
+			input:    `"\r"`,
+			expected: '\r',
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := New(tt.input)
+			tok, err := l.nextToken()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tok.Type != TOKEN_STRING && tok.Type != TOKEN_FSTRING {
+				t.Fatalf("expected string token, got %v", tok.Type)
+			}
+
+			// Check that the string contains a carriage return
+			found := false
+			for i := 0; i < len(tok.Literal); i++ {
+				if tok.Literal[i] == tt.expected {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("expected string to contain carriage return (0x%02x), got: %q", tt.expected, tok.Literal)
+			}
+		})
+	}
+}
+
+func TestCarriageReturnInBASL(t *testing.T) {
+	// Test that \r works in actual BASL code
+	input := `
+		import "fmt";
+		fn main() -> i32 {
+			string crlf = "\r\n";
+			if (crlf.len() == 2) {
+				return 0;
+			}
+			return 1;
+		}
+	`
+
+	l := New(input)
+	tokens := []Token{}
+
+	for {
+		tok, err := l.nextToken()
+		if err != nil {
+			t.Fatalf("lexer error: %v", err)
+		}
+		tokens = append(tokens, tok)
+		if tok.Type == TOKEN_EOF {
+			break
+		}
+	}
+
+	// Just verify it lexes without error
+	if len(tokens) == 0 {
+		t.Error("expected tokens, got none")
+	}
+}

--- a/pkg/basl/lexer/lexer.go
+++ b/pkg/basl/lexer/lexer.go
@@ -113,12 +113,14 @@ func (l *Lexer) readString() (Token, error) {
 				buf = append(buf, '\n')
 			case 't':
 				buf = append(buf, '\t')
+			case 'r':
+				buf = append(buf, '\r')
 			case '\\':
 				buf = append(buf, '\\')
 			case '"':
 				buf = append(buf, '"')
 			default:
-				return Token{}, fmt.Errorf("%d:%d: unknown escape sequence \\%c — valid escapes are \\n, \\t, \\\\, \\\"", l.line, l.col, esc)
+				return Token{}, fmt.Errorf("%d:%d: unknown escape sequence \\%c — valid escapes are \\n, \\t, \\r, \\\\, \\\"", l.line, l.col, esc)
 			}
 		} else {
 			buf = append(buf, ch)
@@ -237,12 +239,14 @@ func (l *Lexer) readFString() (Token, error) {
 				buf = append(buf, '\n')
 			case 't':
 				buf = append(buf, '\t')
+			case 'r':
+				buf = append(buf, '\r')
 			case '\\':
 				buf = append(buf, '\\')
 			case '"':
 				buf = append(buf, '"')
 			default:
-				return Token{}, fmt.Errorf("%d:%d: unknown escape sequence \\%c in f-string — valid escapes are \\n, \\t, \\\\, \\\"", l.line, l.col, esc)
+				return Token{}, fmt.Errorf("%d:%d: unknown escape sequence \\%c in f-string — valid escapes are \\n, \\t, \\r, \\\\, \\\"", l.line, l.col, esc)
 			}
 			l.advance()
 			continue


### PR DESCRIPTION
Fixes #11

## Changes

Adds support for `\r` escape sequence in both regular strings and f-strings.

## Motivation

Without `\r`, handling Windows-style CRLF text required workarounds:

**Before:**
```c
// Could not create CRLF in string literals
// Had to use bytes() and check for byte value 13
```

**After:**
```c
string crlf = "\r\n";  // Clean and explicit
string line = "text\r\n";
```

## Implementation

- Added `'r'` case to escape sequence handling in `lexer.go`
- Handles both regular strings and f-strings
- Produces byte value 13 (0x0D)
- Updated error messages to list `\r` as valid escape

## Use Cases

1. **CRLF line endings:**
   ```c
   string windows_text = "line1\r\nline2\r\n";
   ```

2. **Explicit carriage return:**
   ```c
   string progress = "Processing...\r";  // Overwrite line
   ```

3. **Cross-platform text handling:**
   ```c
   if (ch == "\r") {
       // Handle CR explicitly
   }
   ```

## Testing

- 5 new tests covering:
  - Regular strings with `\r`
  - F-strings with `\r`
  - CRLF sequences
  - Standalone `\r`
  - Integration test in BASL code
- All existing tests pass (59 integration + 11 debugger)

## Impact

This was identified as a gap during basl-wc development (PR #9). The workaround required using `bytes()` to detect CR by byte value, which was less readable than using `\r` directly.

Now BASL supports all common escape sequences: `\n`, `\t`, `\r`, `\\`, `\"`