### PR TITLE
Add semantic checking API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 add_library(basl ${BASL_LIBRARY_TYPE}
     src/allocator.c
     src/array.c
+    src/checker.c
     src/chunk.c
     src/compiler.c
     src/diagnostic.c
@@ -75,6 +76,7 @@ if(BASL_BUILD_TESTS)
 
     add_executable(basl_tests
         tests/array_test.cpp
+        tests/checker_test.cpp
         tests/chunk_test.cpp
         tests/compiler_test.cpp
         tests/diagnostic_test.cpp

--- a/include/basl/basl.h
+++ b/include/basl/basl.h
@@ -3,6 +3,7 @@
 
 #include "basl/array.h"
 #include "basl/allocator.h"
+#include "basl/checker.h"
 #include "basl/chunk.h"
 #include "basl/compiler.h"
 #include "basl/diagnostic.h"

--- a/include/basl/checker.h
+++ b/include/basl/checker.h
@@ -1,0 +1,29 @@
+#ifndef BASL_CHECKER_H
+#define BASL_CHECKER_H
+
+#include "basl/diagnostic.h"
+#include "basl/export.h"
+#include "basl/source.h"
+#include "basl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Validates a BASL source file without returning an executable entrypoint.
+ * Diagnostics describe syntax and semantic errors discovered during lexing,
+ * declaration parsing, and function-body compilation.
+ */
+BASL_API basl_status_t basl_check_source(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/checker.c
+++ b/src/checker.c
@@ -1,0 +1,19 @@
+#include "basl/checker.h"
+
+#include "internal/basl_compiler_internal.h"
+
+basl_status_t basl_check_source(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    return basl_compile_source_internal(
+        registry,
+        source_id,
+        BASL_COMPILE_MODE_CHECK_ONLY,
+        NULL,
+        diagnostics,
+        error
+    );
+}

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -4,6 +4,11 @@
 
 #include "basl/basl.h"
 
+typedef enum basl_cli_mode {
+    BASL_CLI_MODE_RUN = 0,
+    BASL_CLI_MODE_CHECK = 1
+} basl_cli_mode_t;
+
 static FILE *basl_open_file(const char *path, const char *mode) {
 #ifdef _WIN32
     FILE *file = NULL;
@@ -89,27 +94,129 @@ static char *basl_read_file(const char *path, size_t *out_length) {
     return buffer;
 }
 
+static int basl_parse_mode(
+    int argc,
+    char **argv,
+    basl_cli_mode_t *out_mode,
+    const char **out_path
+) {
+    if (argc == 2) {
+        *out_mode = BASL_CLI_MODE_RUN;
+        *out_path = argv[1];
+        return 1;
+    }
+
+    if (argc == 3 && strcmp(argv[1], "check") == 0) {
+        *out_mode = BASL_CLI_MODE_CHECK;
+        *out_path = argv[2];
+        return 1;
+    }
+
+    return 0;
+}
+
+static int basl_register_script_source(
+    basl_source_registry_t *registry,
+    const char *path,
+    const char *file_text,
+    size_t file_length,
+    basl_source_id_t *out_source_id,
+    basl_error_t *error
+) {
+    return basl_source_registry_register(
+               registry,
+               path,
+               strlen(path),
+               file_text,
+               file_length,
+               out_source_id,
+               error
+           ) == BASL_STATUS_OK;
+}
+
+static int basl_check_script(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    basl_status_t status;
+
+    status = basl_check_source(registry, source_id, diagnostics, error);
+    if (status == BASL_STATUS_OK) {
+        return 0;
+    }
+
+    if (basl_diagnostic_list_count(diagnostics) != 0U) {
+        return 2;
+    }
+
+    fprintf(stderr, "check failed: %s\n", basl_error_message(error));
+    return 1;
+}
+
+static int basl_run_script(
+    basl_vm_t *vm,
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_diagnostic_list_t *diagnostics,
+    basl_value_t *result,
+    basl_error_t *error
+) {
+    basl_object_t *function;
+    basl_status_t status;
+
+    function = NULL;
+    status = basl_compile_source(registry, source_id, &function, diagnostics, error);
+    if (status != BASL_STATUS_OK) {
+        if (basl_diagnostic_list_count(diagnostics) != 0U) {
+            basl_object_release(&function);
+            return 2;
+        }
+
+        fprintf(stderr, "compile failed: %s\n", basl_error_message(error));
+        basl_object_release(&function);
+        return 1;
+    }
+
+    status = basl_vm_execute_function(vm, function, result, error);
+    basl_object_release(&function);
+    if (status != BASL_STATUS_OK) {
+        fprintf(stderr, "execution failed: %s\n", basl_error_message(error));
+        return 1;
+    }
+
+    if (basl_value_kind(result) != BASL_VALUE_INT) {
+        fprintf(stderr, "compiled entrypoint did not return i32\n");
+        return 1;
+    }
+
+    return (int)basl_value_as_int(result);
+}
+
 int main(int argc, char **argv) {
+    basl_cli_mode_t mode;
+    const char *script_path;
     basl_runtime_t *runtime = NULL;
     basl_vm_t *vm = NULL;
     basl_error_t error = {0};
     basl_source_registry_t registry;
     basl_diagnostic_list_t diagnostics;
-    basl_object_t *function = NULL;
     basl_value_t result;
     basl_source_id_t source_id = 0U;
     char *file_text = NULL;
     size_t file_length = 0U;
     int exit_code = 0;
 
-    if (argc != 2) {
+    if (!basl_parse_mode(argc, argv, &mode, &script_path)) {
         fprintf(stderr, "usage: %s <script.basl>\n", argv[0]);
+        fprintf(stderr, "       %s check <script.basl>\n", argv[0]);
         return 2;
     }
 
-    file_text = basl_read_file(argv[1], &file_length);
+    file_text = basl_read_file(script_path, &file_length);
     if (file_text == NULL) {
-        fprintf(stderr, "failed to read script: %s\n", argv[1]);
+        fprintf(stderr, "failed to read script: %s\n", script_path);
         return 1;
     }
 
@@ -119,7 +226,10 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    if (basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK) {
+    if (
+        mode == BASL_CLI_MODE_RUN &&
+        basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK
+    ) {
         fprintf(stderr, "failed to initialize vm: %s\n", basl_error_message(&error));
         basl_runtime_close(&runtime);
         free(file_text);
@@ -131,51 +241,42 @@ int main(int argc, char **argv) {
     basl_value_init_nil(&result);
 
     if (
-        basl_source_registry_register(
+        !basl_register_script_source(
             &registry,
-            argv[1],
-            strlen(argv[1]),
+            script_path,
             file_text,
             file_length,
             &source_id,
             &error
-        ) != BASL_STATUS_OK
+        )
     ) {
         fprintf(stderr, "failed to register source: %s\n", basl_error_message(&error));
         exit_code = 1;
         goto cleanup;
     }
 
-    if (
-        basl_compile_source(&registry, source_id, &function, &diagnostics, &error)
-        != BASL_STATUS_OK
-    ) {
+    if (mode == BASL_CLI_MODE_CHECK) {
+        exit_code = basl_check_script(&registry, source_id, &diagnostics, &error);
         if (basl_diagnostic_list_count(&diagnostics) != 0U) {
             exit_code = basl_print_diagnostics(&registry, &diagnostics);
-        } else {
-            fprintf(stderr, "compile failed: %s\n", basl_error_message(&error));
-            exit_code = 1;
         }
         goto cleanup;
     }
 
-    if (basl_vm_execute_function(vm, function, &result, &error) != BASL_STATUS_OK) {
-        fprintf(stderr, "execution failed: %s\n", basl_error_message(&error));
-        exit_code = 1;
-        goto cleanup;
+    exit_code = basl_run_script(
+        vm,
+        &registry,
+        source_id,
+        &diagnostics,
+        &result,
+        &error
+    );
+    if (basl_diagnostic_list_count(&diagnostics) != 0U) {
+        exit_code = basl_print_diagnostics(&registry, &diagnostics);
     }
-
-    if (basl_value_kind(&result) != BASL_VALUE_INT) {
-        fprintf(stderr, "compiled entrypoint did not return i32\n");
-        exit_code = 1;
-        goto cleanup;
-    }
-
-    exit_code = (int)basl_value_as_int(&result);
 
 cleanup:
     basl_value_release(&result);
-    basl_object_release(&function);
     basl_diagnostic_list_free(&diagnostics);
     basl_source_registry_free(&registry);
     basl_vm_close(&vm);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3,9 +3,9 @@
 #include <string.h>
 
 #include "basl/chunk.h"
-#include "basl/compiler.h"
 #include "basl/lexer.h"
 #include "basl/token.h"
+#include "internal/basl_compiler_internal.h"
 #include "internal/basl_internal.h"
 
 typedef enum basl_parser_type {
@@ -211,6 +211,30 @@ static basl_status_t basl_program_resolve_type_name(
     }
 
     return basl_compile_report(program, token->span, unsupported_message);
+}
+
+static basl_status_t basl_program_validate_main_signature(
+    basl_program_state_t *program,
+    basl_function_decl_t *decl,
+    const basl_token_t *type_token
+) {
+    if (decl->param_count != 0U) {
+        return basl_compile_report(
+            program,
+            decl->name_span,
+            "main entrypoint must not declare parameters"
+        );
+    }
+
+    if (decl->return_type != BASL_PARSER_TYPE_I32) {
+        return basl_compile_report(
+            program,
+            type_token->span,
+            "main entrypoint must declare return type i32"
+        );
+    }
+
+    return BASL_STATUS_OK;
 }
 
 static basl_status_t basl_program_grow_functions(
@@ -558,19 +582,9 @@ static basl_status_t basl_program_parse_declarations(
             if (status != BASL_STATUS_OK) {
                 return status;
             }
-            if (decl->param_count != 0U) {
-                return basl_compile_report(
-                    program,
-                    decl->name_span,
-                    "main entrypoint must not declare parameters"
-                );
-            }
-            if (decl->return_type != BASL_PARSER_TYPE_I32) {
-                return basl_compile_report(
-                    program,
-                    type_token->span,
-                    "main entrypoint must declare return type i32"
-                );
+            status = basl_program_validate_main_signature(program, decl, type_token);
+            if (status != BASL_STATUS_OK) {
+                return status;
             }
         } else {
             status = basl_program_resolve_type_name(
@@ -740,6 +754,63 @@ static basl_status_t basl_parser_report(
     const char *message
 ) {
     return basl_compile_report(state->program, span, message);
+}
+
+static basl_status_t basl_parser_require_type(
+    basl_parser_state_t *state,
+    basl_source_span_t span,
+    basl_parser_type_t actual_type,
+    basl_parser_type_t expected_type,
+    const char *message
+) {
+    if (actual_type == expected_type) {
+        return BASL_STATUS_OK;
+    }
+
+    return basl_parser_report(state, span, message);
+}
+
+static basl_status_t basl_parser_require_bool_type(
+    basl_parser_state_t *state,
+    basl_source_span_t span,
+    basl_parser_type_t actual_type,
+    const char *message
+) {
+    return basl_parser_require_type(
+        state,
+        span,
+        actual_type,
+        BASL_PARSER_TYPE_BOOL,
+        message
+    );
+}
+
+static basl_status_t basl_parser_require_same_type(
+    basl_parser_state_t *state,
+    basl_source_span_t span,
+    basl_parser_type_t left_type,
+    basl_parser_type_t right_type,
+    const char *message
+) {
+    if (left_type == right_type) {
+        return BASL_STATUS_OK;
+    }
+
+    return basl_parser_report(state, span, message);
+}
+
+static basl_status_t basl_parser_require_i32_operands(
+    basl_parser_state_t *state,
+    basl_source_span_t span,
+    basl_parser_type_t left_type,
+    basl_parser_type_t right_type,
+    const char *message
+) {
+    if (left_type == BASL_PARSER_TYPE_I32 && right_type == BASL_PARSER_TYPE_I32) {
+        return BASL_STATUS_OK;
+    }
+
+    return basl_parser_report(state, span, message);
 }
 
 static basl_status_t basl_parser_expect(
@@ -1391,12 +1462,15 @@ static basl_status_t basl_parser_parse_call(
                     "call argument count does not match function signature"
                 );
             }
-            if (arg_type != decl->params[arg_count].type) {
-                return basl_parser_report(
-                    state,
-                    name_token->span,
-                    "call argument type does not match parameter type"
-                );
+            status = basl_parser_require_type(
+                state,
+                name_token->span,
+                arg_type,
+                decl->params[arg_count].type,
+                "call argument type does not match parameter type"
+            );
+            if (status != BASL_STATUS_OK) {
+                return status;
             }
             arg_count += 1U;
 
@@ -1558,23 +1632,28 @@ static basl_status_t basl_parser_parse_unary(
         }
 
         if (operator_token->kind == BASL_TOKEN_MINUS) {
-            if (operand_type != BASL_PARSER_TYPE_I32) {
-                return basl_parser_report(
-                    state,
-                    operator_token->span,
-                    "unary '-' requires an i32 operand"
-                );
+            status = basl_parser_require_type(
+                state,
+                operator_token->span,
+                operand_type,
+                BASL_PARSER_TYPE_I32,
+                "unary '-' requires an i32 operand"
+            );
+            if (status != BASL_STATUS_OK) {
+                return status;
             }
             *out_type = BASL_PARSER_TYPE_I32;
             return basl_parser_emit_opcode(state, BASL_OPCODE_NEGATE, operator_token->span);
         }
 
-        if (operand_type != BASL_PARSER_TYPE_BOOL) {
-            return basl_parser_report(
-                state,
-                operator_token->span,
-                "logical '!' requires a bool operand"
-            );
+        status = basl_parser_require_bool_type(
+            state,
+            operator_token->span,
+            operand_type,
+            "logical '!' requires a bool operand"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
         *out_type = BASL_PARSER_TYPE_BOOL;
         return basl_parser_emit_opcode(state, BASL_OPCODE_NOT, operator_token->span);
@@ -1614,12 +1693,15 @@ static basl_status_t basl_parser_parse_factor(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (left_type != BASL_PARSER_TYPE_I32 || right_type != BASL_PARSER_TYPE_I32) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "arithmetic operators require i32 operands"
-            );
+        status = basl_parser_require_i32_operands(
+            state,
+            operator_span,
+            left_type,
+            right_type,
+            "arithmetic operators require i32 operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         if (operator_kind == BASL_TOKEN_STAR) {
@@ -1668,12 +1750,15 @@ static basl_status_t basl_parser_parse_term(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (left_type != BASL_PARSER_TYPE_I32 || right_type != BASL_PARSER_TYPE_I32) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "arithmetic operators require i32 operands"
-            );
+        status = basl_parser_require_i32_operands(
+            state,
+            operator_span,
+            left_type,
+            right_type,
+            "arithmetic operators require i32 operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_emit_opcode(
@@ -1724,12 +1809,15 @@ static basl_status_t basl_parser_parse_comparison(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (left_type != BASL_PARSER_TYPE_I32 || right_type != BASL_PARSER_TYPE_I32) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "comparison operators require i32 operands"
-            );
+        status = basl_parser_require_i32_operands(
+            state,
+            operator_span,
+            left_type,
+            right_type,
+            "comparison operators require i32 operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         switch (operator_kind) {
@@ -1794,12 +1882,15 @@ static basl_status_t basl_parser_parse_equality(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (left_type != right_type) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "equality operators require operands of the same type"
-            );
+        status = basl_parser_require_same_type(
+            state,
+            operator_span,
+            left_type,
+            right_type,
+            "equality operators require operands of the same type"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_emit_opcode(state, BASL_OPCODE_EQUAL, operator_span);
@@ -1836,12 +1927,14 @@ static basl_status_t basl_parser_parse_logical_and(
 
     while (basl_parser_check(state, BASL_TOKEN_AMPERSAND_AMPERSAND)) {
         operator_span = basl_parser_advance(state)->span;
-        if (left_type != BASL_PARSER_TYPE_BOOL) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "logical '&&' requires bool operands"
-            );
+        status = basl_parser_require_bool_type(
+            state,
+            operator_span,
+            left_type,
+            "logical '&&' requires bool operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_emit_jump(
@@ -1862,12 +1955,14 @@ static basl_status_t basl_parser_parse_logical_and(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (right_type != BASL_PARSER_TYPE_BOOL) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "logical '&&' requires bool operands"
-            );
+        status = basl_parser_require_bool_type(
+            state,
+            operator_span,
+            right_type,
+            "logical '&&' requires bool operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_patch_jump(state, false_jump_offset);
@@ -1899,12 +1994,14 @@ static basl_status_t basl_parser_parse_logical_or(
 
     while (basl_parser_check(state, BASL_TOKEN_PIPE_PIPE)) {
         operator_span = basl_parser_advance(state)->span;
-        if (left_type != BASL_PARSER_TYPE_BOOL) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "logical '||' requires bool operands"
-            );
+        status = basl_parser_require_bool_type(
+            state,
+            operator_span,
+            left_type,
+            "logical '||' requires bool operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_emit_jump(
@@ -1939,12 +2036,14 @@ static basl_status_t basl_parser_parse_logical_or(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        if (right_type != BASL_PARSER_TYPE_BOOL) {
-            return basl_parser_report(
-                state,
-                operator_span,
-                "logical '||' requires bool operands"
-            );
+        status = basl_parser_require_bool_type(
+            state,
+            operator_span,
+            right_type,
+            "logical '||' requires bool operands"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
         }
 
         status = basl_parser_patch_jump(state, end_jump_offset);
@@ -2014,14 +2113,17 @@ static basl_status_t basl_parser_parse_return_statement(
     if (status != BASL_STATUS_OK) {
         return status;
     }
-    if (return_type != state->expected_return_type) {
-        return basl_parser_report(
-            state,
-            return_token->span,
-            state->function_index == state->program->main_index
-                ? "main entrypoint must return an i32 expression"
-                : "return expression type does not match function return type"
-        );
+    status = basl_parser_require_type(
+        state,
+        return_token->span,
+        return_type,
+        state->expected_return_type,
+        state->function_index == state->program->main_index
+            ? "main entrypoint must return an i32 expression"
+            : "return expression type does not match function return type"
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
     }
 
     status = basl_parser_expect(
@@ -2060,8 +2162,14 @@ static basl_status_t basl_parser_parse_if_statement(
     if (status != BASL_STATUS_OK) {
         return status;
     }
-    if (condition_type != BASL_PARSER_TYPE_BOOL) {
-        return basl_parser_report(state, if_token->span, "if condition must be bool");
+    status = basl_parser_require_bool_type(
+        state,
+        if_token->span,
+        condition_type,
+        "if condition must be bool"
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
     }
 
     status = basl_parser_expect(state, BASL_TOKEN_RPAREN, "expected ')' after if condition", NULL);
@@ -2150,8 +2258,14 @@ static basl_status_t basl_parser_parse_while_statement(
     if (status != BASL_STATUS_OK) {
         return status;
     }
-    if (condition_type != BASL_PARSER_TYPE_BOOL) {
-        return basl_parser_report(state, while_token->span, "while condition must be bool");
+    status = basl_parser_require_bool_type(
+        state,
+        while_token->span,
+        condition_type,
+        "while condition must be bool"
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
     }
 
     status = basl_parser_expect(state, BASL_TOKEN_RPAREN, "expected ')' after while condition", NULL);
@@ -2354,12 +2468,15 @@ static basl_status_t basl_parser_parse_assignment_statement(
     if (status != BASL_STATUS_OK) {
         return status;
     }
-    if (value_type != local_type) {
-        return basl_parser_report(
-            state,
-            name_token->span,
-            "assigned expression type does not match local variable type"
-        );
+    status = basl_parser_require_type(
+        state,
+        name_token->span,
+        value_type,
+        local_type,
+        "assigned expression type does not match local variable type"
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
     }
 
     status = basl_parser_expect(state, BASL_TOKEN_SEMICOLON, "expected ';' after assignment", NULL);
@@ -2473,12 +2590,15 @@ static basl_status_t basl_parser_parse_variable_declaration(
     if (status != BASL_STATUS_OK) {
         return status;
     }
-    if (initializer_type != declared_type) {
-        return basl_parser_report(
-            state,
-            name_token->span,
-            "initializer type does not match local variable type"
-        );
+    status = basl_parser_require_type(
+        state,
+        name_token->span,
+        initializer_type,
+        declared_type,
+        "initializer type does not match local variable type"
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
     }
 
     status = basl_parser_expect(state, BASL_TOKEN_SEMICOLON, "expected ';' after local declaration", NULL);
@@ -2588,26 +2708,13 @@ static basl_status_t basl_compile_function(
     return BASL_STATUS_OK;
 }
 
-basl_status_t basl_compile_source(
+static basl_status_t basl_compile_validate_inputs(
     const basl_source_registry_t *registry,
-    basl_source_id_t source_id,
-    basl_object_t **out_function,
     basl_diagnostic_list_t *diagnostics,
+    basl_object_t **out_function,
+    basl_compile_mode_t mode,
     basl_error_t *error
 ) {
-    basl_status_t status;
-    basl_token_list_t tokens;
-    basl_program_state_t program;
-    const basl_source_file_t *source;
-    size_t i;
-    basl_object_t **function_table;
-    void *memory;
-
-    basl_error_clear(error);
-    if (out_function != NULL) {
-        *out_function = NULL;
-    }
-
     if (registry == NULL) {
         basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "source registry must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
@@ -2616,10 +2723,24 @@ basl_status_t basl_compile_source(
         basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "diagnostic list must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
     }
-    if (out_function == NULL) {
+    if (mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT && out_function == NULL) {
         basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "out_function must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
     }
+
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t basl_compile_lex_source(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error,
+    const basl_source_file_t **out_source,
+    basl_token_list_t *out_tokens
+) {
+    basl_status_t status;
+    const basl_source_file_t *source;
 
     source = basl_source_registry_get(registry, source_id);
     if (source == NULL) {
@@ -2627,10 +2748,117 @@ basl_status_t basl_compile_source(
         return BASL_STATUS_INVALID_ARGUMENT;
     }
 
-    basl_token_list_init(&tokens, registry->runtime);
-    status = basl_lex_source(registry, source_id, &tokens, diagnostics, error);
+    basl_token_list_init(out_tokens, registry->runtime);
+    status = basl_lex_source(registry, source_id, out_tokens, diagnostics, error);
     if (status != BASL_STATUS_OK) {
-        basl_token_list_free(&tokens);
+        basl_token_list_free(out_tokens);
+        return status;
+    }
+
+    *out_source = source;
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t basl_compile_all_functions(
+    basl_program_state_t *program
+) {
+    basl_status_t status;
+    size_t i;
+
+    for (i = 0U; i < program->function_count; ++i) {
+        status = basl_compile_function(program, i);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    }
+
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t basl_compile_attach_entrypoint(
+    basl_program_state_t *program,
+    basl_object_t **out_function
+) {
+    basl_status_t status;
+    basl_object_t **function_table;
+    size_t i;
+    void *memory;
+
+    memory = NULL;
+    status = basl_runtime_alloc(
+        program->registry->runtime,
+        program->function_count * sizeof(*function_table),
+        &memory,
+        program->error
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    function_table = (basl_object_t **)memory;
+    for (i = 0U; i < program->function_count; ++i) {
+        function_table[i] = program->functions[i].object;
+    }
+
+    status = basl_function_object_attach_siblings(
+        program->functions[program->main_index].object,
+        function_table,
+        program->function_count,
+        program->main_index,
+        program->error
+    );
+    if (status != BASL_STATUS_OK) {
+        memory = function_table;
+        basl_runtime_free(program->registry->runtime, &memory);
+        return status;
+    }
+
+    *out_function = program->functions[program->main_index].object;
+    for (i = 0U; i < program->function_count; ++i) {
+        program->functions[i].object = NULL;
+    }
+
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_compile_source_internal(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_compile_mode_t mode,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_token_list_t tokens;
+    basl_program_state_t program;
+    const basl_source_file_t *source;
+
+    basl_error_clear(error);
+    if (out_function != NULL) {
+        *out_function = NULL;
+    }
+
+    status = basl_compile_validate_inputs(
+        registry,
+        diagnostics,
+        out_function,
+        mode,
+        error
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    status = basl_compile_lex_source(
+        registry,
+        source_id,
+        diagnostics,
+        error,
+        &source,
+        &tokens
+    );
+    if (status != BASL_STATUS_OK) {
         return status;
     }
 
@@ -2648,8 +2876,15 @@ basl_status_t basl_compile_source(
         return status;
     }
 
-    for (i = 0U; i < program.function_count; ++i) {
-        status = basl_compile_function(&program, i);
+    status = basl_compile_all_functions(&program);
+    if (status != BASL_STATUS_OK) {
+        basl_program_free(&program);
+        basl_token_list_free(&tokens);
+        return status;
+    }
+
+    if (mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT) {
+        status = basl_compile_attach_entrypoint(&program, out_function);
         if (status != BASL_STATUS_OK) {
             basl_program_free(&program);
             basl_token_list_free(&tokens);
@@ -2657,45 +2892,24 @@ basl_status_t basl_compile_source(
         }
     }
 
-    memory = NULL;
-    status = basl_runtime_alloc(
-        registry->runtime,
-        program.function_count * sizeof(*function_table),
-        &memory,
-        error
-    );
-    if (status != BASL_STATUS_OK) {
-        basl_program_free(&program);
-        basl_token_list_free(&tokens);
-        return status;
-    }
-
-    function_table = (basl_object_t **)memory;
-    for (i = 0U; i < program.function_count; ++i) {
-        function_table[i] = program.functions[i].object;
-    }
-
-    status = basl_function_object_attach_siblings(
-        program.functions[program.main_index].object,
-        function_table,
-        program.function_count,
-        program.main_index,
-        error
-    );
-    if (status != BASL_STATUS_OK) {
-        memory = function_table;
-        basl_runtime_free(registry->runtime, &memory);
-        basl_program_free(&program);
-        basl_token_list_free(&tokens);
-        return status;
-    }
-
-    *out_function = program.functions[program.main_index].object;
-    for (i = 0U; i < program.function_count; ++i) {
-        program.functions[i].object = NULL;
-    }
-
     basl_program_free(&program);
     basl_token_list_free(&tokens);
     return BASL_STATUS_OK;
+}
+
+basl_status_t basl_compile_source(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    return basl_compile_source_internal(
+        registry,
+        source_id,
+        BASL_COMPILE_MODE_BUILD_ENTRYPOINT,
+        out_function,
+        diagnostics,
+        error
+    );
 }

--- a/src/internal/basl_compiler_internal.h
+++ b/src/internal/basl_compiler_internal.h
@@ -1,0 +1,20 @@
+#ifndef BASL_COMPILER_INTERNAL_H
+#define BASL_COMPILER_INTERNAL_H
+
+#include "basl/compiler.h"
+
+typedef enum basl_compile_mode {
+    BASL_COMPILE_MODE_CHECK_ONLY = 0,
+    BASL_COMPILE_MODE_BUILD_ENTRYPOINT = 1
+} basl_compile_mode_t;
+
+basl_status_t basl_compile_source_internal(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    basl_compile_mode_t mode,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+);
+
+#endif

--- a/tests/checker_test.cpp
+++ b/tests/checker_test.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "basl/basl.h"
+}
+
+namespace {
+
+basl_source_id_t RegisterSource(
+    basl_source_registry_t *registry,
+    const char *path,
+    const char *text,
+    basl_error_t *error
+) {
+    basl_source_id_t source_id = 0U;
+
+    EXPECT_EQ(
+        basl_source_registry_register_cstr(registry, path, text, &source_id, error),
+        BASL_STATUS_OK
+    );
+    return source_id;
+}
+
+}  // namespace
+
+TEST(BaslCheckerTest, ValidatesWellTypedProgramWithoutDiagnostics) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_diagnostic_list_t diagnostics;
+    basl_source_id_t source_id;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+
+    source_id = RegisterSource(
+        &registry,
+        "main.basl",
+        "fn add(i32 left, i32 right) -> i32 {"
+        "    return left + right;"
+        "}"
+        "fn main() -> i32 {"
+        "    i32 total = add(3, 4);"
+        "    while (total > 4) {"
+        "        total = total - 1;"
+        "        if (total == 5) {"
+        "            break;"
+        "        }"
+        "    }"
+        "    return total;"
+        "}",
+        &error
+    );
+
+    EXPECT_EQ(
+        basl_check_source(&registry, source_id, &diagnostics, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(basl_diagnostic_list_count(&diagnostics), 0U);
+
+    basl_diagnostic_list_free(&diagnostics);
+    basl_source_registry_free(&registry);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslCheckerTest, ReportsSemanticErrorsWithoutProducingEntrypoint) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_diagnostic_list_t diagnostics;
+    basl_source_id_t source_id;
+    const basl_diagnostic_t *diagnostic;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+
+    source_id = RegisterSource(
+        &registry,
+        "bad.basl",
+        "fn is_ready() -> bool {"
+        "    return true;"
+        "}"
+        "fn main() -> i32 {"
+        "    i32 value = 1;"
+        "    value = is_ready();"
+        "    return value;"
+        "}",
+        &error
+    );
+
+    EXPECT_EQ(
+        basl_check_source(&registry, source_id, &diagnostics, &error),
+        BASL_STATUS_SYNTAX_ERROR
+    );
+    ASSERT_EQ(basl_diagnostic_list_count(&diagnostics), 1U);
+    diagnostic = basl_diagnostic_list_get(&diagnostics, 0U);
+    ASSERT_NE(diagnostic, nullptr);
+    EXPECT_STREQ(
+        basl_string_c_str(&diagnostic->message),
+        "assigned expression type does not match local variable type"
+    );
+
+    basl_diagnostic_list_free(&diagnostics);
+    basl_source_registry_free(&registry);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslCheckerTest, ValidatesArguments) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_diagnostic_list_t diagnostics;
+    basl_source_id_t source_id = 0U;
+
+    ASSERT_EQ(
+        basl_check_source(nullptr, source_id, &diagnostics, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_STREQ(basl_error_message(&error), "source registry must not be null");
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+    source_id = RegisterSource(
+        &registry,
+        "main.basl",
+        "fn main() -> i32 { return 0; }",
+        &error
+    );
+
+    EXPECT_EQ(
+        basl_check_source(&registry, source_id, nullptr, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_STREQ(basl_error_message(&error), "diagnostic list must not be null");
+
+    basl_diagnostic_list_free(&diagnostics);
+    basl_source_registry_free(&registry);
+    basl_runtime_close(&runtime);
+}


### PR DESCRIPTION
## Summary
- add a public basl_check_source() API for non-executing validation
- refactor the compiler into a shared internal compile/check pipeline with clearer semantic validation helpers
- add a basl check <script.basl> CLI path and dedicated checker tests

## Verification
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure -C Release
- ./build/basl check /tmp/basl_check.basl
- ./build/basl /tmp/basl_check.basl