### PR TITLE
Detect import cycles in module loading

### DIFF
--- a/docs/check.md
+++ b/docs/check.md
@@ -95,7 +95,7 @@ Imports are resolved across:
 - Project `deps/`
 - Builtin modules
 
-The checker loads imported modules statically and detects import cycles.
+The checker loads imported modules statically and detects import cycles, reporting the cycle chain when one is found.
 
 ### 3. Collect Declarations
 
@@ -159,7 +159,7 @@ This includes many builtin object types and methods such as:
 ### Import and Module Errors
 
 - Missing modules
-- Import cycles
+- Import cycles, including the cycle chain
 - Duplicate import aliases
 - Missing module exports
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -29,6 +29,7 @@ Imports resolve to built-in stdlib modules or `.basl` files.
 For direct script execution, BASL searches the script's directory first.
 When the script is inside a BASL project, BASL also searches the project's `lib/` and `deps/` directories automatically.
 Modules export only `pub` declarations.
+Circular imports are rejected with an explicit import chain, for example: `import cycle detected: a -> b -> a`.
 
 ## Types
 

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -143,6 +143,26 @@ class BaslSyntaxIntegrationTests(unittest.TestCase):
             main_rel="app/main.basl",
         )
 
+    def test_import_cycle_reports_chain(self) -> None:
+        files = {
+            "a.basl": """
+                import "b";
+                pub fn a_value() -> i32 { return 1; }
+            """,
+            "b.basl": """
+                import "a";
+                pub fn b_value() -> i32 { return 2; }
+            """,
+        }
+        source = """
+            import "a";
+
+            fn main() -> i32 {
+                return 0;
+            }
+        """
+        self._assert_failure(source, "import cycle detected: a -> b -> a", files=files)
+
     def test_types_literals_and_explicit_conversions(self) -> None:
         source = """
             import "fmt";

--- a/pkg/basl/interp/interp_test.go
+++ b/pkg/basl/interp/interp_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func evalBASL(src string) (int, []string, error) {
+	return evalBASLWithSearchPaths(src)
+}
+
+func evalBASLWithSearchPaths(src string, searchPaths ...string) (int, []string, error) {
 	lex := lexer.New(src)
 	tokens, err := lex.Tokenize()
 	if err != nil {
@@ -22,6 +26,9 @@ func evalBASL(src string) (int, []string, error) {
 		return 0, nil, err
 	}
 	interp := New()
+	for _, dir := range searchPaths {
+		interp.AddSearchPath(dir)
+	}
 	var lines []string
 	interp.PrintFn = func(s string) { lines = append(lines, strings.TrimRight(s, "\n")) }
 	code, err := interp.Exec(prog)
@@ -2209,6 +2216,68 @@ fn main() -> i32 {
 
 	want := []string{"initialized"}
 	checkOutput(t, lines, want)
+}
+
+func TestExec_ImportCycleReportsChain(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.basl"), []byte(`import "b";
+pub fn a_value() -> i32 {
+    return 1;
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "b.basl"), []byte(`import "a";
+pub fn b_value() -> i32 {
+    return 2;
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := evalBASLWithSearchPaths(`import "a";
+
+fn main() -> i32 {
+    return 0;
+}`, tmpDir)
+	if err == nil {
+		t.Fatal("expected import cycle error")
+	}
+	if !strings.Contains(err.Error(), "import cycle detected: a -> b -> a") {
+		t.Fatalf("error = %q, want cycle chain", err.Error())
+	}
+}
+
+func TestExec_ImportCycleReportsNestedChain(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.basl"), []byte(`import "b";
+pub fn a_value() -> i32 {
+    return 1;
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "b.basl"), []byte(`import "c";
+pub fn b_value() -> i32 {
+    return 2;
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "c.basl"), []byte(`import "a";
+pub fn c_value() -> i32 {
+    return 3;
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := evalBASLWithSearchPaths(`import "a";
+
+fn main() -> i32 {
+    return 0;
+}`, tmpDir)
+	if err == nil {
+		t.Fatal("expected import cycle error")
+	}
+	if !strings.Contains(err.Error(), "import cycle detected: a -> b -> c -> a") {
+		t.Fatalf("error = %q, want nested cycle chain", err.Error())
+	}
 }
 
 func TestExec_AnonymousFunctions(t *testing.T) {

--- a/pkg/basl/interp/modules.go
+++ b/pkg/basl/interp/modules.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bluesentinelsec/basl/pkg/basl/ast"
 	"github.com/bluesentinelsec/basl/pkg/basl/lexer"
@@ -20,14 +21,24 @@ type ModuleLoader struct {
 	EmbeddedFS map[string]fs.FS
 	// Cache of already-loaded modules
 	cache map[string]*Env
+	// Modules currently being loaded, keyed by canonical source identity
+	loading map[string]int
+	// Stack of in-progress module loads for cycle diagnostics
+	stack []moduleLoadFrame
 	// Interpreter reference for evaluating modules
 	interp *Interpreter
+}
+
+type moduleLoadFrame struct {
+	key  string
+	name string
 }
 
 func newModuleLoader(interp *Interpreter) *ModuleLoader {
 	return &ModuleLoader{
 		EmbeddedFS: make(map[string]fs.FS),
 		cache:      make(map[string]*Env),
+		loading:    make(map[string]int),
 		interp:     interp,
 	}
 }
@@ -62,7 +73,8 @@ func (ml *ModuleLoader) Resolve(name string) (*Env, error) {
 		filePath := relPath + ".basl"
 		data, err := fs.ReadFile(efs, filePath)
 		if err == nil {
-			env, err := ml.loadSource(name, string(data))
+			cacheKey := "embedded:" + prefix + ":" + filePath
+			env, err := ml.loadResolvedModule(name, cacheKey, string(data))
 			if err != nil {
 				return nil, fmt.Errorf("module %q: %w", name, err)
 			}
@@ -85,11 +97,10 @@ func (ml *ModuleLoader) Resolve(name string) (*Env, error) {
 		}
 		data, err := os.ReadFile(absPath)
 		if err == nil {
-			env, err := ml.loadSource(name, string(data))
+			env, err := ml.loadResolvedModule(name, absPath, string(data))
 			if err != nil {
 				return nil, fmt.Errorf("module %q (%s): %w", name, absPath, err)
 			}
-			ml.cache[absPath] = env
 			return env, nil
 		}
 
@@ -105,11 +116,10 @@ func (ml *ModuleLoader) Resolve(name string) (*Env, error) {
 		}
 		data, err = os.ReadFile(absPkg)
 		if err == nil {
-			env, err := ml.loadSource(name, string(data))
+			env, err := ml.loadResolvedModule(name, absPkg, string(data))
 			if err != nil {
 				return nil, fmt.Errorf("module %q (%s): %w", name, absPkg, err)
 			}
-			ml.cache[absPkg] = env
 			return env, nil
 		}
 	}
@@ -117,11 +127,60 @@ func (ml *ModuleLoader) Resolve(name string) (*Env, error) {
 	return nil, fmt.Errorf("module %q not found — check the import path or ensure the .basl file exists", name)
 }
 
+func (ml *ModuleLoader) loadResolvedModule(name string, key string, src string) (*Env, error) {
+	if env, ok := ml.cache[key]; ok {
+		ml.cache[name] = env
+		return env, nil
+	}
+	if err := ml.beginLoad(key, name); err != nil {
+		return nil, err
+	}
+	defer ml.finishLoad(key)
+
+	env, err := ml.loadSource(name, src)
+	if err != nil {
+		return nil, err
+	}
+	ml.cache[key] = env
+	ml.cache[name] = env
+	return env, nil
+}
+
+func (ml *ModuleLoader) beginLoad(key string, name string) error {
+	if idx, ok := ml.loading[key]; ok {
+		chain := make([]string, 0, len(ml.stack)-idx+1)
+		for _, frame := range ml.stack[idx:] {
+			chain = append(chain, frame.name)
+		}
+		chain = append(chain, name)
+		return fmt.Errorf("import cycle detected: %s", strings.Join(chain, " -> "))
+	}
+	ml.loading[key] = len(ml.stack)
+	ml.stack = append(ml.stack, moduleLoadFrame{key: key, name: name})
+	return nil
+}
+
+func (ml *ModuleLoader) finishLoad(key string) {
+	idx, ok := ml.loading[key]
+	if !ok {
+		return
+	}
+	delete(ml.loading, key)
+
+	last := len(ml.stack) - 1
+	if idx == last {
+		ml.stack = ml.stack[:last]
+		return
+	}
+
+	ml.stack = append(ml.stack[:idx], ml.stack[idx+1:]...)
+	for i := idx; i < len(ml.stack); i++ {
+		ml.loading[ml.stack[i].key] = i
+	}
+}
+
 // loadSource parses and evaluates a module, returning only its pub exports.
 func (ml *ModuleLoader) loadSource(name string, src string) (*Env, error) {
-	if _, ok := ml.cache[name]; ok {
-		return nil, fmt.Errorf("fatal: module %q loaded twice — this is a bug in the module loader", name)
-	}
 	lex := lexer.New(src)
 	tokens, err := lex.Tokenize()
 	if err != nil {
@@ -252,6 +311,5 @@ func (ml *ModuleLoader) loadSource(name string, src string) (*Env, error) {
 		}
 	}
 
-	ml.cache[name] = exports
 	return exports, nil
 }


### PR DESCRIPTION
Closes #49

## Summary
- detect circular imports explicitly in the runtime module loader
- report a stable, human-readable import chain instead of recursing until failure
- add regression coverage for simple and nested cycles

## What Changed
- Added in-progress load tracking to the module loader so imports are checked before recursive loading proceeds.
- Modules are now tracked by a canonical source identity during load, which lets the loader detect cycles even when the same module is reached through recursive imports before it has been cached.
- When a cycle is found, BASL now returns a direct error such as:
  - `import cycle detected: a -> b -> a`
  - `import cycle detected: a -> b -> c -> a`
- Successful module loading and normal caching behavior remain unchanged.
- Added runtime tests for simple and nested import cycles.
- Added CLI integration coverage so the user-facing interpreter path reports the same cycle-chain diagnostic.
- Updated docs to note that circular imports are rejected explicitly and that cycle chains are reported.

## Why
Previously, a circular import could recurse until it failed indirectly, which produced confusing secondary errors or stack overflows. BASL aims to be predictable and explicit, so import cycles should fail deterministically with a clear message that explains the exact problem.

## Validation
- `make test`
