### PR TITLE
Add per-runtime structured logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(basl ${BASL_LIBRARY_TYPE}
     src/compiler.c
     src/diagnostic.c
     src/lexer.c
+    src/log.c
     src/map.c
     src/runtime.c
     src/source.c
@@ -81,6 +82,7 @@ if(BASL_BUILD_TESTS)
         tests/compiler_test.cpp
         tests/diagnostic_test.cpp
         tests/lexer_test.cpp
+        tests/log_test.cpp
         tests/map_test.cpp
         tests/runtime_test.cpp
         tests/source_test.cpp

--- a/include/basl/basl.h
+++ b/include/basl/basl.h
@@ -8,6 +8,7 @@
 #include "basl/compiler.h"
 #include "basl/diagnostic.h"
 #include "basl/export.h"
+#include "basl/log.h"
 #include "basl/map.h"
 #include "basl/runtime.h"
 #include "basl/source.h"

--- a/include/basl/log.h
+++ b/include/basl/log.h
@@ -1,0 +1,91 @@
+#ifndef BASL_LOG_H
+#define BASL_LOG_H
+
+#include <stddef.h>
+
+#include "basl/export.h"
+#include "basl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum basl_log_level {
+    BASL_LOG_DEBUG = 0,
+    BASL_LOG_INFO = 1,
+    BASL_LOG_WARNING = 2,
+    BASL_LOG_ERROR = 3,
+    BASL_LOG_FATAL = 4
+} basl_log_level_t;
+
+typedef struct basl_log_field {
+    const char *key;
+    const char *value;
+} basl_log_field_t;
+
+typedef struct basl_log_record {
+    basl_log_level_t level;
+    const char *message;
+    size_t message_length;
+    const basl_log_field_t *fields;
+    size_t field_count;
+} basl_log_record_t;
+
+typedef void (*basl_log_handler_fn)(void *user_data, const basl_log_record_t *record);
+
+typedef struct basl_logger {
+    basl_log_level_t minimum_level;
+    basl_log_handler_fn handler;
+    void *user_data;
+} basl_logger_t;
+
+BASL_API void basl_logger_init(basl_logger_t *logger);
+BASL_API const char *basl_log_level_name(basl_log_level_t level);
+BASL_API int basl_logger_should_log(
+    const basl_logger_t *logger,
+    basl_log_level_t level
+);
+BASL_API void basl_stderr_log_handler(
+    void *user_data,
+    const basl_log_record_t *record
+);
+BASL_API basl_status_t basl_logger_log(
+    const basl_logger_t *logger,
+    basl_log_level_t level,
+    const char *message,
+    const basl_log_field_t *fields,
+    size_t field_count,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_logger_debug(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_logger_info(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_logger_warning(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_logger_error(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+);
+BASL_API void basl_logger_fatal(
+    const basl_logger_t *logger,
+    const char *message,
+    const basl_log_field_t *fields,
+    size_t field_count
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/basl/runtime.h
+++ b/include/basl/runtime.h
@@ -5,6 +5,7 @@
 
 #include "basl/allocator.h"
 #include "basl/export.h"
+#include "basl/log.h"
 #include "basl/status.h"
 
 #ifdef __cplusplus
@@ -13,6 +14,7 @@ extern "C" {
 
 typedef struct basl_runtime_options {
     const basl_allocator_t *allocator;
+    const basl_logger_t *logger;
 } basl_runtime_options_t;
 
 typedef struct basl_runtime basl_runtime_t;
@@ -25,6 +27,12 @@ BASL_API basl_status_t basl_runtime_open(
 );
 BASL_API void basl_runtime_close(basl_runtime_t **runtime);
 BASL_API const basl_allocator_t *basl_runtime_allocator(const basl_runtime_t *runtime);
+BASL_API const basl_logger_t *basl_runtime_logger(const basl_runtime_t *runtime);
+BASL_API basl_status_t basl_runtime_set_logger(
+    basl_runtime_t *runtime,
+    const basl_logger_t *logger,
+    basl_error_t *error
+);
 /* basl_runtime_alloc zero-initializes the returned memory on success. */
 BASL_API basl_status_t basl_runtime_alloc(
     basl_runtime_t *runtime,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -9,6 +9,35 @@ typedef enum basl_cli_mode {
     BASL_CLI_MODE_CHECK = 1
 } basl_cli_mode_t;
 
+static void basl_log_cli_message(
+    basl_runtime_t *runtime,
+    basl_log_level_t level,
+    const char *message,
+    const char *field_key,
+    const char *field_value
+) {
+    basl_log_field_t field;
+    const basl_logger_t *logger;
+
+    logger = basl_runtime_logger(runtime);
+
+    if (field_key != NULL && field_value != NULL) {
+        field.key = field_key;
+        field.value = field_value;
+        (void)basl_logger_log(
+            logger,
+            level,
+            message,
+            &field,
+            1U,
+            NULL
+        );
+        return;
+    }
+
+    (void)basl_logger_log(logger, level, message, NULL, 0U, NULL);
+}
+
 static FILE *basl_open_file(const char *path, const char *mode) {
 #ifdef _WIN32
     FILE *file = NULL;
@@ -45,7 +74,13 @@ static int basl_print_diagnostics(
         if (basl_diagnostic_format(registry, diagnostic, &line, &error) == BASL_STATUS_OK) {
             fprintf(stderr, "%s\n", basl_string_c_str(&line));
         } else {
-            fprintf(stderr, "failed to format diagnostic: %s\n", basl_error_message(&error));
+            basl_log_cli_message(
+                runtime,
+                BASL_LOG_ERROR,
+                "failed to format diagnostic",
+                "error",
+                basl_error_message(&error)
+            );
         }
     }
     basl_string_free(&line);
@@ -192,6 +227,7 @@ static int basl_check_script(
 }
 
 static int basl_run_script(
+    basl_runtime_t *runtime,
     basl_vm_t *vm,
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
@@ -223,7 +259,13 @@ static int basl_run_script(
     }
 
     if (basl_value_kind(result) != BASL_VALUE_INT) {
-        fprintf(stderr, "compiled entrypoint did not return i32\n");
+        basl_log_cli_message(
+            runtime,
+            BASL_LOG_ERROR,
+            "compiled entrypoint did not return i32",
+            NULL,
+            NULL
+        );
         return 1;
     }
 
@@ -266,7 +308,13 @@ int main(int argc, char **argv) {
         mode == BASL_CLI_MODE_RUN &&
         basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK
     ) {
-        fprintf(stderr, "failed to initialize vm: %s\n", basl_error_message(&error));
+        basl_log_cli_message(
+            runtime,
+            BASL_LOG_ERROR,
+            "failed to initialize vm",
+            "error",
+            basl_error_message(&error)
+        );
         basl_runtime_close(&runtime);
         free(file_text);
         return 1;
@@ -286,7 +334,13 @@ int main(int argc, char **argv) {
             &error
         )
     ) {
-        fprintf(stderr, "failed to register source: %s\n", basl_error_message(&error));
+        basl_log_cli_message(
+            runtime,
+            BASL_LOG_ERROR,
+            "failed to register source",
+            "error",
+            basl_error_message(&error)
+        );
         exit_code = 1;
         goto cleanup;
     }
@@ -300,6 +354,7 @@ int main(int argc, char **argv) {
     }
 
     exit_code = basl_run_script(
+        runtime,
         vm,
         &registry,
         source_id,

--- a/src/internal/basl_internal.h
+++ b/src/internal/basl_internal.h
@@ -6,6 +6,7 @@
 
 struct basl_runtime {
     basl_allocator_t allocator;
+    basl_logger_t logger;
 };
 
 basl_allocator_t basl_default_allocator(void);

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,270 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "internal/basl_internal.h"
+#include "basl/log.h"
+
+static const basl_logger_t BASL_DEFAULT_LOGGER = {
+    BASL_LOG_INFO,
+    basl_stderr_log_handler,
+    NULL
+};
+
+static const basl_logger_t *basl_resolve_logger(const basl_logger_t *logger) {
+    if (logger == NULL) {
+        return &BASL_DEFAULT_LOGGER;
+    }
+
+    return logger;
+}
+
+static int basl_log_level_is_valid(basl_log_level_t level) {
+    return level >= BASL_LOG_DEBUG && level <= BASL_LOG_FATAL;
+}
+
+static basl_status_t basl_logger_validate(
+    const basl_logger_t *logger,
+    basl_error_t *error
+) {
+    if (!basl_log_level_is_valid(logger->minimum_level)) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "logger minimum_level is invalid"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    return BASL_STATUS_OK;
+}
+
+static basl_log_handler_fn basl_resolve_handler(const basl_logger_t *logger) {
+    if (logger->handler != NULL) {
+        return logger->handler;
+    }
+
+    return basl_stderr_log_handler;
+}
+
+static void basl_write_quoted(FILE *stream, const char *value) {
+    size_t index;
+
+    fputc('"', stream);
+    if (value != NULL) {
+        for (index = 0U; value[index] != '\0'; index += 1U) {
+            char ch;
+
+            ch = value[index];
+            switch (ch) {
+                case '\\':
+                case '"':
+                    fputc('\\', stream);
+                    fputc(ch, stream);
+                    break;
+                case '\n':
+                    fputs("\\n", stream);
+                    break;
+                case '\r':
+                    fputs("\\r", stream);
+                    break;
+                case '\t':
+                    fputs("\\t", stream);
+                    break;
+                default:
+                    fputc(ch, stream);
+                    break;
+            }
+        }
+    }
+    fputc('"', stream);
+}
+
+void basl_logger_init(basl_logger_t *logger) {
+    if (logger == NULL) {
+        return;
+    }
+
+    *logger = BASL_DEFAULT_LOGGER;
+}
+
+const char *basl_log_level_name(basl_log_level_t level) {
+    switch (level) {
+        case BASL_LOG_DEBUG:
+            return "debug";
+        case BASL_LOG_INFO:
+            return "info";
+        case BASL_LOG_WARNING:
+            return "warning";
+        case BASL_LOG_ERROR:
+            return "error";
+        case BASL_LOG_FATAL:
+            return "fatal";
+        default:
+            return "unknown";
+    }
+}
+
+int basl_logger_should_log(const basl_logger_t *logger, basl_log_level_t level) {
+    const basl_logger_t *resolved_logger;
+
+    if (!basl_log_level_is_valid(level)) {
+        return 0;
+    }
+
+    resolved_logger = basl_resolve_logger(logger);
+    if (level == BASL_LOG_FATAL) {
+        return 1;
+    }
+
+    return level >= resolved_logger->minimum_level;
+}
+
+void basl_stderr_log_handler(void *user_data, const basl_log_record_t *record) {
+    size_t index;
+
+    (void)user_data;
+
+    if (record == NULL || record->message == NULL) {
+        return;
+    }
+
+    fprintf(stderr, "level=%s msg=", basl_log_level_name(record->level));
+    basl_write_quoted(stderr, record->message);
+
+    for (index = 0U; index < record->field_count; index += 1U) {
+        const basl_log_field_t *field;
+
+        field = &record->fields[index];
+        if (field->key == NULL || field->value == NULL) {
+            continue;
+        }
+
+        fprintf(stderr, " %s=", field->key);
+        basl_write_quoted(stderr, field->value);
+    }
+
+    fputc('\n', stderr);
+    fflush(stderr);
+}
+
+basl_status_t basl_logger_log(
+    const basl_logger_t *logger,
+    basl_log_level_t level,
+    const char *message,
+    const basl_log_field_t *fields,
+    size_t field_count,
+    basl_error_t *error
+) {
+    const basl_logger_t *resolved_logger;
+    basl_log_handler_fn handler;
+    basl_log_record_t record;
+    size_t index;
+    basl_status_t status;
+
+    basl_error_clear(error);
+
+    if (!basl_log_level_is_valid(level)) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "log level is invalid");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (message == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "log message must not be null");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (field_count != 0U && fields == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "log fields must not be null when field_count is non-zero");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    for (index = 0U; index < field_count; index += 1U) {
+        if (fields[index].key == NULL || fields[index].value == NULL) {
+            basl_error_set_literal(
+                error,
+                BASL_STATUS_INVALID_ARGUMENT,
+                "log fields must define key and value"
+            );
+            return BASL_STATUS_INVALID_ARGUMENT;
+        }
+    }
+
+    resolved_logger = basl_resolve_logger(logger);
+    status = basl_logger_validate(resolved_logger, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    if (!basl_logger_should_log(resolved_logger, level)) {
+        return BASL_STATUS_OK;
+    }
+
+    handler = basl_resolve_handler(resolved_logger);
+    record.level = level;
+    record.message = message;
+    record.message_length = strlen(message);
+    record.fields = fields;
+    record.field_count = field_count;
+    handler(resolved_logger->user_data, &record);
+
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_logger_debug(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+) {
+    return basl_logger_log(logger, BASL_LOG_DEBUG, message, NULL, 0U, error);
+}
+
+basl_status_t basl_logger_info(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+) {
+    return basl_logger_log(logger, BASL_LOG_INFO, message, NULL, 0U, error);
+}
+
+basl_status_t basl_logger_warning(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+) {
+    return basl_logger_log(logger, BASL_LOG_WARNING, message, NULL, 0U, error);
+}
+
+basl_status_t basl_logger_error(
+    const basl_logger_t *logger,
+    const char *message,
+    basl_error_t *error
+) {
+    return basl_logger_log(logger, BASL_LOG_ERROR, message, NULL, 0U, error);
+}
+
+void basl_logger_fatal(
+    const basl_logger_t *logger,
+    const char *message,
+    const basl_log_field_t *fields,
+    size_t field_count
+) {
+    basl_error_t error;
+    basl_log_record_t record;
+
+    memset(&error, 0, sizeof(error));
+    if (
+        basl_logger_log(logger, BASL_LOG_FATAL, message, fields, field_count, &error) !=
+        BASL_STATUS_OK
+    ) {
+        record.level = BASL_LOG_FATAL;
+        record.message =
+            basl_error_message(&error) != NULL ? basl_error_message(&error) : "fatal log failure";
+        record.message_length = strlen(record.message);
+        record.fields = NULL;
+        record.field_count = 0U;
+        basl_stderr_log_handler(NULL, &record);
+    }
+
+    abort();
+}

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -13,6 +13,24 @@ static basl_allocator_t basl_resolve_allocator(const basl_runtime_options_t *opt
     return allocator;
 }
 
+static basl_logger_t basl_resolve_logger(const basl_logger_t *logger) {
+    basl_logger_t resolved_logger;
+
+    basl_logger_init(&resolved_logger);
+    if (logger != NULL) {
+        resolved_logger = *logger;
+        if (resolved_logger.handler == NULL) {
+            resolved_logger.handler = basl_stderr_log_handler;
+        }
+    }
+
+    return resolved_logger;
+}
+
+static int basl_logger_level_is_valid(basl_log_level_t level) {
+    return level >= BASL_LOG_DEBUG && level <= BASL_LOG_FATAL;
+}
+
 void basl_runtime_options_init(basl_runtime_options_t *options) {
     if (options == NULL) {
         return;
@@ -28,6 +46,7 @@ basl_status_t basl_runtime_open(
 ) {
     basl_allocator_t allocator;
     basl_runtime_t *runtime;
+    basl_status_t status;
 
     basl_error_clear(error);
 
@@ -65,6 +84,15 @@ basl_status_t basl_runtime_open(
 
     memset(runtime, 0, sizeof(*runtime));
     runtime->allocator = allocator;
+    status = basl_runtime_set_logger(
+        runtime,
+        options == NULL ? NULL : options->logger,
+        error
+    );
+    if (status != BASL_STATUS_OK) {
+        allocator.deallocate(allocator.user_data, runtime);
+        return status;
+    }
     *out_runtime = runtime;
     return BASL_STATUS_OK;
 }
@@ -89,4 +117,40 @@ const basl_allocator_t *basl_runtime_allocator(const basl_runtime_t *runtime) {
     }
 
     return &runtime->allocator;
+}
+
+const basl_logger_t *basl_runtime_logger(const basl_runtime_t *runtime) {
+    if (runtime == NULL) {
+        return NULL;
+    }
+
+    return &runtime->logger;
+}
+
+basl_status_t basl_runtime_set_logger(
+    basl_runtime_t *runtime,
+    const basl_logger_t *logger,
+    basl_error_t *error
+) {
+    basl_logger_t resolved_logger;
+
+    basl_error_clear(error);
+
+    if (runtime == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "runtime must not be null");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    resolved_logger = basl_resolve_logger(logger);
+    if (!basl_logger_level_is_valid(resolved_logger.minimum_level)) {
+        basl_error_set_literal(
+            error,
+            BASL_STATUS_INVALID_ARGUMENT,
+            "logger minimum_level is invalid"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    runtime->logger = resolved_logger;
+    return BASL_STATUS_OK;
 }

--- a/tests/log_test.cpp
+++ b/tests/log_test.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include "basl/basl.h"
+}
+
+namespace {
+
+struct CaptureState {
+    int call_count;
+    basl_log_level_t level;
+    char message[128];
+    size_t field_count;
+    char field_key[64];
+    char field_value[128];
+};
+
+void CaptureHandler(void *user_data, const basl_log_record_t *record) {
+    CaptureState *state = static_cast<CaptureState *>(user_data);
+
+    state->call_count += 1;
+    state->level = record->level;
+    std::snprintf(state->message, sizeof(state->message), "%s", record->message);
+    state->field_count = record->field_count;
+    if (record->field_count != 0U) {
+        std::snprintf(state->field_key, sizeof(state->field_key), "%s", record->fields[0].key);
+        std::snprintf(
+            state->field_value,
+            sizeof(state->field_value),
+            "%s",
+            record->fields[0].value
+        );
+    }
+}
+
+}  // namespace
+
+TEST(BaslLogTest, LoggerInitSetsDefaultConfiguration) {
+    basl_logger_t logger = {};
+
+    basl_logger_init(&logger);
+
+    EXPECT_EQ(logger.minimum_level, BASL_LOG_INFO);
+    EXPECT_NE(logger.handler, nullptr);
+    EXPECT_EQ(logger.user_data, nullptr);
+}
+
+TEST(BaslLogTest, LoggerPassesStructuredRecordsToCustomHandler) {
+    CaptureState state = {};
+    basl_logger_t logger = {};
+    basl_log_field_t field = {"path", "/tmp/example.basl"};
+    basl_error_t error = {};
+
+    basl_logger_init(&logger);
+    logger.minimum_level = BASL_LOG_DEBUG;
+    logger.handler = CaptureHandler;
+    logger.user_data = &state;
+
+    EXPECT_EQ(
+        basl_logger_log(&logger, BASL_LOG_INFO, "compiled", &field, 1U, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(state.call_count, 1);
+    EXPECT_EQ(state.level, BASL_LOG_INFO);
+    EXPECT_STREQ(state.message, "compiled");
+    EXPECT_EQ(state.field_count, static_cast<size_t>(1));
+    EXPECT_STREQ(state.field_key, "path");
+    EXPECT_STREQ(state.field_value, "/tmp/example.basl");
+}
+
+TEST(BaslLogTest, LoggerFiltersMessagesBelowMinimumLevel) {
+    CaptureState state = {};
+    basl_logger_t logger = {};
+    basl_error_t error = {};
+
+    basl_logger_init(&logger);
+    logger.minimum_level = BASL_LOG_WARNING;
+    logger.handler = CaptureHandler;
+    logger.user_data = &state;
+
+    EXPECT_EQ(basl_logger_info(&logger, "skip me", &error), BASL_STATUS_OK);
+    EXPECT_EQ(state.call_count, 0);
+
+    EXPECT_EQ(basl_logger_error(&logger, "keep me", &error), BASL_STATUS_OK);
+    EXPECT_EQ(state.call_count, 1);
+    EXPECT_EQ(state.level, BASL_LOG_ERROR);
+    EXPECT_STREQ(state.message, "keep me");
+}
+
+TEST(BaslLogTest, RuntimeUsesConfiguredLogger) {
+    CaptureState state = {};
+    basl_logger_t logger = {};
+    basl_runtime_options_t options = {};
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+
+    basl_logger_init(&logger);
+    logger.minimum_level = BASL_LOG_DEBUG;
+    logger.handler = CaptureHandler;
+    logger.user_data = &state;
+    basl_runtime_options_init(&options);
+    options.logger = &logger;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, &options, &error), BASL_STATUS_OK);
+    ASSERT_NE(runtime, nullptr);
+    ASSERT_NE(basl_runtime_logger(runtime), nullptr);
+
+    EXPECT_EQ(
+        basl_logger_warning(basl_runtime_logger(runtime), "runtime logger", &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(state.call_count, 1);
+    EXPECT_EQ(state.level, BASL_LOG_WARNING);
+    EXPECT_STREQ(state.message, "runtime logger");
+
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslLogTest, RuntimeSetLoggerRejectsInvalidLevel) {
+    basl_runtime_t *runtime = nullptr;
+    basl_logger_t logger = {};
+    basl_error_t error = {};
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_logger_init(&logger);
+    logger.minimum_level = static_cast<basl_log_level_t>(999);
+
+    EXPECT_EQ(
+        basl_runtime_set_logger(runtime, &logger, &error),
+        BASL_STATUS_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(error.type, BASL_STATUS_INVALID_ARGUMENT);
+    ASSERT_NE(error.value, nullptr);
+    EXPECT_EQ(std::strcmp(error.value, "logger minimum_level is invalid"), 0);
+
+    basl_runtime_close(&runtime);
+}
+
+#if defined(__EMSCRIPTEN__)
+TEST(BaslLogTest, FatalIsSkippedOnEmscripten) {
+    GTEST_SKIP() << "fatal logging death tests are not supported on Emscripten";
+}
+#else
+TEST(BaslLogTest, FatalAlwaysTerminates) {
+    EXPECT_DEATH(
+        {
+            basl_logger_fatal(nullptr, "fatal test message", nullptr, 0U);
+        },
+        "fatal test message"
+    );
+}
+#endif

--- a/tests/runtime_test.cpp
+++ b/tests/runtime_test.cpp
@@ -127,11 +127,14 @@ TEST(BaslRuntimeTest, RuntimeUsesCustomAllocatorHooks) {
 TEST(BaslRuntimeTest, RuntimeOptionsInitClearsFields) {
     basl_runtime_options_t options = {};
     basl_allocator_t allocator = {};
+    basl_logger_t logger = {};
 
     options.allocator = &allocator;
+    options.logger = &logger;
     basl_runtime_options_init(&options);
 
     EXPECT_EQ(options.allocator, nullptr);
+    EXPECT_EQ(options.logger, nullptr);
 }
 
 TEST(BaslRuntimeTest, RuntimeRejectsIncompleteAllocator) {


### PR DESCRIPTION
## Summary
- add a small structured logging module with per-runtime logger ownership
- support default stderr logging, custom handlers, level filtering, and fatal termination
- wire the runtime and CLI to the shared logger surface and add logger coverage

## Verification
- cmake --build build --config Release
- ctest --test-dir build --output-on-failure -C Release