### PR TITLE
Add symbolic and hard link operations

### DIFF
--- a/docs/stdlib/file.md
+++ b/docs/stdlib/file.md
@@ -85,6 +85,41 @@ Copies a file from `src` to `dst`. Uses efficient streaming copy.
 err e = file.copy("source.txt", "dest.txt");
 ```
 
+### file.symlink(string target, string link) -> err
+
+Creates a symbolic link pointing to `target`.
+
+- Returns `ok` on success.
+- Returns `err(message)` on failure.
+- **Windows:** Requires administrator privileges or Developer Mode enabled.
+
+```c
+err e = file.symlink("target.txt", "link.txt");
+```
+
+### file.link(string target, string link) -> err
+
+Creates a hard link to `target`.
+
+- Returns `ok` on success.
+- Returns `err(message)` on failure.
+- Hard links share the same inode as the target.
+
+```c
+err e = file.link("target.txt", "hardlink.txt");
+```
+
+### file.readlink(string path) -> (string, err)
+
+Reads the target of a symbolic link.
+
+- Returns `(target, ok)` on success.
+- Returns `("", err(message))` on failure or if path is not a symlink.
+
+```c
+string target, err e = file.readlink("link.txt");
+```
+
 ### file.mkdir(string path) -> err
 
 Creates a directory and all necessary parents (like `mkdir -p`). Directory permissions: `0755`.

--- a/pkg/basl/interp/file_links_test.go
+++ b/pkg/basl/interp/file_links_test.go
@@ -1,0 +1,181 @@
+package interp
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestFileSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Symlinks require admin privileges on Windows")
+	}
+
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create target file
+			err e1 = file.write_all("test_symlink_target.txt", "target content");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Create symlink
+			err e2 = file.symlink("test_symlink_target.txt", "test_symlink_link.txt");
+			if (e2 != ok) {
+				file.remove("test_symlink_target.txt");
+				return 2;
+			}
+			
+			// Read through symlink
+			string content, err e3 = file.read_all("test_symlink_link.txt");
+			if (e3 != ok || content != "target content") {
+				file.remove("test_symlink_target.txt");
+				file.remove("test_symlink_link.txt");
+				return 3;
+			}
+			
+			// Cleanup
+			file.remove("test_symlink_link.txt");
+			file.remove("test_symlink_target.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileReadlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Symlinks require admin privileges on Windows")
+	}
+
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create target and symlink
+			file.write_all("test_readlink_target.txt", "data");
+			err e1 = file.symlink("test_readlink_target.txt", "test_readlink_link.txt");
+			if (e1 != ok) {
+				file.remove("test_readlink_target.txt");
+				return 1;
+			}
+			
+			// Read symlink target
+			string target, err e2 = file.readlink("test_readlink_link.txt");
+			if (e2 != ok || target != "test_readlink_target.txt") {
+				file.remove("test_readlink_target.txt");
+				file.remove("test_readlink_link.txt");
+				return 2;
+			}
+			
+			// Cleanup
+			file.remove("test_readlink_link.txt");
+			file.remove("test_readlink_target.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileHardlink(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create target file
+			err e1 = file.write_all("test_hardlink_target.txt", "shared content");
+			if (e1 != ok) {
+				return 1;
+			}
+			
+			// Create hard link
+			err e2 = file.link("test_hardlink_target.txt", "test_hardlink_link.txt");
+			if (e2 != ok) {
+				file.remove("test_hardlink_target.txt");
+				return 2;
+			}
+			
+			// Read through hard link
+			string content, err e3 = file.read_all("test_hardlink_link.txt");
+			if (e3 != ok || content != "shared content") {
+				file.remove("test_hardlink_target.txt");
+				file.remove("test_hardlink_link.txt");
+				return 3;
+			}
+			
+			// Modify through link
+			err e4 = file.write_all("test_hardlink_link.txt", "modified");
+			if (e4 != ok) {
+				file.remove("test_hardlink_target.txt");
+				file.remove("test_hardlink_link.txt");
+				return 4;
+			}
+			
+			// Verify original sees modification
+			string content2, err e5 = file.read_all("test_hardlink_target.txt");
+			if (e5 != ok || content2 != "modified") {
+				file.remove("test_hardlink_target.txt");
+				file.remove("test_hardlink_link.txt");
+				return 5;
+			}
+			
+			// Cleanup
+			file.remove("test_hardlink_link.txt");
+			file.remove("test_hardlink_target.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+func TestFileReadlinkNotSymlink(t *testing.T) {
+	code := `
+		import "file";
+		
+		fn main() -> i32 {
+			// Create regular file
+			file.write_all("test_not_symlink.txt", "data");
+			
+			// Try to read as symlink (should fail)
+			string target, err e = file.readlink("test_not_symlink.txt");
+			if (e == ok) {
+				file.remove("test_not_symlink.txt");
+				return 1;
+			}
+			
+			// Cleanup
+			file.remove("test_not_symlink.txt");
+			return 0;
+		}
+	`
+
+	exitCode, _, err := evalBASL(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+}

--- a/pkg/basl/interp/stdlib_file.go
+++ b/pkg/basl/interp/stdlib_file.go
@@ -122,6 +122,39 @@ func (interp *Interpreter) makeFileModule() *Env {
 
 		return value.Ok, nil
 	}))
+	env.Define("symlink", value.NewNativeFunc("file.symlink", func(args []value.Value) (value.Value, error) {
+		if len(args) != 2 || args[0].T != value.TypeString || args[1].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.symlink: expected (string target, string link)")
+		}
+		target := args[0].AsString()
+		link := args[1].AsString()
+		if err := os.Symlink(target, link); err != nil {
+			return value.NewErr(fileErr(err, link)), nil
+		}
+		return value.Ok, nil
+	}))
+	env.Define("link", value.NewNativeFunc("file.link", func(args []value.Value) (value.Value, error) {
+		if len(args) != 2 || args[0].T != value.TypeString || args[1].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.link: expected (string target, string link)")
+		}
+		target := args[0].AsString()
+		link := args[1].AsString()
+		if err := os.Link(target, link); err != nil {
+			return value.NewErr(fileErr(err, link)), nil
+		}
+		return value.Ok, nil
+	}))
+	env.Define("readlink", value.NewNativeFunc("file.readlink", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.readlink: expected string path")
+		}
+		path := args[0].AsString()
+		target, err := os.Readlink(path)
+		if err != nil {
+			return value.Void, &MultiReturnVal{Values: []value.Value{value.NewString(""), value.NewErr(fileErr(err, path))}}
+		}
+		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewString(target), value.Ok}}
+	}))
 	env.Define("mkdir", value.NewNativeFunc("file.mkdir", func(args []value.Value) (value.Value, error) {
 		if len(args) != 1 || args[0].T != value.TypeString {
 			return value.Void, fmt.Errorf("file.mkdir: expected string path")


### PR DESCRIPTION
Implements link creation and reading for Unix ln command support.

API:
- file.symlink(string target, string link) -> err
- file.link(string target, string link) -> err  
- file.readlink(string path) -> (string, err)

Cross-platform compatible. Tests and documentation included.

Needed for: ln command in Unix tools 2