### PR TITLE
Add pragmatic file walk helpers with explicit modes

### DIFF
--- a/docs/stdlib/README.md
+++ b/docs/stdlib/README.md
@@ -11,7 +11,7 @@ Detailed documentation for each module is in `docs/stdlib/`.
 | [fmt](fmt.md) | Formatted output | `fmt.print`, `fmt.println`, `fmt.sprintf`, `fmt.dollar` |
 | [os](os.md) | OS interaction | `os.env`, `os.exec`, `os.cwd`, `os.platform`, `os.exit` |
 | [math](math.md) | Math functions | `sqrt`, `pow`, `sin`, `cos`, `floor`, `ceil`, `pi`, `e` |
-| [file](file.md) | Filesystem | `read_all`, `write_all`, `open`, `stat`, `mkdir`, `list_dir` |
+| [file](file.md) | Filesystem | `read_all`, `write_all`, `open`, `stat`, `walk`, `walk_best_effort` |
 | [strings](strings.md) | String utilities | `join`, `repeat` |
 | [parse](parse.md) | Fallible string parsing | `i32`, `i64`, `f64`, `u8`, `u32`, `u64`, `bool` |
 | [time](time.md) | Time operations | `now`, `sleep`, `since`, `format`, `parse` |

--- a/docs/stdlib/file.md
+++ b/docs/stdlib/file.md
@@ -1,6 +1,6 @@
 # file
 
-Filesystem operations: read, write, directory management, and file handles.
+Filesystem operations: read, write, directory management, traversal, and file handles.
 
 ```
 import "file";
@@ -105,6 +105,59 @@ Lists the names of entries in a directory.
 array<string> entries, err e = file.list_dir(".");
 ```
 
+### file.read_dir(string path) -> (array\<string\>, err)
+
+Alias for `file.list_dir(path)`.
+
+### file.walk(string root) -> (array\<file.Entry\>, err)
+
+Recursively walks `root` in lexicographic order (fail-fast mode).
+
+- Does **not** follow symlinked directories.
+- Includes `root` itself as the first entry.
+- Returns `(entries, ok)` on success.
+- Returns `([], err(...))` on the first traversal error.
+
+```c
+array<file.Entry> entries, err e = file.walk("src");
+```
+
+### file.walk_follow_links(string root) -> (array\<file.Entry\>, err)
+
+Recursively walks `root` and follows symlinked directories (fail-fast mode).
+
+- Includes `root` itself as the first entry.
+- Detects symlink cycles and returns `err(..., err.state)` instead of recursing forever.
+- Returns `([], err(...))` on the first traversal error.
+
+```c
+array<file.Entry> entries, err e = file.walk_follow_links("src");
+```
+
+### file.walk_best_effort(string root) -> (array\<file.Entry\>, array\<file.WalkIssue\>)
+
+Recursively walks `root` in lexicographic order (best-effort mode).
+
+- Does **not** follow symlinked directories.
+- Includes `root` itself as the first entry when readable.
+- Continues walking after per-path errors.
+- Returns collected entries plus per-path issues.
+
+```c
+array<file.Entry> entries, array<file.WalkIssue> issues = file.walk_best_effort("src");
+```
+
+### file.walk_follow_links_best_effort(string root) -> (array\<file.Entry\>, array\<file.WalkIssue\>)
+
+Best-effort traversal that follows symlinked directories.
+
+- Detects symlink cycles and reports them in `issues` as `err.state`.
+- Continues walking other paths after recoverable failures.
+
+```c
+array<file.Entry> entries, array<file.WalkIssue> issues = file.walk_follow_links_best_effort("src");
+```
+
 ### file.exists(string path) -> bool
 
 Returns `true` if the path exists, `false` otherwise. Does not return an error.
@@ -149,6 +202,7 @@ FileStat fields:
 | `size` | `i32` | File size in bytes |
 | `is_dir` | `bool` | Whether it's a directory |
 | `mod_time` | `string` | Last modified time (ISO 8601: `"2006-01-02T15:04:05Z07:00"`) |
+| `mode` | `i32` | Full file mode bits |
 
 ```c
 FileStat info, err e = file.stat("data.txt");
@@ -157,6 +211,30 @@ fmt.println(info.size);      // 1234
 fmt.println(info.is_dir);    // false
 fmt.println(info.mod_time);  // "2024-01-15T10:30:00-05:00"
 ```
+
+### file.Entry
+
+Object returned by `file.walk*` functions.
+
+Entry fields:
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `string` | Full walked path |
+| `name` | `string` | Base name |
+| `is_dir` | `bool` | Whether the entry is a directory |
+| `size` | `i32` | Size in bytes |
+| `mode` | `i32` | Full file mode bits |
+| `mod_time` | `string` | Last modified time (ISO 8601) |
+
+### file.WalkIssue
+
+Object returned in best-effort walk modes.
+
+Issue fields:
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `string` | Path that failed |
+| `err` | `err` | Error value for the path |
 
 ## File Methods
 

--- a/examples/basl-rm/main.basl
+++ b/examples/basl-rm/main.basl
@@ -4,30 +4,20 @@ import "fmt";
 import "args";
 
 fn remove_recursive(string path) -> err {
-    FileStat info, err e1 = file.stat(path);
-    if (e1 != ok) {
-        return e1;
+    array<file.Entry> entries, err walkErr = file.walk(path);
+    if (walkErr != ok) {
+        return walkErr;
     }
-    
-    if (!info.is_dir) {
-        return file.remove(path);
-    }
-    
-    // Directory - remove contents first
-    array<string> entries, err e2 = file.list_dir(path);
-    if (e2 != ok) {
-        return e2;
-    }
-    
-    for (i32 i = 0; i < entries.len(); i++) {
-        string child = path + "/" + entries[i];
-        err e3 = remove_recursive(child);
-        if (e3 != ok) {
-            return e3;
+
+    // Remove deepest paths first so directories are empty when removed.
+    for (i32 i = entries.len() - 1; i >= 0; i--) {
+        err rmErr = file.remove(entries[i].path);
+        if (rmErr != ok) {
+            return rmErr;
         }
     }
-    
-    return file.remove(path);
+
+    return ok;
 }
 
 fn main() -> i32 {

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -935,6 +935,41 @@ class BaslSyntaxIntegrationTests(unittest.TestCase):
             stdout="true:true:true:a\nb\nc:true:3:b:true:1:note.txt:true:true:true:false:true:note2.txt:5:false:true:true:abc:true:true:true::true:true:true:true:false",
         )
 
+    def test_stdlib_file_walk_modes(self) -> None:
+        source = """
+            import "fmt";
+            import "file";
+
+            fn main() -> i32 {
+                err mk = file.mkdir("data/sub");
+                err w1 = file.write_all("data/one.txt", "1");
+                err w2 = file.write_all("data/sub/two.txt", "2");
+
+                array<file.Entry> strict, err se = file.walk("data");
+                array<file.Entry> strictFollow, err sfe = file.walk_follow_links("data");
+                array<file.Entry> best, array<file.WalkIssue> issues = file.walk_best_effort("missing");
+                array<file.Entry> bestFollow, array<file.WalkIssue> issuesFollow = file.walk_follow_links_best_effort("missing");
+
+                fmt.print(
+                    string(mk == ok) + ":" +
+                    string(w1 == ok) + ":" +
+                    string(w2 == ok) + ":" +
+                    string(se == ok) + ":" +
+                    string(strict.len()) + ":" +
+                    string(sfe == ok) + ":" +
+                    string(strictFollow.len()) + ":" +
+                    string(best.len()) + ":" +
+                    string(issues.len()) + ":" +
+                    issues[0].err.kind() + ":" +
+                    string(bestFollow.len()) + ":" +
+                    string(issuesFollow.len()) + ":" +
+                    issuesFollow[0].err.kind()
+                );
+                return 0;
+            }
+        """
+        self._assert_success(source, stdout="true:true:true:true:4:true:4:0:1:not_found:0:1:not_found")
+
     def test_stdlib_base64_module(self) -> None:
         source = """
             import "fmt";

--- a/pkg/basl/checker/checker.go
+++ b/pkg/basl/checker/checker.go
@@ -1612,6 +1612,10 @@ func newBuiltinModule(name string) *moduleInfo {
 	typMapStringString := &ast.TypeExpr{Name: "map", KeyType: typString, ValType: typString}
 	typFileStat := &ast.TypeExpr{Name: "file.FileStat"}
 	typFile := &ast.TypeExpr{Name: "file.File"}
+	typFileEntry := &ast.TypeExpr{Name: "file.Entry"}
+	typWalkIssue := &ast.TypeExpr{Name: "file.WalkIssue"}
+	typArrayFileEntry := &ast.TypeExpr{Name: "array", ElemType: typFileEntry}
+	typArrayWalkIssue := &ast.TypeExpr{Name: "array", ElemType: typWalkIssue}
 	typRegex := &ast.TypeExpr{Name: "regex.Regex"}
 	typArgParser := &ast.TypeExpr{Name: "args.ArgParser"}
 	typArgsResult := &ast.TypeExpr{Name: "args.Result"}
@@ -1676,6 +1680,10 @@ func newBuiltinModule(name string) *moduleInfo {
 		addFn("readlink", []*ast.TypeExpr{typString, typErr}, typString)
 		addFn("list_dir", []*ast.TypeExpr{typArrayString, typErr}, typString)
 		addFn("read_dir", []*ast.TypeExpr{typArrayString, typErr}, typString)
+		addFn("walk", []*ast.TypeExpr{typArrayFileEntry, typErr}, typString)
+		addFn("walk_follow_links", []*ast.TypeExpr{typArrayFileEntry, typErr}, typString)
+		addFn("walk_best_effort", []*ast.TypeExpr{typArrayFileEntry, typArrayWalkIssue}, typString)
+		addFn("walk_follow_links_best_effort", []*ast.TypeExpr{typArrayFileEntry, typArrayWalkIssue}, typString)
 		addFn("exists", singleReturnType(typBool), typString)
 		addFn("write_all", singleReturnType(typErr), typString, typString)
 		addFn("write", singleReturnType(typErr), typString, typString)
@@ -1709,6 +1717,26 @@ func newBuiltinModule(name string) *moduleInfo {
 				"mod_time": typString,
 				"name":     typString,
 				"mode":     typI32,
+			},
+			methods: make(map[string]*funcSig),
+		})
+		addClass(&classInfo{
+			name: "file.Entry",
+			fields: map[string]*ast.TypeExpr{
+				"path":     typString,
+				"name":     typString,
+				"is_dir":   typBool,
+				"size":     typI32,
+				"mode":     typI32,
+				"mod_time": typString,
+			},
+			methods: make(map[string]*funcSig),
+		})
+		addClass(&classInfo{
+			name: "file.WalkIssue",
+			fields: map[string]*ast.TypeExpr{
+				"path": typString,
+				"err":  typErr,
 			},
 			methods: make(map[string]*funcSig),
 		})

--- a/pkg/basl/checker/checker_test.go
+++ b/pkg/basl/checker/checker_test.go
@@ -493,6 +493,16 @@ fn main() -> i32 {
     cb.free();
 
     bool exists = file.exists("main.basl");
+    array<file.Entry> walked, err walkErr = file.walk(".");
+    array<file.Entry> walkedFollow, err walkFollowErr = file.walk_follow_links(".");
+    array<file.Entry> walkedBest, array<file.WalkIssue> walkIssues = file.walk_best_effort("missing");
+    array<file.Entry> walkedLinksBest, array<file.WalkIssue> walkLinkIssues = file.walk_follow_links_best_effort("missing");
+    string firstWalkPath = walked[0].path;
+    bool firstWalkDir = walked[0].is_dir;
+    err issueErr = walkIssues[0].err;
+    string issuePath = walkIssues[0].path;
+    err linkIssueErr = walkLinkIssues[0].err;
+    string linkIssuePath = walkLinkIssues[0].path;
     args.ArgParser ap = args.parser("tool", "desc");
     err flagErr = ap.flag("verbose", "bool", "false", "Verbose");
 

--- a/pkg/basl/interp/stdlib_file.go
+++ b/pkg/basl/interp/stdlib_file.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,6 +25,154 @@ func fileErrVal(err error, path string) value.Value {
 		return value.NewErr(fmt.Sprintf("file already exists: %s", path), value.ErrKindExists)
 	}
 	return value.NewErr(fmt.Sprintf("file error: %s", path), value.ErrKindIO)
+}
+
+func walkErrVal(err error, path string) value.Value {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "too many links") {
+		return value.NewErr(fmt.Sprintf("symlink cycle detected while walking: %s", path), value.ErrKindState)
+	}
+	return fileErrVal(err, path)
+}
+
+func newFileEntry(path string, info os.FileInfo) value.Value {
+	return value.Value{
+		T: value.TypeObject,
+		Data: &value.ObjectVal{
+			ClassName: "file.Entry",
+			Fields: map[string]value.Value{
+				"path":     value.NewString(path),
+				"name":     value.NewString(info.Name()),
+				"is_dir":   value.NewBool(info.IsDir()),
+				"size":     value.NewI32(int32(info.Size())),
+				"mode":     value.NewI32(int32(info.Mode())),
+				"mod_time": value.NewString(info.ModTime().Format("2006-01-02T15:04:05Z07:00")),
+			},
+		},
+	}
+}
+
+func newWalkIssue(path string, errVal value.Value) value.Value {
+	return value.Value{
+		T: value.TypeObject,
+		Data: &value.ObjectVal{
+			ClassName: "file.WalkIssue",
+			Fields: map[string]value.Value{
+				"path": value.NewString(path),
+				"err":  errVal,
+			},
+		},
+	}
+}
+
+func walkDirKey(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func walkEntries(root string, followLinks bool, bestEffort bool) ([]value.Value, []value.Value, value.Value) {
+	entries := make([]value.Value, 0)
+	issues := make([]value.Value, 0)
+
+	recordIssue := func(path string, errVal value.Value) {
+		issues = append(issues, newWalkIssue(path, errVal))
+	}
+
+	var walkErr value.Value = value.Ok
+
+	var visit func(path string, active map[string]struct{}) bool
+	visit = func(path string, active map[string]struct{}) bool {
+		info, err := os.Lstat(path)
+		if err != nil {
+			errVal := walkErrVal(err, path)
+			if bestEffort {
+				recordIssue(path, errVal)
+				return true
+			}
+			walkErr = errVal
+			return false
+		}
+
+		entryInfo := info
+		isDir := info.IsDir()
+		if followLinks && (info.Mode()&os.ModeSymlink) != 0 {
+			targetInfo, statErr := os.Stat(path)
+			if statErr != nil {
+				errVal := walkErrVal(statErr, path)
+				if bestEffort {
+					recordIssue(path, errVal)
+					return true
+				}
+				walkErr = errVal
+				return false
+			}
+			entryInfo = targetInfo
+			isDir = targetInfo.IsDir()
+		}
+
+		entries = append(entries, newFileEntry(path, entryInfo))
+
+		if !isDir {
+			return true
+		}
+
+		if followLinks {
+			key, keyErr := walkDirKey(path)
+			if keyErr != nil {
+				errVal := walkErrVal(keyErr, path)
+				if bestEffort {
+					recordIssue(path, errVal)
+					return true
+				}
+				walkErr = errVal
+				return false
+			}
+			if _, ok := active[key]; ok {
+				errVal := value.NewErr(fmt.Sprintf("symlink cycle detected while walking: %s", path), value.ErrKindState)
+				if bestEffort {
+					recordIssue(path, errVal)
+					return true
+				}
+				walkErr = errVal
+				return false
+			}
+			active[key] = struct{}{}
+			defer delete(active, key)
+		}
+
+		children, readErr := os.ReadDir(path)
+		if readErr != nil {
+			errVal := walkErrVal(readErr, path)
+			if bestEffort {
+				recordIssue(path, errVal)
+				return true
+			}
+			walkErr = errVal
+			return false
+		}
+		sort.Slice(children, func(i, j int) bool {
+			return children[i].Name() < children[j].Name()
+		})
+		for _, child := range children {
+			childPath := filepath.Join(path, child.Name())
+			if !visit(childPath, active) {
+				return false
+			}
+		}
+		return true
+	}
+
+	if !visit(filepath.Clean(root), make(map[string]struct{})) {
+		return nil, issues, walkErr
+	}
+	return entries, issues, value.Ok
 }
 
 func (interp *Interpreter) makeFileModule() *Env {
@@ -246,6 +396,44 @@ func (interp *Interpreter) makeFileModule() *Env {
 			elems[i] = value.NewString(e.Name())
 		}
 		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(elems), value.Ok}}
+	}))
+	env.Define("walk", value.NewNativeFunc("file.walk", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.walk: expected string root")
+		}
+		root := args[0].AsString()
+		entries, _, walkErr := walkEntries(root, false, false)
+		if !walkErr.IsOk() {
+			return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(nil), walkErr}}
+		}
+		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(entries), value.Ok}}
+	}))
+	env.Define("walk_follow_links", value.NewNativeFunc("file.walk_follow_links", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.walk_follow_links: expected string root")
+		}
+		root := args[0].AsString()
+		entries, _, walkErr := walkEntries(root, true, false)
+		if !walkErr.IsOk() {
+			return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(nil), walkErr}}
+		}
+		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(entries), value.Ok}}
+	}))
+	env.Define("walk_best_effort", value.NewNativeFunc("file.walk_best_effort", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.walk_best_effort: expected string root")
+		}
+		root := args[0].AsString()
+		entries, issues, _ := walkEntries(root, false, true)
+		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(entries), value.NewArray(issues)}}
+	}))
+	env.Define("walk_follow_links_best_effort", value.NewNativeFunc("file.walk_follow_links_best_effort", func(args []value.Value) (value.Value, error) {
+		if len(args) != 1 || args[0].T != value.TypeString {
+			return value.Void, fmt.Errorf("file.walk_follow_links_best_effort: expected string root")
+		}
+		root := args[0].AsString()
+		entries, issues, _ := walkEntries(root, true, true)
+		return value.Void, &MultiReturnVal{Values: []value.Value{value.NewArray(entries), value.NewArray(issues)}}
 	}))
 	env.Define("exists", value.NewNativeFunc("file.exists", func(args []value.Value) (value.Value, error) {
 		if len(args) != 1 || args[0].T != value.TypeString {

--- a/pkg/basl/interp/stdlib_file_test.go
+++ b/pkg/basl/interp/stdlib_file_test.go
@@ -57,3 +57,86 @@ func TestFileMkdirListDir(t *testing.T) {
 		t.Fatalf("got %q", out[0])
 	}
 }
+
+func TestFileWalkFailFast(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.txt"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootEsc := escapePathForBASL(root)
+	src := `import "fmt"; import "file";
+fn main() -> i32 {
+    array<file.Entry> entries, err e = file.walk("` + rootEsc + `");
+    i32 dirs = 0;
+    for (i32 i = 0; i < entries.len(); i++) {
+        if (entries[i].is_dir) {
+            dirs++;
+        }
+    }
+    fmt.print(string(e == ok) + ":" + string(entries.len()) + ":" + string(dirs));
+    return 0;
+}`
+	_, out, err := evalBASL(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out[0] != "true:4:2" {
+		t.Fatalf("got %q", out[0])
+	}
+}
+
+func TestFileWalkBestEffortCollectsIssues(t *testing.T) {
+	missing := escapePathForBASL(filepath.Join(t.TempDir(), "missing"))
+	src := `import "fmt"; import "file";
+fn main() -> i32 {
+    array<file.Entry> entries, array<file.WalkIssue> issues = file.walk_best_effort("` + missing + `");
+    fmt.print(string(entries.len()) + ":" + string(issues.len()) + ":" + issues[0].err.kind());
+    return 0;
+}`
+	_, out, err := evalBASL(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out[0] != "0:1:not_found" {
+		t.Fatalf("got %q", out[0])
+	}
+}
+
+func TestFileWalkFollowLinksCycleSafe(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	loop := filepath.Join(sub, "loop")
+	if err := os.Symlink("..", loop); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	rootEsc := escapePathForBASL(root)
+	src := `import "fmt"; import "file";
+fn main() -> i32 {
+    array<file.Entry> strictEntries, err strictErr = file.walk_follow_links("` + rootEsc + `");
+    array<file.Entry> bestEntries, array<file.WalkIssue> bestIssues = file.walk_follow_links_best_effort("` + rootEsc + `");
+    fmt.print(string(strictEntries.len()) + ":" + strictErr.kind() + ":" + string(bestEntries.len()) + ":" + string(bestIssues.len()) + ":" + bestIssues[0].err.kind());
+    return 0;
+}`
+	_, out, err := evalBASL(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out[0] != "0:state:4:1:state" {
+		t.Fatalf("got %q", out[0])
+	}
+}


### PR DESCRIPTION
Closes #48

## Summary
Adds focused filesystem traversal helpers to reduce scripting boilerplate while keeping BASL error handling explicit.

### New file APIs
- `file.walk(string root) -> (array<file.Entry>, err)`
- `file.walk_follow_links(string root) -> (array<file.Entry>, err)`
- `file.walk_best_effort(string root) -> (array<file.Entry>, array<file.WalkIssue>)`
- `file.walk_follow_links_best_effort(string root) -> (array<file.Entry>, array<file.WalkIssue>)`

### New object types
- `file.Entry` with fields: `path`, `name`, `is_dir`, `size`, `mode`, `mod_time`
- `file.WalkIssue` with fields: `path`, `err`

## Behavior
- Traversal order is deterministic (lexicographic).
- `walk*` functions include `root` as the first entry when readable.
- Fail-fast modes return on the first traversal error.
- Best-effort modes continue and report per-path issues.
- Follow-links modes detect symlink cycles and return/report `err.state` instead of recursing forever.

## Tooling updates
- `basl check` builtin modeling updated for new file APIs and types.

## Docs and examples
- Updated `docs/stdlib/file.md` with traversal APIs and object references.
- Updated `docs/stdlib/README.md` module summary.
- Updated `examples/basl-rm/main.basl` to use `file.walk(...)` for recursive removal.

## Validation
- `go test ./...`
- `make test`