### PR TITLE
Add file.chmod() and mode field to FileStat

### DIFF
--- a/docs/stdlib/file.md
+++ b/docs/stdlib/file.md
@@ -136,6 +136,7 @@ FileStat fields:
 | `size` | `i32` | File size in bytes |
 | `is_dir` | `bool` | Whether it's a directory |
 | `mod_time` | `string` | Last modified time (ISO 8601: `"2006-01-02T15:04:05Z07:00"`) |
+| `mode` | `i32` | File mode/permissions (Unix permission bits) |
 
 ```c
 FileStat info, err e = file.stat("data.txt");
@@ -143,7 +144,27 @@ fmt.println(info.name);      // "data.txt"
 fmt.println(info.size);      // 1234
 fmt.println(info.is_dir);    // false
 fmt.println(info.mod_time);  // "2024-01-15T10:30:00-05:00"
+fmt.println(info.mode);      // 420 (0644 in octal)
 ```
+
+### file.chmod(string path, i32 mode) -> err
+
+Changes file permissions.
+
+- Returns `ok` on success.
+- Returns `err(message)` on failure.
+- Mode uses Unix permission bits (e.g., `0644` = `420` decimal).
+- **Windows:** Limited support (read-only flag only).
+
+```c
+err e = file.chmod("script.sh", 0o755);  // rwxr-xr-x
+```
+
+Common modes:
+- `0o644` (420) - rw-r--r-- (regular file)
+- `0o755` (493) - rwxr-xr-x (executable)
+- `0o600` (384) - rw------- (private file)
+- `0o777` (511) - rwxrwxrwx (all permissions)
 
 ## File Methods
 

--- a/pkg/basl/interp/file_chmod_test.go
+++ b/pkg/basl/interp/file_chmod_test.go
@@ -1,0 +1,166 @@
+package interp
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestFileChmod(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod has limited support on Windows")
+	}
+
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create file with default permissions
+			err e1 = file.write_all("test_chmod.txt", "data");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Change to 0600 (read/write owner only)
+			err e2 = file.chmod("test_chmod.txt", 0o600);
+			if (e2 != ok) {
+				file.remove("test_chmod.txt");
+				return 2;
+			}
+			
+			// Verify mode changed
+			FileStat info, err e3 = file.stat("test_chmod.txt");
+			if (e3 != ok) {
+				file.remove("test_chmod.txt");
+				return 3;
+			}
+			
+			// Mode should be 0600 (384 decimal) plus file type bits
+			// On Unix, regular files have type bits, so we check lower 9 bits
+			i32 perms = info.mode & 0o777;
+			if (perms != 0o600) {
+				file.remove("test_chmod.txt");
+				return 4;
+			}
+			
+			// Cleanup
+			file.remove("test_chmod.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileStatMode(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create file
+			err e1 = file.write_all("test_stat_mode.txt", "data");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Get stat
+			FileStat info, err e2 = file.stat("test_stat_mode.txt");
+			if (e2 != ok) {
+				file.remove("test_stat_mode.txt");
+				return 2;
+			}
+			
+			// Mode should be non-zero
+			if (info.mode == 0) {
+				file.remove("test_stat_mode.txt");
+				return 3;
+			}
+			
+			// Cleanup
+			file.remove("test_stat_mode.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileChmodExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod has limited support on Windows")
+	}
+
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create file
+			file.write_all("test_chmod_exec.txt", "#!/bin/sh\necho test");
+			
+			// Make executable (0755)
+			err e = file.chmod("test_chmod_exec.txt", 0o755);
+			if (e != ok) {
+				file.remove("test_chmod_exec.txt");
+				return 1;
+			}
+			
+			// Verify
+			FileStat info, err e2 = file.stat("test_chmod_exec.txt");
+			if (e2 != ok) {
+				file.remove("test_chmod_exec.txt");
+				return 2;
+			}
+			
+			i32 perms = info.mode & 0o777;
+			if (perms != 0o755) {
+				file.remove("test_chmod_exec.txt");
+				return 3;
+			}
+			
+			// Cleanup
+			file.remove("test_chmod_exec.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileChmodNonexistent(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			err e = file.chmod("nonexistent_file_xyz.txt", 0o644);
+			if (e == ok) {
+				return 1;
+			}
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}

--- a/pkg/basl/interp/stdlib_file.go
+++ b/pkg/basl/interp/stdlib_file.go
@@ -180,12 +180,25 @@ func (interp *Interpreter) makeFileModule() *Env {
 				"is_dir":   value.NewBool(info.IsDir()),
 				"mod_time": value.NewString(info.ModTime().Format("2006-01-02T15:04:05Z07:00")),
 				"name":     value.NewString(info.Name()),
+				"mode":     value.NewI32(int32(info.Mode())),
 			},
 		}
 		return value.Void, &MultiReturnVal{Values: []value.Value{
 			{T: value.TypeObject, Data: obj},
 			value.Ok,
 		}}
+	}))
+
+	env.Define("chmod", value.NewNativeFunc("file.chmod", func(args []value.Value) (value.Value, error) {
+		if len(args) != 2 || args[0].T != value.TypeString || args[1].T != value.TypeI32 {
+			return value.Void, fmt.Errorf("file.chmod: expected (string path, i32 mode)")
+		}
+		path := args[0].AsString()
+		mode := os.FileMode(args[1].AsI32())
+		if err := os.Chmod(path, mode); err != nil {
+			return value.NewErr(fileErr(err, path)), nil
+		}
+		return value.Ok, nil
 	}))
 
 	return env


### PR DESCRIPTION
Implements permission management for Unix chmod command support.

API:
- file.chmod(string path, i32 mode) -> err
  Changes file permissions using Unix permission bits
  
- FileStat.mode field added (i32)
  Contains file mode/permissions from os.FileMode

Permission bits:
- 0o644 (420) - rw-r--r-- (regular file)
- 0o755 (493) - rwxr-xr-x (executable)
- 0o600 (384) - rw------- (private file)
- 0o777 (511) - rwxrwxrwx (all permissions)

Cross-platform notes:
- Full support on Unix/Linux/macOS
- Windows has limited support (read-only flag only)
- Tests skip on Windows

Implementation:
- Uses os.Chmod for permission changes
- FileStat.mode contains full os.FileMode value
- Lower 9 bits (& 0o777) contain Unix permissions
- Upper bits contain file type flags

Tests:
- TestFileChmod: Change permissions to 0600
- TestFileStatMode: Verify mode field exists
- TestFileChmodExecutable: Make file executable (0755)
- TestFileChmodNonexistent: Error handling

Documentation updated in docs/stdlib/file.md

Needed for: chmod command in Unix tools 2