### PR TITLE
Add file.copy() for efficient file copying

### DIFF
--- a/docs/stdlib/file.md
+++ b/docs/stdlib/file.md
@@ -73,6 +73,18 @@ Renames (moves) a file.
 err e = file.rename("old.txt", "new.txt");
 ```
 
+### file.copy(string src, string dst) -> err
+
+Copies a file from `src` to `dst`. Uses efficient streaming copy.
+
+- Returns `ok` on success.
+- Returns `err(message)` on failure.
+- Overwrites destination if it exists.
+
+```c
+err e = file.copy("source.txt", "dest.txt");
+```
+
 ### file.mkdir(string path) -> err
 
 Creates a directory and all necessary parents (like `mkdir -p`). Directory permissions: `0755`.

--- a/pkg/basl/interp/file_copy_test.go
+++ b/pkg/basl/interp/file_copy_test.go
@@ -1,0 +1,116 @@
+package interp
+
+import (
+	"testing"
+)
+
+func TestFileCopy(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create source file
+			err e1 = file.write_all("test_copy_src.txt", "hello world");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Copy file
+			err e2 = file.copy("test_copy_src.txt", "test_copy_dst.txt");
+			if (e2 != ok) {
+				file.remove("test_copy_src.txt");
+				return 2;
+			}
+			
+			// Verify destination
+			string content, err e3 = file.read_all("test_copy_dst.txt");
+			if (e3 != ok) {
+				file.remove("test_copy_src.txt");
+				file.remove("test_copy_dst.txt");
+				return 3;
+			}
+			
+			if (content != "hello world") {
+				file.remove("test_copy_src.txt");
+				file.remove("test_copy_dst.txt");
+				return 4;
+			}
+			
+			// Cleanup
+			file.remove("test_copy_src.txt");
+			file.remove("test_copy_dst.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileCopyNonexistent(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			err e = file.copy("nonexistent_file_xyz.txt", "dest.txt");
+			if (e == ok) {
+				return 1;
+			}
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileCopyOverwrite(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create source and destination
+			file.write_all("test_copy_src2.txt", "new content");
+			file.write_all("test_copy_dst2.txt", "old content");
+			
+			// Copy (overwrite)
+			err e = file.copy("test_copy_src2.txt", "test_copy_dst2.txt");
+			if (e != ok) {
+				file.remove("test_copy_src2.txt");
+				file.remove("test_copy_dst2.txt");
+				return 1;
+			}
+			
+			// Verify overwrite
+			string content, err e2 = file.read_all("test_copy_dst2.txt");
+			if (content != "new content") {
+				file.remove("test_copy_src2.txt");
+				file.remove("test_copy_dst2.txt");
+				return 2;
+			}
+			
+			// Cleanup
+			file.remove("test_copy_src2.txt");
+			file.remove("test_copy_dst2.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}

--- a/pkg/basl/interp/stdlib_file.go
+++ b/pkg/basl/interp/stdlib_file.go
@@ -97,6 +97,31 @@ func (interp *Interpreter) makeFileModule() *Env {
 		}
 		return value.Ok, nil
 	}))
+	env.Define("copy", value.NewNativeFunc("file.copy", func(args []value.Value) (value.Value, error) {
+		if len(args) != 2 || args[0].T != value.TypeString || args[1].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.copy: expected (string src, string dst)")
+		}
+		src := args[0].AsString()
+		dst := args[1].AsString()
+
+		srcFile, err := os.Open(src)
+		if err != nil {
+			return value.NewErr(fileErr(err, src)), nil
+		}
+		defer srcFile.Close()
+
+		dstFile, err := os.Create(dst)
+		if err != nil {
+			return value.NewErr(fileErr(err, dst)), nil
+		}
+		defer dstFile.Close()
+
+		if _, err := io.Copy(dstFile, srcFile); err != nil {
+			return value.NewErr(fileErr(err, dst)), nil
+		}
+
+		return value.Ok, nil
+	}))
 	env.Define("mkdir", value.NewNativeFunc("file.mkdir", func(args []value.Value) (value.Value, error) {
 		if len(args) != 1 || args[0].T != value.TypeString {
 			return value.Void, fmt.Errorf("file.mkdir: expected string path")


### PR DESCRIPTION
Implements streaming file copy using io.Copy for memory efficiency.

API:
- file.copy(string src, string dst) -> err
- Returns ok on success
- Returns err(message) on failure
- Overwrites destination if it exists

Implementation:
- Uses os.Open + os.Create + io.Copy
- Streams data without loading entire file into memory
- Efficient for large files
- Cross-platform compatible

Tests:
- TestFileCopy: Basic copy operation
- TestFileCopyNonexistent: Error handling for missing source
- TestFileCopyOverwrite: Destination overwrite behavior

Documentation updated in docs/stdlib/file.md

Needed for: cp command in Unix tools 2