### PR TITLE
Add file.touch() for creating files and updating timestamps

### DIFF
--- a/docs/stdlib/file.md
+++ b/docs/stdlib/file.md
@@ -81,6 +81,19 @@ Creates a directory and all necessary parents (like `mkdir -p`). Directory permi
 err e = file.mkdir("a/b/c");
 ```
 
+### file.touch(string path) -> err
+
+Creates an empty file or updates the modification time of an existing file.
+
+- Returns `ok` on success.
+- Returns `err(message)` on failure.
+- If file doesn't exist, creates it with permissions `0644`.
+- If file exists, updates access and modification times to current time.
+
+```c
+err e = file.touch("newfile.txt");
+```
+
 ### file.list_dir(string path) -> (array\<string\>, err)
 
 Lists the names of entries in a directory.

--- a/pkg/basl/interp/file_touch_test.go
+++ b/pkg/basl/interp/file_touch_test.go
@@ -1,0 +1,180 @@
+package interp
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFileTouchCreate(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Touch non-existent file (should create)
+			err e1 = file.touch("test_touch_new.txt");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Verify file exists
+			bool exists = file.exists("test_touch_new.txt");
+			if (!exists) {
+				file.remove("test_touch_new.txt");
+				return 2;
+			}
+			
+			// Verify file is empty
+			string content, err e2 = file.read_all("test_touch_new.txt");
+			if (e2 != ok || content != "") {
+				file.remove("test_touch_new.txt");
+				return 3;
+			}
+			
+			// Cleanup
+			file.remove("test_touch_new.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileTouchUpdate(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create file with content
+			err e1 = file.write_all("test_touch_update.txt", "content");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Get initial mod time
+			FileStat info1, err e2 = file.stat("test_touch_update.txt");
+			if (e2 != ok) {
+				file.remove("test_touch_update.txt");
+				return 2;
+			}
+			string time1 = info1.mod_time;
+			
+			// Touch file (update timestamp)
+			err e3 = file.touch("test_touch_update.txt");
+			if (e3 != ok) {
+				file.remove("test_touch_update.txt");
+				return 3;
+			}
+			
+			// Verify content unchanged
+			string content, err e4 = file.read_all("test_touch_update.txt");
+			if (e4 != ok || content != "content") {
+				file.remove("test_touch_update.txt");
+				return 4;
+			}
+			
+			// Get new mod time
+			FileStat info2, err e5 = file.stat("test_touch_update.txt");
+			if (e5 != ok) {
+				file.remove("test_touch_update.txt");
+				return 5;
+			}
+			string time2 = info2.mod_time;
+			
+			// Times should be different (note: may fail if system is very fast)
+			// We just verify the touch succeeded, not that time changed
+			// (timing tests are flaky)
+			
+			// Cleanup
+			file.remove("test_touch_update.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileTouchTimestampUpdate(t *testing.T) {
+	// This test verifies timestamp actually changes at Go level
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create file
+			err e = file.write_all("test_touch_ts.txt", "data");
+			if (e != ok) {
+				return 1;
+			}
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("failed to create test file")
+	}
+
+	// Get initial mod time
+	info1, err := os.Stat("test_touch_ts.txt")
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+	time1 := info1.ModTime()
+
+	// Sleep to ensure time difference
+	time.Sleep(10 * time.Millisecond)
+
+	// Touch file
+	code2 := `
+		import "file";
+		
+		fn main() -> i32 {
+			err e = file.touch("test_touch_ts.txt");
+			if (e != ok) {
+				return 1;
+			}
+			return 0;
+		}
+	`
+
+	exitCode, _, err = evalBASL(code2)
+	if err != nil {
+		os.Remove("test_touch_ts.txt")
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		os.Remove("test_touch_ts.txt")
+		t.Fatalf("touch failed")
+	}
+
+	// Get new mod time
+	info2, err := os.Stat("test_touch_ts.txt")
+	if err != nil {
+		os.Remove("test_touch_ts.txt")
+		t.Fatalf("failed to stat file after touch: %v", err)
+	}
+	time2 := info2.ModTime()
+
+	// Cleanup
+	os.Remove("test_touch_ts.txt")
+
+	// Verify timestamp changed
+	if !time2.After(time1) {
+		t.Errorf("expected mod time to increase, got %v -> %v", time1, time2)
+	}
+}

--- a/pkg/basl/interp/stdlib_file.go
+++ b/pkg/basl/interp/stdlib_file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/bluesentinelsec/basl/pkg/basl/value"
 )
@@ -105,6 +106,34 @@ func (interp *Interpreter) makeFileModule() *Env {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			return value.NewErr(fileErr(err, path)), nil
 		}
+		return value.Ok, nil
+	}))
+	env.Define("touch", value.NewNativeFunc("file.touch", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.touch: expected string path")
+		}
+		path := args[0].AsString()
+
+		// Check if file exists
+		_, err := os.Stat(path)
+		if err == nil {
+			// File exists, update timestamp
+			now := time.Now()
+			if err := os.Chtimes(path, now, now); err != nil {
+				return value.NewErr(fileErr(err, path)), nil
+			}
+		} else if errors.Is(err, os.ErrNotExist) {
+			// File doesn't exist, create it
+			f, err := os.Create(path)
+			if err != nil {
+				return value.NewErr(fileErr(err, path)), nil
+			}
+			f.Close()
+		} else {
+			// Other error
+			return value.NewErr(fileErr(err, path)), nil
+		}
+
 		return value.Ok, nil
 	}))
 	env.Define("list_dir", value.NewNativeFunc("file.list_dir", func(args []value.Value) (value.Value, error) {


### PR DESCRIPTION
Implements Unix touch command functionality.

API:
- file.touch(string path) -> err
  Creates empty file or updates modification time

Behavior:
- If file doesn't exist: creates empty file with 0644 permissions
- If file exists: updates access and modification times to current time
- Content is preserved when updating existing files

Implementation:
- Uses os.Stat to check existence
- Uses os.Create for new files
- Uses os.Chtimes to update timestamps
- Cross-platform compatible

Tests:
- TestFileTouchCreate: Create new empty file
- TestFileTouchUpdate: Update existing file, preserve content
- TestFileTouchTimestampUpdate: Verify timestamp actually changes

Documentation updated in docs/stdlib/file.md

Needed for: touch command in Unix tools 2