### PR TITLE
Add symbol interning table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(basl ${BASL_LIBRARY_TYPE}
     src/source.c
     src/string.c
     src/status.c
+    src/symbol.c
     src/value.c
     src/vm.c
 )
@@ -78,6 +79,7 @@ if(BASL_BUILD_TESTS)
         tests/source_test.cpp
         tests/string_test.cpp
         tests/status_test.cpp
+        tests/symbol_test.cpp
         tests/value_test.cpp
         tests/vm_test.cpp
     )

--- a/include/basl/basl.h
+++ b/include/basl/basl.h
@@ -11,6 +11,7 @@
 #include "basl/source.h"
 #include "basl/string.h"
 #include "basl/status.h"
+#include "basl/symbol.h"
 #include "basl/value.h"
 #include "basl/vm.h"
 

--- a/include/basl/symbol.h
+++ b/include/basl/symbol.h
@@ -1,0 +1,65 @@
+#ifndef BASL_SYMBOL_H
+#define BASL_SYMBOL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "basl/export.h"
+#include "basl/map.h"
+#include "basl/runtime.h"
+#include "basl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t basl_symbol_t;
+
+#define BASL_SYMBOL_INVALID ((basl_symbol_t)0U)
+
+typedef struct basl_symbol_table {
+    basl_runtime_t *runtime;
+    basl_map_t by_name;
+    void *strings;
+    size_t count;
+    size_t capacity;
+} basl_symbol_table_t;
+
+BASL_API void basl_symbol_table_init(
+    basl_symbol_table_t *table,
+    basl_runtime_t *runtime
+);
+BASL_API void basl_symbol_table_clear(basl_symbol_table_t *table);
+BASL_API void basl_symbol_table_free(basl_symbol_table_t *table);
+BASL_API size_t basl_symbol_table_count(const basl_symbol_table_t *table);
+BASL_API basl_status_t basl_symbol_table_intern(
+    basl_symbol_table_t *table,
+    const char *text,
+    size_t length,
+    basl_symbol_t *out_symbol,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_symbol_table_intern_cstr(
+    basl_symbol_table_t *table,
+    const char *text,
+    basl_symbol_t *out_symbol,
+    basl_error_t *error
+);
+BASL_API const char *basl_symbol_table_c_str(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+);
+BASL_API size_t basl_symbol_table_length(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+);
+BASL_API int basl_symbol_table_is_valid(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -1,0 +1,328 @@
+#include <limits.h>
+#include <string.h>
+
+#include "internal/basl_internal.h"
+#include "basl/string.h"
+#include "basl/symbol.h"
+
+static basl_string_t *basl_symbol_strings(basl_symbol_table_t *table) {
+    return (basl_string_t *)table->strings;
+}
+
+static const basl_string_t *basl_symbol_const_strings(
+    const basl_symbol_table_t *table
+) {
+    return (const basl_string_t *)table->strings;
+}
+
+static int basl_symbol_table_validate_mutable(
+    const basl_symbol_table_t *table,
+    basl_error_t *error
+) {
+    basl_error_clear(error);
+
+    if (table == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol table must not be null"
+        );
+        return 0;
+    }
+
+    if (table->runtime == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol table runtime must not be null"
+        );
+        return 0;
+    }
+
+    return 1;
+}
+
+static size_t basl_symbol_next_capacity(size_t current_capacity) {
+    if (current_capacity == 0U) {
+        return 16U;
+    }
+
+    return current_capacity * 2U;
+}
+
+static basl_status_t basl_symbol_table_grow(
+    basl_symbol_table_t *table,
+    size_t minimum_capacity,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_string_t *strings;
+    size_t new_capacity;
+    size_t old_capacity;
+    void *memory;
+
+    if (table->capacity >= minimum_capacity) {
+        basl_error_clear(error);
+        return BASL_STATUS_OK;
+    }
+
+    new_capacity = basl_symbol_next_capacity(table->capacity);
+    while (new_capacity < minimum_capacity) {
+        if (new_capacity > SIZE_MAX / 2U) {
+            basl_error_set_literal(
+                error,
+                BASL_STATUS_INVALID_ARGUMENT,
+                "symbol table capacity would overflow"
+            );
+            return BASL_STATUS_INVALID_ARGUMENT;
+        }
+
+        new_capacity *= 2U;
+    }
+
+    if (new_capacity > SIZE_MAX / sizeof(*strings)) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol table capacity would overflow"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    old_capacity = table->capacity;
+    memory = table->strings;
+    if (memory == NULL) {
+        status = basl_runtime_alloc(
+            table->runtime,
+            new_capacity * sizeof(*strings),
+            &memory,
+            error
+        );
+    } else {
+        status = basl_runtime_realloc(
+            table->runtime,
+            &memory,
+            new_capacity * sizeof(*strings),
+            error
+        );
+        if (status == BASL_STATUS_OK) {
+            memset(
+                (basl_string_t *)memory + old_capacity,
+                0,
+                (new_capacity - old_capacity) * sizeof(*strings)
+            );
+        }
+    }
+
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    table->strings = memory;
+    table->capacity = new_capacity;
+    return BASL_STATUS_OK;
+}
+
+void basl_symbol_table_init(
+    basl_symbol_table_t *table,
+    basl_runtime_t *runtime
+) {
+    if (table == NULL) {
+        return;
+    }
+
+    memset(table, 0, sizeof(*table));
+    table->runtime = runtime;
+    basl_map_init(&table->by_name, runtime);
+}
+
+void basl_symbol_table_clear(basl_symbol_table_t *table) {
+    size_t index;
+    basl_string_t *strings;
+
+    if (table == NULL) {
+        return;
+    }
+
+    strings = basl_symbol_strings(table);
+    for (index = 0U; index < table->count; index += 1U) {
+        basl_string_free(&strings[index]);
+        memset(&strings[index], 0, sizeof(strings[index]));
+    }
+
+    basl_map_clear(&table->by_name);
+    table->count = 0U;
+}
+
+void basl_symbol_table_free(basl_symbol_table_t *table) {
+    void *memory;
+
+    if (table == NULL) {
+        return;
+    }
+
+    basl_symbol_table_clear(table);
+    memory = table->strings;
+    if (table->runtime != NULL) {
+        basl_runtime_free(table->runtime, &memory);
+    }
+    basl_map_free(&table->by_name);
+    memset(table, 0, sizeof(*table));
+}
+
+size_t basl_symbol_table_count(const basl_symbol_table_t *table) {
+    if (table == NULL) {
+        return 0U;
+    }
+
+    return table->count;
+}
+
+basl_status_t basl_symbol_table_intern(
+    basl_symbol_table_t *table,
+    const char *text,
+    size_t length,
+    basl_symbol_t *out_symbol,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    const basl_value_t *stored_value;
+    basl_value_t symbol_value;
+    basl_string_t *strings;
+    basl_symbol_t symbol;
+
+    if (out_symbol != NULL) {
+        *out_symbol = BASL_SYMBOL_INVALID;
+    }
+
+    if (!basl_symbol_table_validate_mutable(table, error)) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (text == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol text must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (out_symbol == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "out_symbol must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    stored_value = basl_map_get(&table->by_name, text, length);
+    if (stored_value != NULL) {
+        if (basl_value_kind(stored_value) != BASL_VALUE_INT) {
+            basl_error_set_literal(
+                error,
+                BASL_STATUS_INTERNAL,
+                "symbol table map entry must be an integer"
+            );
+            return BASL_STATUS_INTERNAL;
+        }
+
+        *out_symbol = (basl_symbol_t)basl_value_as_int(stored_value);
+        basl_error_clear(error);
+        return BASL_STATUS_OK;
+    }
+
+    if (table->count == UINT32_MAX) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol table is full"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    status = basl_symbol_table_grow(table, table->count + 1U, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    strings = basl_symbol_strings(table);
+    basl_string_init(&strings[table->count], table->runtime);
+    status = basl_string_assign(&strings[table->count], text, length, error);
+    if (status != BASL_STATUS_OK) {
+        basl_string_free(&strings[table->count]);
+        return status;
+    }
+
+    symbol = (basl_symbol_t)(table->count + 1U);
+    basl_value_init_int(&symbol_value, (int64_t)symbol);
+    status = basl_map_set(&table->by_name, text, length, &symbol_value, error);
+    if (status != BASL_STATUS_OK) {
+        basl_string_free(&strings[table->count]);
+        memset(&strings[table->count], 0, sizeof(strings[table->count]));
+        return status;
+    }
+
+    table->count += 1U;
+    *out_symbol = symbol;
+    basl_error_clear(error);
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_symbol_table_intern_cstr(
+    basl_symbol_table_t *table,
+    const char *text,
+    basl_symbol_t *out_symbol,
+    basl_error_t *error
+) {
+    if (text == NULL) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "symbol text must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    return basl_symbol_table_intern(table, text, strlen(text), out_symbol, error);
+}
+
+const char *basl_symbol_table_c_str(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+) {
+    const basl_string_t *strings;
+
+    if (!basl_symbol_table_is_valid(table, symbol)) {
+        return NULL;
+    }
+
+    strings = basl_symbol_const_strings(table);
+    return basl_string_c_str(&strings[symbol - 1U]);
+}
+
+size_t basl_symbol_table_length(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+) {
+    const basl_string_t *strings;
+
+    if (!basl_symbol_table_is_valid(table, symbol)) {
+        return 0U;
+    }
+
+    strings = basl_symbol_const_strings(table);
+    return basl_string_length(&strings[symbol - 1U]);
+}
+
+int basl_symbol_table_is_valid(
+    const basl_symbol_table_t *table,
+    basl_symbol_t symbol
+) {
+    if (table == NULL || symbol == BASL_SYMBOL_INVALID) {
+        return 0;
+    }
+
+    return (size_t)symbol <= table->count;
+}

--- a/tests/symbol_test.cpp
+++ b/tests/symbol_test.cpp
@@ -1,0 +1,246 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+
+extern "C" {
+#include "basl/basl.h"
+}
+
+namespace {
+
+struct AllocatorStats {
+    int allocate_calls;
+    int reallocate_calls;
+    int deallocate_calls;
+};
+
+void *CountedAllocate(void *user_data, size_t size) {
+    AllocatorStats *stats = static_cast<AllocatorStats *>(user_data);
+
+    stats->allocate_calls += 1;
+    return std::calloc(1U, size);
+}
+
+void *CountedReallocate(void *user_data, void *memory, size_t size) {
+    AllocatorStats *stats = static_cast<AllocatorStats *>(user_data);
+
+    stats->reallocate_calls += 1;
+    return std::realloc(memory, size);
+}
+
+void CountedDeallocate(void *user_data, void *memory) {
+    AllocatorStats *stats = static_cast<AllocatorStats *>(user_data);
+
+    stats->deallocate_calls += 1;
+    std::free(memory);
+}
+
+}  // namespace
+
+TEST(BaslSymbolTest, InitStartsEmpty) {
+    basl_symbol_table_t table;
+
+    basl_symbol_table_init(&table, nullptr);
+
+    EXPECT_EQ(table.runtime, nullptr);
+    EXPECT_EQ(table.count, 0U);
+    EXPECT_EQ(table.capacity, 0U);
+    EXPECT_EQ(table.strings, nullptr);
+    EXPECT_EQ(basl_symbol_table_count(&table), 0U);
+    EXPECT_FALSE(basl_symbol_table_is_valid(&table, BASL_SYMBOL_INVALID));
+    EXPECT_EQ(basl_symbol_table_c_str(&table, BASL_SYMBOL_INVALID), nullptr);
+    EXPECT_EQ(basl_symbol_table_length(&table, BASL_SYMBOL_INVALID), 0U);
+}
+
+TEST(BaslSymbolTest, InternReturnsStableSymbolForSameText) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_symbol_table_t table;
+    basl_symbol_t first;
+    basl_symbol_t second;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_symbol_table_init(&table, runtime);
+
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "alpha", &first, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "alpha", &second, &error),
+        BASL_STATUS_OK
+    );
+
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(first, 1U);
+    EXPECT_EQ(basl_symbol_table_count(&table), 1U);
+    EXPECT_TRUE(basl_symbol_table_is_valid(&table, first));
+    ASSERT_NE(basl_symbol_table_c_str(&table, first), nullptr);
+    EXPECT_STREQ(basl_symbol_table_c_str(&table, first), "alpha");
+    EXPECT_EQ(basl_symbol_table_length(&table, first), 5U);
+
+    basl_symbol_table_free(&table);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslSymbolTest, DistinctSymbolsGetDistinctIdsAndReverseLookup) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_symbol_table_t table;
+    basl_symbol_t alpha;
+    basl_symbol_t beta;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_symbol_table_init(&table, runtime);
+
+    ASSERT_EQ(
+        basl_symbol_table_intern(&table, "alpha", 5U, &alpha, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_symbol_table_intern(&table, "beta", 4U, &beta, &error),
+        BASL_STATUS_OK
+    );
+
+    EXPECT_NE(alpha, beta);
+    EXPECT_EQ(alpha, 1U);
+    EXPECT_EQ(beta, 2U);
+    EXPECT_STREQ(basl_symbol_table_c_str(&table, alpha), "alpha");
+    EXPECT_STREQ(basl_symbol_table_c_str(&table, beta), "beta");
+    EXPECT_EQ(basl_symbol_table_length(&table, alpha), 5U);
+    EXPECT_EQ(basl_symbol_table_length(&table, beta), 4U);
+    EXPECT_EQ(basl_symbol_table_c_str(&table, 3U), nullptr);
+
+    basl_symbol_table_free(&table);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslSymbolTest, ClearKeepsTableReusable) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_symbol_table_t table;
+    basl_symbol_t symbol;
+    size_t capacity;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_symbol_table_init(&table, runtime);
+
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "alpha", &symbol, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "beta", &symbol, &error),
+        BASL_STATUS_OK
+    );
+    capacity = table.capacity;
+
+    basl_symbol_table_clear(&table);
+    EXPECT_EQ(basl_symbol_table_count(&table), 0U);
+    EXPECT_EQ(table.capacity, capacity);
+    EXPECT_EQ(basl_symbol_table_c_str(&table, 1U), nullptr);
+
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "gamma", &symbol, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(symbol, 1U);
+    EXPECT_STREQ(basl_symbol_table_c_str(&table, symbol), "gamma");
+
+    basl_symbol_table_free(&table);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslSymbolTest, GrowthPreservesInternedNames) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_symbol_table_t table;
+    char name[32];
+    size_t index;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_symbol_table_init(&table, runtime);
+
+    for (index = 0U; index < 128U; index += 1U) {
+        basl_symbol_t symbol;
+
+        std::snprintf(name, sizeof(name), "name-%zu", index);
+        ASSERT_EQ(
+            basl_symbol_table_intern_cstr(&table, name, &symbol, &error),
+            BASL_STATUS_OK
+        );
+        EXPECT_EQ(symbol, index + 1U);
+    }
+
+    for (index = 0U; index < 128U; index += 1U) {
+        basl_symbol_t symbol;
+
+        std::snprintf(name, sizeof(name), "name-%zu", index);
+        symbol = static_cast<basl_symbol_t>(index + 1U);
+        ASSERT_NE(basl_symbol_table_c_str(&table, symbol), nullptr);
+        EXPECT_STREQ(basl_symbol_table_c_str(&table, symbol), name);
+    }
+
+    basl_symbol_table_free(&table);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslSymbolTest, UsesRuntimeAllocatorHooks) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_symbol_table_t table;
+    basl_symbol_t symbol;
+    AllocatorStats stats = {};
+    basl_allocator_t allocator = {};
+    basl_runtime_options_t options = {};
+
+    allocator.user_data = &stats;
+    allocator.allocate = CountedAllocate;
+    allocator.reallocate = CountedReallocate;
+    allocator.deallocate = CountedDeallocate;
+    basl_runtime_options_init(&options);
+    options.allocator = &allocator;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, &options, &error), BASL_STATUS_OK);
+    basl_symbol_table_init(&table, runtime);
+
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "alpha", &symbol, &error),
+        BASL_STATUS_OK
+    );
+    ASSERT_EQ(
+        basl_symbol_table_intern_cstr(&table, "beta", &symbol, &error),
+        BASL_STATUS_OK
+    );
+
+    EXPECT_GE(stats.allocate_calls, 4);
+
+    basl_symbol_table_free(&table);
+    EXPECT_GE(stats.deallocate_calls, 3);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslSymbolTest, RejectsMissingRuntimeAndInvalidArguments) {
+    basl_symbol_table_t table;
+    basl_error_t error = {};
+    basl_symbol_t symbol;
+
+    basl_symbol_table_init(&table, nullptr);
+
+    EXPECT_EQ(
+        basl_symbol_table_intern_cstr(&table, "alpha", &symbol, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(error.type, BASL_STATUS_INVALID_ARGUMENT);
+    ASSERT_NE(error.value, nullptr);
+    EXPECT_EQ(std::strcmp(error.value, "symbol table runtime must not be null"), 0);
+
+    EXPECT_EQ(
+        basl_symbol_table_intern(nullptr, "alpha", 5U, &symbol, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(error.type, BASL_STATUS_INVALID_ARGUMENT);
+    ASSERT_NE(error.value, nullptr);
+    EXPECT_EQ(std::strcmp(error.value, "symbol table must not be null"), 0);
+}


### PR DESCRIPTION
## Summary
- add a runtime-backed symbol table that interns strings into stable `uint32_t` symbol identifiers
- store reverse string data for lookup while using the map foundation for name-to-symbol resolution
- add unit coverage for stable ids, reverse lookup, growth, reuse, allocator hooks, and validation

## Verification
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`