### PR TITLE
Fix stale test API examples in project docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,14 +143,15 @@ basl test -run sqrt                # Tests matching "sqrt"
 
 Test files must:
 - End with `_test.basl`
-- Import `"t"` module
+- Import `"test"` module
+- Accept a single `test.T` parameter
 - Define functions starting with `test_`
 
 Example test:
 ```c
-import "t";
+import "test";
 
-fn test_addition() -> void {
+fn test_addition(test.T t) -> void {
     t.assert(2 + 2 == 4, "addition works");
 }
 ```

--- a/docs/doc_cli.md
+++ b/docs/doc_cli.md
@@ -193,8 +193,10 @@ basl doc lib/api.basl
 Document test behavior:
 
 ```c
+import "test";
+
 // Tests that factorial(0) returns 1
-fn test_factorial_zero() -> void {
+fn test_factorial_zero(test.T t) -> void {
     t.assert(factorial(0) == 1, "factorial(0) should be 1");
 }
 ```

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -88,10 +88,10 @@ pub fn hello() -> string {
 
 `test/mylib_test.basl`:
 ```c
-import "t";
+import "test";
 import "mylib";
 
-fn test_hello() -> void {
+fn test_hello(test.T t) -> void {
     t.assert(mylib.hello() == "hello from mylib", "hello should match");
 }
 ```


### PR DESCRIPTION
Closes #50

## Summary
- fix the `docs/project_structure.md` test example so it matches the actual BASL test API
- update nearby docs that still showed the same stale convention
- keep the docs consistent with `docs/stdlib/test.md` and the current test runner behavior

## What Changed
- Updated `docs/project_structure.md` to use:
  - `import "test"` instead of `import "t"`
  - test functions that accept a single `test.T` parameter
- Updated the `basl test` example in `docs/cli.md` to use the same current convention.
- Updated the `basl doc` guide example in `docs/doc_cli.md` so test-related documentation examples also use `import "test"` and `test.T`.

## Why
These docs are part of the core onboarding path. Showing an outdated test API creates unnecessary confusion for new users and undermines trust in the documentation. This change brings the examples back in line with the one supported way to write BASL tests.

## Validation
- `go test ./...`
