### PR TITLE
Fix use-after-free when local/anonymous functions coexist with interfaces

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -19355,6 +19355,12 @@ static basl_status_t basl_compile_function_with_parent(
         basl_parser_state_free(&state);
         return status;
     }
+
+    /* Re-fetch: the function table may have been reallocated while
+       parsing the body (e.g. local/anonymous function declarations
+       call basl_program_grow_functions). */
+    decl = &program->functions.functions[function_index];
+
     if (
         !body_result.guaranteed_return &&
         decl->return_count == 1U &&


### PR DESCRIPTION
## Problem

Any program combining interfaces (or imported modules with interfaces) and local/anonymous functions would crash with a segfault or fail with `function object name must not be null`.

Minimal reproducer:
```
interface Describable {
    fn describe() -> string;
}
class Circle implements Describable {
    pub string label;
    fn init(string label) -> void { self.label = label; }
    fn describe() -> string { return self.label; }
}
fn main() -> i32 {
    fn dbl(i32 x) -> i32 { return x * 2; }
    return dbl(1);
}
```

## Root Cause

`basl_compile_function_with_parent` caches a pointer to the function declaration (`decl`) before parsing the function body. When the body contains local or anonymous function declarations, `basl_program_grow_functions` may reallocate the function table, leaving `decl` dangling. The stale pointer is then used for return-type checking and object creation, reading freed memory.

Interfaces make this more likely because their methods are registered during declaration scanning, pushing the function table closer to its capacity threshold before compilation begins.

Confirmed with AddressSanitizer:
```
ERROR: AddressSanitizer: heap-use-after-free
  in basl_compile_require_function_returns compiler.c:19264
  ...
freed by:
  basl_program_grow_functions compiler.c:5165
  basl_parser_parse_nested_function_value compiler.c:13732
```

## Fix

One line: re-fetch `decl` from the (possibly reallocated) array after `basl_parser_parse_block_contents` returns.

## Testing

- All 217 existing tests pass
- All three crash variants now produce correct output
- Clean under AddressSanitizer (no heap-use-after-free)