### PR TITLE
Fix nested generic type parsing (>>), add real-program integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 
 # Python
 __pycache__/
+/build-sanitize/

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -191,5 +191,351 @@ class SyntaxIntegrationTest(unittest.TestCase):
             self.assertEqual(result.stderr, "")
 
 
+class RealProgramPatternsTest(unittest.TestCase):
+    """Tests for patterns that arise in real programs."""
+
+    # -- error kind routing --
+
+    def test_error_kind_switch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn lookup(string key) -> (string, err) {
+                    if (key == "") {
+                        return ("", err("empty key", err.arg));
+                    }
+                    if (key == "missing") {
+                        return ("", err("not found", err.not_found));
+                    }
+                    return ("value_" + key, ok);
+                }
+
+                fn main() -> i32 {
+                    string v, err e = lookup("missing");
+                    if (e == ok) { return 1; }
+                    switch (e.kind()) {
+                        case err.not_found:
+                            return 10;
+                        case err.arg:
+                            return 20;
+                        default:
+                            return 30;
+                    }
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 10, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    # -- cross-module classes, interfaces, enums --
+
+    def test_cross_module_interface_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {
+                "types.basl": """
+                    pub enum Status {
+                        Active,
+                        Inactive
+                    }
+
+                    pub interface Describable {
+                        fn describe() -> string;
+                    }
+
+                    pub class User implements Describable {
+                        pub string name;
+                        pub Status status;
+
+                        fn init(string name, Status status) -> void {
+                            self.name = name;
+                            self.status = status;
+                        }
+
+                        fn describe() -> string {
+                            return f"User({self.name})";
+                        }
+                    }
+                """,
+                "main.basl": """
+                    import "types";
+
+                    fn print_desc(types.Describable d) -> string {
+                        return d.describe();
+                    }
+
+                    fn main() -> i32 {
+                        types.User u = types.User("alice", types.Status.Active);
+                        string desc = print_desc(u);
+                        if (desc == "User(alice)") {
+                            return 0;
+                        }
+                        return 1;
+                    }
+                """,
+            })
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    # -- nested generic types (>> token splitting) --
+
+    def test_nested_array_type(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    array<array<i32>> grid = [[1, 2], [3, 4], [5, 6]];
+                    i32 total = 0;
+                    for row in grid {
+                        for val in row {
+                            total += val;
+                        }
+                    }
+                    return total;
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 21, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_map_with_nested_array_value(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    map<string, array<i32>> data = {"a": [1, 2], "b": [3, 4]};
+                    array<i32> a_vals, bool found = data.get("a");
+                    if (!found) { return 1; }
+                    return a_vals[0] + a_vals[1];
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 3, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_triple_nested_array(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    array<array<array<i32>>> deep = [[[1, 2], [3]], [[4]]];
+                    return deep.len();
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 2, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    # -- nested control flow --
+
+    def test_guard_in_loop_with_continue(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn maybe(i32 x) -> (i32, err) {
+                    if (x == 2) {
+                        return (0, err("skip", err.arg));
+                    }
+                    return (x * 10, ok);
+                }
+
+                fn main() -> i32 {
+                    i32 total = 0;
+                    for (i32 i = 0; i < 5; i++) {
+                        guard i32 val, err e = maybe(i) {
+                            continue;
+                        }
+                        total += val;
+                    }
+                    return total;
+                }
+            """})
+            # i=0->0, i=1->10, i=2->skip, i=3->30, i=4->40 = 80
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 80, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_defer_with_break(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                i32 counter = 0;
+
+                fn bump() -> void {
+                    counter += 1;
+                }
+
+                fn work() -> i32 {
+                    defer bump();
+                    for (i32 i = 0; i < 10; i++) {
+                        if (i == 3) { break; }
+                    }
+                    return counter;
+                }
+
+                fn main() -> i32 {
+                    i32 result = work();
+                    return result + counter;
+                }
+            """})
+            # work() returns 0, defer runs -> counter=1, main returns 0+1=1
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_defer_guard_forin_combined(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                i32 cleanup_count = 0;
+
+                fn do_cleanup() -> void {
+                    cleanup_count += 1;
+                }
+
+                fn maybe_val(i32 x) -> (i32, err) {
+                    if (x < 0) {
+                        return (0, err("negative", err.arg));
+                    }
+                    return (x, ok);
+                }
+
+                fn process(array<i32> items) -> i32 {
+                    defer do_cleanup();
+                    i32 total = 0;
+                    for val in items {
+                        guard i32 v, err e = maybe_val(val) {
+                            continue;
+                        }
+                        total += v;
+                    }
+                    return total;
+                }
+
+                fn main() -> i32 {
+                    array<i32> data = [1, -2, 3, -4, 5];
+                    i32 result = process(data);
+                    if (cleanup_count != 1) { return 99; }
+                    return result;
+                }
+            """})
+            # 1+3+5=9, cleanup_count=1
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 9, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    # -- closures capturing loop variables --
+
+    def test_closure_captures_loop_variable(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    array<fn() -> i32> fns = [];
+                    for (i32 i = 0; i < 3; i++) {
+                        i32 captured = i;
+                        fn() -> i32 f = fn() -> i32 {
+                            return captured;
+                        };
+                        fns.push(f);
+                    }
+                    fn() -> i32 f0, err e0 = fns.get(0);
+                    fn() -> i32 f2, err e2 = fns.get(2);
+                    return f0() + f2();
+                }
+            """})
+            # f0()=0, f2()=2, total=2
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 2, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    # -- compound expressions --
+
+    def test_ternary_in_function_args(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn add(i32 a, i32 b) -> i32 {
+                    return a + b;
+                }
+
+                fn main() -> i32 {
+                    bool flag = true;
+                    return add(flag ? 10 : 20, flag ? 1 : 2);
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 11, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_chained_string_methods(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    string result = "  Hello World  ".trim().to_lower().replace("world", "basl");
+                    if (result == "hello basl") {
+                        return 0;
+                    }
+                    return 1;
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_map_compound_index_assignment(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    map<string, i32> m = {"a": 1, "b": 2};
+                    m["a"] += 10;
+                    m["b"] *= 3;
+                    return m["a"] + m["b"];
+                }
+            """})
+            # 1+10=11, 2*3=6, 11+6=17
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 17, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_nested_indexing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    array<array<i32>> grid = [];
+                    array<i32> row1 = [1, 2, 3];
+                    array<i32> row2 = [4, 5, 6];
+                    grid.push(row1);
+                    grid.push(row2);
+                    return grid[0][1] + grid[1][2];
+                }
+            """})
+            # grid[0][1]=2, grid[1][2]=6, 2+6=8
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 8, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+    def test_fstring_with_method_call(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="basl_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.basl": """
+                fn main() -> i32 {
+                    string name = "  alice  ";
+                    string msg = f"hello {name.trim()}!";
+                    if (msg == "hello alice!") {
+                        return 0;
+                    }
+                    return 1;
+                }
+            """})
+            result = run_basl(root, "main.basl")
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5063,6 +5063,38 @@ static basl_status_t basl_program_parse_type_name(
     return basl_compile_report(program, token->span, unsupported_message);
 }
 
+/* Track whether a '>>' token was split and the second '>' is pending. */
+static int basl_type_close_pending = 0;
+
+/* Consume a closing '>' in a generic type context.  When the lexer has
+   produced a '>>' (SHIFT_RIGHT) token, consume the whole token and set
+   a pending flag so the outer type parser's next close-check succeeds
+   without consuming another token. */
+static int basl_program_consume_type_close(
+    const basl_program_state_t *program,
+    size_t *cursor
+) {
+    const basl_token_t *t;
+    if (basl_type_close_pending) {
+        basl_type_close_pending = 0;
+        return 1;
+    }
+    t = basl_program_token_at(program, *cursor);
+    if (t == NULL) {
+        return 0;
+    }
+    if (t->kind == BASL_TOKEN_GREATER) {
+        *cursor += 1U;
+        return 1;
+    }
+    if (t->kind == BASL_TOKEN_SHIFT_RIGHT) {
+        *cursor += 1U;
+        basl_type_close_pending = 1;
+        return 1;
+    }
+    return 0;
+}
+
 static basl_status_t basl_program_parse_type_reference(
     const basl_program_state_t *program,
     size_t *cursor,
@@ -5288,15 +5320,14 @@ static basl_status_t basl_program_parse_type_reference(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        next_token = basl_program_token_at(program, *cursor);
-        if (next_token == NULL || next_token->kind != BASL_TOKEN_GREATER) {
+        if (!basl_program_consume_type_close(program, cursor)) {
+            next_token = basl_program_token_at(program, *cursor);
             return basl_compile_report(
                 program,
                 next_token == NULL ? token->span : next_token->span,
                 "expected '>' after array element type"
             );
         }
-        *cursor += 1U;
         return basl_program_intern_array_type((basl_program_state_t *)program, element_type, out_type);
     }
     if (
@@ -5341,15 +5372,14 @@ static basl_status_t basl_program_parse_type_reference(
         if (status != BASL_STATUS_OK) {
             return status;
         }
-        next_token = basl_program_token_at(program, *cursor);
-        if (next_token == NULL || next_token->kind != BASL_TOKEN_GREATER) {
+        if (!basl_program_consume_type_close(program, cursor)) {
+            next_token = basl_program_token_at(program, *cursor);
             return basl_compile_report(
                 program,
                 next_token == NULL ? token->span : next_token->span,
                 "expected '>' after map value type"
             );
         }
-        *cursor += 1U;
         return basl_program_intern_map_type((basl_program_state_t *)program, key_type, value_type, out_type);
     }
 
@@ -6168,10 +6198,9 @@ static int basl_program_skip_type_reference_syntax(
             }
             token = basl_program_token_at(program, *cursor);
         }
-        if (token == NULL || token->kind != BASL_TOKEN_GREATER) {
+        if (!basl_program_consume_type_close(program, cursor)) {
             return 0;
         }
-        *cursor += 1U;
     }
 
     return 1;
@@ -18484,11 +18513,9 @@ static int basl_parser_skip_type_reference_tokens(
         if (!basl_parser_skip_type_reference_tokens(program, cursor)) {
             return 0;
         }
-        token = basl_program_token_at(program, *cursor);
-        if (token == NULL || token->kind != BASL_TOKEN_GREATER) {
+        if (!basl_program_consume_type_close(program, cursor)) {
             return 0;
         }
-        *cursor += 1U;
         return 1;
     }
     if (
@@ -18508,11 +18535,9 @@ static int basl_parser_skip_type_reference_tokens(
         if (!basl_parser_skip_type_reference_tokens(program, cursor)) {
             return 0;
         }
-        token = basl_program_token_at(program, *cursor);
-        if (token == NULL || token->kind != BASL_TOKEN_GREATER) {
+        if (!basl_program_consume_type_close(program, cursor)) {
             return 0;
         }
-        *cursor += 1U;
         return 1;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a compiler bug and adds 14 new integration tests covering real-program patterns.

### Bug fix: nested generic types

Types like `array<array<i32>>` and `map<string, array<i32>>` failed to parse because the lexer tokenizes `>>` as a single `SHIFT_RIGHT` token. The type parser expected individual `>` tokens.

The fix adds `basl_program_consume_type_close()` which handles `>>` splitting using a pending-close flag:
- When the inner type parser needs a `>` and sees `>>`, it consumes the whole token and sets a pending flag
- When the outer type parser needs a `>`, it checks the pending flag first and succeeds without consuming another token
- The lookahead skip functions use the same mechanism
- Right-shift expressions (`x >> 2`) are unaffected

This enables:
```c
array<array<i32>> grid = [[1, 2], [3, 4]];
map<string, array<i32>> data = {"a": [1, 2]};
array<array<array<i32>>> deep = [[[1]]];
```

### Integration tests (4 → 18)

New `RealProgramPatternsTest` class covering patterns that arise in real programs:

| Category | Tests |
|---|---|
| Error kind routing | `switch(e.kind()) { case err.not_found: ... }` |
| Cross-module dispatch | Classes implementing imported interfaces with enums |
| Nested generics | `array<array<i32>>`, `map<string, array<i32>>`, triple nesting |
| Nested control flow | guard+continue in loops, defer+break, defer+guard+for-in |
| Closures | Capturing loop variables with correct per-iteration binding |
| Compound expressions | Ternary in args, chained methods, map compound index, nested indexing, f-string with methods |

### Verification

- All 216 ctest tests pass
- All 18 Python integration tests pass
- Right-shift operator verified still working