### PR TITLE
Add function objects and call frames

### DIFF
--- a/include/basl/value.h
+++ b/include/basl/value.h
@@ -23,10 +23,12 @@ typedef enum basl_value_kind {
 
 typedef enum basl_object_type {
     BASL_OBJECT_INVALID = 0,
-    BASL_OBJECT_STRING = 1
+    BASL_OBJECT_STRING = 1,
+    BASL_OBJECT_FUNCTION = 2
 } basl_object_type_t;
 
 typedef struct basl_object basl_object_t;
+typedef struct basl_chunk basl_chunk_t;
 
 typedef struct basl_value {
     basl_value_kind_t kind;
@@ -86,6 +88,24 @@ BASL_API basl_status_t basl_string_object_new_cstr(
 );
 BASL_API const char *basl_string_object_c_str(const basl_object_t *object);
 BASL_API size_t basl_string_object_length(const basl_object_t *object);
+
+BASL_API basl_status_t basl_function_object_new(
+    basl_runtime_t *runtime,
+    const char *name,
+    size_t name_length,
+    basl_chunk_t *chunk,
+    basl_object_t **out_object,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_function_object_new_cstr(
+    basl_runtime_t *runtime,
+    const char *name,
+    basl_chunk_t *chunk,
+    basl_object_t **out_object,
+    basl_error_t *error
+);
+BASL_API const char *basl_function_object_name(const basl_object_t *object);
+BASL_API const basl_chunk_t *basl_function_object_chunk(const basl_object_t *object);
 
 #ifdef __cplusplus
 }

--- a/include/basl/vm.h
+++ b/include/basl/vm.h
@@ -29,6 +29,7 @@ BASL_API basl_status_t basl_vm_open(
 BASL_API void basl_vm_close(basl_vm_t **vm);
 BASL_API basl_runtime_t *basl_vm_runtime(const basl_vm_t *vm);
 BASL_API size_t basl_vm_stack_depth(const basl_vm_t *vm);
+BASL_API size_t basl_vm_frame_depth(const basl_vm_t *vm);
 /*
  * out_value must not be null and should be initialized to nil before reuse if
  * it may already own an object reference.
@@ -36,6 +37,12 @@ BASL_API size_t basl_vm_stack_depth(const basl_vm_t *vm);
 BASL_API basl_status_t basl_vm_execute(
     basl_vm_t *vm,
     const basl_chunk_t *chunk,
+    basl_value_t *out_value,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_vm_execute_function(
+    basl_vm_t *vm,
+    const basl_object_t *function,
     basl_value_t *out_value,
     basl_error_t *error
 );

--- a/src/value.c
+++ b/src/value.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "basl/chunk.h"
 #include "internal/basl_internal.h"
 #include "basl/string.h"
 #include "basl/value.h"
@@ -17,6 +18,12 @@ typedef struct basl_string_object {
     basl_string_t value;
 } basl_string_object_t;
 
+typedef struct basl_function_object {
+    basl_object_t base;
+    basl_string_t name;
+    basl_chunk_t chunk;
+} basl_function_object_t;
+
 static const basl_string_object_t *basl_string_object_cast(
     const basl_object_t *object
 ) {
@@ -27,10 +34,21 @@ static const basl_string_object_t *basl_string_object_cast(
     return (const basl_string_object_t *)object;
 }
 
+static const basl_function_object_t *basl_function_object_cast(
+    const basl_object_t *object
+) {
+    if (object == NULL || object->type != BASL_OBJECT_FUNCTION) {
+        return NULL;
+    }
+
+    return (const basl_function_object_t *)object;
+}
+
 static void basl_object_destroy(basl_object_t *object) {
     basl_runtime_t *runtime;
     void *memory;
     basl_string_object_t *string_object;
+    basl_function_object_t *function_object;
 
     if (object == NULL) {
         return;
@@ -41,6 +59,11 @@ static void basl_object_destroy(basl_object_t *object) {
         case BASL_OBJECT_STRING:
             string_object = (basl_string_object_t *)object;
             basl_string_free(&string_object->value);
+            break;
+        case BASL_OBJECT_FUNCTION:
+            function_object = (basl_function_object_t *)object;
+            basl_string_free(&function_object->name);
+            basl_chunk_free(&function_object->chunk);
             break;
         case BASL_OBJECT_INVALID:
         default:
@@ -349,4 +372,133 @@ size_t basl_string_object_length(const basl_object_t *object) {
     }
 
     return basl_string_length(&string_object->value);
+}
+
+basl_status_t basl_function_object_new(
+    basl_runtime_t *runtime,
+    const char *name,
+    size_t name_length,
+    basl_chunk_t *chunk,
+    basl_object_t **out_object,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_function_object_t *object;
+    void *memory;
+
+    basl_error_clear(error);
+
+    if (runtime == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "runtime must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (name == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "function object name must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (chunk == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "function object chunk must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (chunk->runtime != runtime) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "function object chunk runtime must match runtime"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (out_object == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "out_object must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    *out_object = NULL;
+    memory = NULL;
+    status = basl_runtime_alloc(runtime, sizeof(*object), &memory, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    object = (basl_function_object_t *)memory;
+    basl_object_init(&object->base, runtime, BASL_OBJECT_FUNCTION);
+    basl_string_init(&object->name, runtime);
+    status = basl_string_assign(&object->name, name, name_length, error);
+    if (status != BASL_STATUS_OK) {
+        basl_object_destroy(&object->base);
+        return status;
+    }
+
+    object->chunk = *chunk;
+    memset(chunk, 0, sizeof(*chunk));
+    *out_object = &object->base;
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_function_object_new_cstr(
+    basl_runtime_t *runtime,
+    const char *name,
+    basl_chunk_t *chunk,
+    basl_object_t **out_object,
+    basl_error_t *error
+) {
+    if (name == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "function object name must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    return basl_function_object_new(
+        runtime,
+        name,
+        strlen(name),
+        chunk,
+        out_object,
+        error
+    );
+}
+
+const char *basl_function_object_name(const basl_object_t *object) {
+    const basl_function_object_t *function_object;
+
+    function_object = basl_function_object_cast(object);
+    if (function_object == NULL) {
+        return "";
+    }
+
+    return basl_string_c_str(&function_object->name);
+}
+
+const basl_chunk_t *basl_function_object_chunk(const basl_object_t *object) {
+    const basl_function_object_t *function_object;
+
+    function_object = basl_function_object_cast(object);
+    if (function_object == NULL) {
+        return NULL;
+    }
+
+    return &function_object->chunk;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -5,8 +5,10 @@
 #include "basl/vm.h"
 
 typedef struct basl_vm_frame {
+    const basl_object_t *function;
     const basl_chunk_t *chunk;
     size_t ip;
+    size_t base_slot;
 } basl_vm_frame_t;
 
 struct basl_vm {
@@ -14,8 +16,9 @@ struct basl_vm {
     basl_value_t *stack;
     size_t stack_count;
     size_t stack_capacity;
-    basl_vm_frame_t frame;
-    int has_frame;
+    basl_vm_frame_t *frames;
+    size_t frame_count;
+    size_t frame_capacity;
 };
 
 static basl_status_t basl_vm_validate(
@@ -57,6 +60,14 @@ static void basl_vm_release_stack(basl_vm_t *vm) {
     }
 
     vm->stack_count = 0U;
+}
+
+static void basl_vm_clear_frames(basl_vm_t *vm) {
+    if (vm == NULL) {
+        return;
+    }
+
+    vm->frame_count = 0U;
 }
 
 static basl_status_t basl_vm_grow_stack(
@@ -129,6 +140,117 @@ static basl_status_t basl_vm_grow_stack(
     return BASL_STATUS_OK;
 }
 
+static basl_status_t basl_vm_grow_frames(
+    basl_vm_t *vm,
+    size_t minimum_capacity,
+    basl_error_t *error
+) {
+    size_t old_capacity;
+    size_t next_capacity;
+    void *memory;
+    basl_status_t status;
+
+    if (minimum_capacity <= vm->frame_capacity) {
+        basl_error_clear(error);
+        return BASL_STATUS_OK;
+    }
+
+    old_capacity = vm->frame_capacity;
+    next_capacity = old_capacity == 0U ? 4U : old_capacity;
+    while (next_capacity < minimum_capacity) {
+        if (next_capacity > (SIZE_MAX / 2U)) {
+            next_capacity = minimum_capacity;
+            break;
+        }
+
+        next_capacity *= 2U;
+    }
+
+    if (next_capacity > (SIZE_MAX / sizeof(*vm->frames))) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_OUT_OF_MEMORY,
+            "vm frame allocation overflow"
+        );
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+
+    if (vm->frames == NULL) {
+        memory = NULL;
+        status = basl_runtime_alloc(
+            vm->runtime,
+            next_capacity * sizeof(*vm->frames),
+            &memory,
+            error
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    } else {
+        memory = vm->frames;
+        status = basl_runtime_realloc(
+            vm->runtime,
+            &memory,
+            next_capacity * sizeof(*vm->frames),
+            error
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+
+        memset(
+            (basl_vm_frame_t *)memory + old_capacity,
+            0,
+            (next_capacity - old_capacity) * sizeof(*vm->frames)
+        );
+    }
+
+    vm->frames = (basl_vm_frame_t *)memory;
+    vm->frame_capacity = next_capacity;
+    return BASL_STATUS_OK;
+}
+
+static basl_vm_frame_t *basl_vm_current_frame(basl_vm_t *vm) {
+    if (vm == NULL || vm->frame_count == 0U) {
+        return NULL;
+    }
+
+    return &vm->frames[vm->frame_count - 1U];
+}
+
+static basl_status_t basl_vm_push_frame(
+    basl_vm_t *vm,
+    const basl_object_t *function,
+    const basl_chunk_t *chunk,
+    size_t base_slot,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_vm_frame_t *frame;
+
+    if (vm->frame_count == SIZE_MAX) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_OUT_OF_MEMORY,
+            "vm frame stack overflow"
+        );
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+
+    status = basl_vm_grow_frames(vm, vm->frame_count + 1U, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    frame = &vm->frames[vm->frame_count];
+    frame->function = function;
+    frame->chunk = chunk;
+    frame->ip = 0U;
+    frame->base_slot = base_slot;
+    vm->frame_count += 1U;
+    return BASL_STATUS_OK;
+}
+
 static basl_status_t basl_vm_push(
     basl_vm_t *vm,
     const basl_value_t *value,
@@ -176,10 +298,12 @@ static basl_status_t basl_vm_fail_at_ip(
     basl_error_t *error
 ) {
     basl_source_span_t span;
+    basl_vm_frame_t *frame;
 
     basl_error_set_literal(error, status, message);
-    if (error != NULL && vm != NULL && vm->has_frame) {
-        span = basl_chunk_span_at(vm->frame.chunk, vm->frame.ip);
+    frame = basl_vm_current_frame(vm);
+    if (error != NULL && frame != NULL) {
+        span = basl_chunk_span_at(frame->chunk, frame->ip);
         error->location.source_id = span.source_id;
     }
 
@@ -191,13 +315,24 @@ static basl_status_t basl_vm_read_u32(
     uint32_t *out_value,
     basl_error_t *error
 ) {
+    basl_vm_frame_t *frame;
     const uint8_t *code;
     size_t code_size;
     size_t ip;
 
-    code = basl_chunk_code(vm->frame.chunk);
-    code_size = basl_chunk_code_size(vm->frame.chunk);
-    ip = vm->frame.ip;
+    frame = basl_vm_current_frame(vm);
+    if (frame == NULL) {
+        return basl_vm_fail_at_ip(
+            vm,
+            BASL_STATUS_INTERNAL,
+            "vm frame is missing",
+            error
+        );
+    }
+
+    code = basl_chunk_code(frame->chunk);
+    code_size = basl_chunk_code_size(frame->chunk);
+    ip = frame->ip;
     if (code == NULL || ip + 4U >= code_size) {
         return basl_vm_fail_at_ip(
             vm,
@@ -211,7 +346,7 @@ static basl_status_t basl_vm_read_u32(
     *out_value |= (uint32_t)code[ip + 2U] << 8U;
     *out_value |= (uint32_t)code[ip + 3U] << 16U;
     *out_value |= (uint32_t)code[ip + 4U] << 24U;
-    vm->frame.ip += 5U;
+    frame->ip += 5U;
     return BASL_STATUS_OK;
 }
 
@@ -289,7 +424,13 @@ void basl_vm_close(basl_vm_t **vm) {
     *vm = NULL;
     runtime = resolved_vm->runtime;
     basl_vm_release_stack(resolved_vm);
+    basl_vm_clear_frames(resolved_vm);
     memory = resolved_vm->stack;
+    if (runtime != NULL) {
+        basl_runtime_free(runtime, &memory);
+    }
+
+    memory = resolved_vm->frames;
     if (runtime != NULL) {
         basl_runtime_free(runtime, &memory);
     }
@@ -316,6 +457,14 @@ size_t basl_vm_stack_depth(const basl_vm_t *vm) {
     return vm->stack_count;
 }
 
+size_t basl_vm_frame_depth(const basl_vm_t *vm) {
+    if (vm == NULL) {
+        return 0U;
+    }
+
+    return vm->frame_count;
+}
+
 basl_status_t basl_vm_execute(
     basl_vm_t *vm,
     const basl_chunk_t *chunk,
@@ -323,11 +472,6 @@ basl_status_t basl_vm_execute(
     basl_error_t *error
 ) {
     basl_status_t status;
-    basl_value_t value;
-    const basl_value_t *constant;
-    uint32_t constant_index;
-    const uint8_t *code;
-    size_t code_size;
 
     status = basl_vm_validate(vm, error);
     if (status != BASL_STATUS_OK) {
@@ -353,20 +497,88 @@ basl_status_t basl_vm_execute(
     }
 
     basl_vm_release_stack(vm);
-    vm->frame.chunk = chunk;
-    vm->frame.ip = 0U;
-    vm->has_frame = 1;
-    code = basl_chunk_code(chunk);
-    code_size = basl_chunk_code_size(chunk);
-    while (vm->frame.ip < code_size) {
-        switch ((basl_opcode_t)code[vm->frame.ip]) {
+    basl_vm_clear_frames(vm);
+    status = basl_vm_push_frame(vm, NULL, chunk, 0U, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    return basl_vm_execute_function(vm, NULL, out_value, error);
+}
+
+basl_status_t basl_vm_execute_function(
+    basl_vm_t *vm,
+    const basl_object_t *function,
+    basl_value_t *out_value,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_value_t value;
+    const basl_value_t *constant;
+    uint32_t constant_index;
+    basl_vm_frame_t *frame;
+    const uint8_t *code;
+    size_t code_size;
+
+    status = basl_vm_validate(vm, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    if (out_value == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "out_value must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (function != NULL) {
+        if (basl_object_type(function) != BASL_OBJECT_FUNCTION) {
+            basl_error_set_literal(
+                error,
+                BASL_STATUS_INVALID_ARGUMENT,
+                "function must be a function object"
+            );
+            return BASL_STATUS_INVALID_ARGUMENT;
+        }
+
+        basl_vm_release_stack(vm);
+        basl_vm_clear_frames(vm);
+        status = basl_vm_push_frame(
+            vm,
+            function,
+            basl_function_object_chunk(function),
+            0U,
+            error
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    }
+
+    frame = basl_vm_current_frame(vm);
+    if (frame == NULL || frame->chunk == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "vm frame chunk must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    code = basl_chunk_code(frame->chunk);
+    code_size = basl_chunk_code_size(frame->chunk);
+    while (frame->ip < code_size) {
+        switch ((basl_opcode_t)code[frame->ip]) {
             case BASL_OPCODE_CONSTANT:
                 status = basl_vm_read_u32(vm, &constant_index, error);
                 if (status != BASL_STATUS_OK) {
                     goto cleanup;
                 }
 
-                constant = basl_chunk_constant(chunk, (size_t)constant_index);
+                constant = basl_chunk_constant(frame->chunk, (size_t)constant_index);
                 if (constant == NULL) {
                     status = basl_vm_fail_at_ip(
                         vm,
@@ -388,7 +600,7 @@ basl_status_t basl_vm_execute(
                 if (status != BASL_STATUS_OK) {
                     goto cleanup;
                 }
-                vm->frame.ip += 1U;
+                frame->ip += 1U;
                 break;
             case BASL_OPCODE_TRUE:
                 basl_value_init_bool(&value, 1);
@@ -396,7 +608,7 @@ basl_status_t basl_vm_execute(
                 if (status != BASL_STATUS_OK) {
                     goto cleanup;
                 }
-                vm->frame.ip += 1U;
+                frame->ip += 1U;
                 break;
             case BASL_OPCODE_FALSE:
                 basl_value_init_bool(&value, 0);
@@ -404,13 +616,13 @@ basl_status_t basl_vm_execute(
                 if (status != BASL_STATUS_OK) {
                     goto cleanup;
                 }
-                vm->frame.ip += 1U;
+                frame->ip += 1U;
                 break;
             case BASL_OPCODE_RETURN:
-                vm->frame.ip += 1U;
+                frame->ip += 1U;
                 *out_value = basl_vm_pop_or_nil(vm);
                 basl_vm_release_stack(vm);
-                vm->has_frame = 0;
+                basl_vm_clear_frames(vm);
                 return BASL_STATUS_OK;
             default:
                 status = basl_vm_fail_at_ip(
@@ -432,6 +644,6 @@ basl_status_t basl_vm_execute(
 
 cleanup:
     basl_vm_release_stack(vm);
-    vm->has_frame = 0;
+    basl_vm_clear_frames(vm);
     return status;
 }

--- a/tests/value_test.cpp
+++ b/tests/value_test.cpp
@@ -211,3 +211,80 @@ TEST(BaslValueTest, StringObjectValidatesArguments) {
 
     basl_runtime_close(&runtime);
 }
+
+TEST(BaslValueTest, FunctionObjectTakesOwnershipOfChunkAndExposesMetadata) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_chunk_t chunk;
+    basl_object_t *function = nullptr;
+    basl_value_t value;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_chunk_init(&chunk, runtime);
+    basl_value_init_int(&value, 42);
+    ASSERT_EQ(
+        basl_chunk_write_constant(&chunk, &value, {}, nullptr, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_function_object_new_cstr(runtime, "main", &chunk, &function, &error),
+        BASL_STATUS_OK
+    );
+
+    ASSERT_NE(function, nullptr);
+    EXPECT_EQ(basl_object_type(function), BASL_OBJECT_FUNCTION);
+    EXPECT_EQ(basl_object_ref_count(function), 1U);
+    EXPECT_STREQ(basl_function_object_name(function), "main");
+    ASSERT_NE(basl_function_object_chunk(function), nullptr);
+    EXPECT_EQ(basl_chunk_constant_count(basl_function_object_chunk(function)), 1U);
+
+    EXPECT_EQ(chunk.runtime, nullptr);
+    EXPECT_EQ(basl_chunk_code_size(&chunk), 0U);
+    EXPECT_EQ(basl_chunk_constant_count(&chunk), 0U);
+
+    basl_object_release(&function);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslValueTest, FunctionObjectValidatesArguments) {
+    basl_runtime_t *runtime = nullptr;
+    basl_runtime_t *other_runtime = nullptr;
+    basl_error_t error = {};
+    basl_chunk_t chunk;
+    basl_object_t *function = nullptr;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    ASSERT_EQ(basl_runtime_open(&other_runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_chunk_init(&chunk, other_runtime);
+
+    EXPECT_EQ(
+        basl_function_object_new(nullptr, "main", 4U, &chunk, &function, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        basl_function_object_new(runtime, nullptr, 0U, &chunk, &function, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        basl_function_object_new(runtime, "main", 4U, nullptr, &function, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        basl_function_object_new(runtime, "main", 4U, &chunk, nullptr, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        basl_function_object_new(runtime, "main", 4U, &chunk, &function, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(error.type, BASL_STATUS_INVALID_ARGUMENT);
+    ASSERT_NE(error.value, nullptr);
+    EXPECT_EQ(
+        std::strcmp(error.value, "function object chunk runtime must match runtime"),
+        0
+    );
+
+    basl_chunk_free(&chunk);
+    basl_runtime_close(&other_runtime);
+    basl_runtime_close(&runtime);
+}

--- a/tests/vm_test.cpp
+++ b/tests/vm_test.cpp
@@ -65,6 +65,7 @@ TEST(BaslVmTest, OpenAndCloseVm) {
     ASSERT_NE(vm, nullptr);
     EXPECT_EQ(basl_vm_runtime(vm), runtime);
     EXPECT_EQ(basl_vm_stack_depth(vm), 0U);
+    EXPECT_EQ(basl_vm_frame_depth(vm), 0U);
 
     basl_vm_close(&vm);
     EXPECT_EQ(vm, nullptr);
@@ -98,6 +99,7 @@ TEST(BaslVmTest, ExecutesConstantAndReturn) {
     EXPECT_EQ(basl_value_kind(&result), BASL_VALUE_INT);
     EXPECT_EQ(basl_value_as_int(&result), 42);
     EXPECT_EQ(basl_vm_stack_depth(vm), 0U);
+    EXPECT_EQ(basl_vm_frame_depth(vm), 0U);
 
     basl_value_release(&result);
     basl_chunk_free(&chunk);
@@ -228,6 +230,10 @@ TEST(BaslVmTest, RejectsMissingArguments) {
         basl_vm_execute(vm, &chunk, nullptr, &error),
         BASL_STATUS_INVALID_ARGUMENT
     );
+    EXPECT_EQ(
+        basl_vm_execute_function(vm, nullptr, nullptr, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
 
     basl_chunk_free(&chunk);
     basl_vm_close(&vm);
@@ -309,4 +315,74 @@ TEST(BaslVmTest, UsesRuntimeAllocatorHooks) {
     basl_vm_close(&vm);
     basl_runtime_close(&runtime);
     EXPECT_GE(stats.deallocate_calls, 4);
+}
+
+TEST(BaslVmTest, ExecutesFunctionObjectEntry) {
+    basl_runtime_t *runtime = nullptr;
+    basl_vm_t *vm = nullptr;
+    basl_chunk_t chunk;
+    basl_object_t *function = nullptr;
+    basl_value_t constant;
+    basl_value_t result;
+    basl_error_t error = {};
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    ASSERT_EQ(basl_vm_open(&vm, runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_chunk_init(&chunk, runtime);
+    basl_value_init_int(&constant, 99);
+    basl_value_init_nil(&result);
+
+    ASSERT_EQ(
+        basl_chunk_write_constant(&chunk, &constant, Span(4U, 0U, 3U), nullptr, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_chunk_write_opcode(&chunk, BASL_OPCODE_RETURN, Span(4U, 4U, 5U), &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_function_object_new_cstr(runtime, "main", &chunk, &function, &error),
+        BASL_STATUS_OK
+    );
+
+    ASSERT_EQ(
+        basl_vm_execute_function(vm, function, &result, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(basl_value_kind(&result), BASL_VALUE_INT);
+    EXPECT_EQ(basl_value_as_int(&result), 99);
+    EXPECT_EQ(basl_vm_stack_depth(vm), 0U);
+    EXPECT_EQ(basl_vm_frame_depth(vm), 0U);
+
+    basl_value_release(&result);
+    basl_object_release(&function);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslVmTest, ExecuteFunctionRejectsNonFunctionObject) {
+    basl_runtime_t *runtime = nullptr;
+    basl_vm_t *vm = nullptr;
+    basl_object_t *object = nullptr;
+    basl_value_t result;
+    basl_error_t error = {};
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    ASSERT_EQ(basl_vm_open(&vm, runtime, nullptr, &error), BASL_STATUS_OK);
+    ASSERT_EQ(
+        basl_string_object_new_cstr(runtime, "hello", &object, &error),
+        BASL_STATUS_OK
+    );
+    basl_value_init_nil(&result);
+
+    EXPECT_EQ(
+        basl_vm_execute_function(vm, object, &result, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(error.type, BASL_STATUS_INVALID_ARGUMENT);
+    ASSERT_NE(error.value, nullptr);
+    EXPECT_EQ(std::strcmp(error.value, "function must be a function object"), 0);
+
+    basl_object_release(&object);
+    basl_vm_close(&vm);
+    basl_runtime_close(&runtime);
 }


### PR DESCRIPTION
## Summary
- extend the managed object model with a function object type that owns a moved `basl_chunk_t` plus function name metadata
- extend the VM with a real frame stack, frame-depth inspection, and `basl_vm_execute_function()` for callable entry execution
- keep `basl_vm_execute()` as the raw-chunk convenience path on top of the same frame machinery
- add value/VM tests for function-object ownership transfer, function argument validation, function entry execution, and non-function rejection

## Verification
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`

Related to #63