### PR TITLE
Add native function infrastructure for stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(basl_core OBJECT
     src/lexer.c
     src/log.c
     src/map.c
+    src/native_module.c
     src/runtime.c
     src/source.c
     src/string.c

--- a/include/basl/basl.h
+++ b/include/basl/basl.h
@@ -10,6 +10,7 @@
 #include "basl/export.h"
 #include "basl/log.h"
 #include "basl/map.h"
+#include "basl/native_module.h"
 #include "basl/runtime.h"
 #include "basl/source.h"
 #include "basl/string.h"

--- a/include/basl/chunk.h
+++ b/include/basl/chunk.h
@@ -179,7 +179,8 @@ typedef enum basl_opcode {
        Format: [opcode][u32 local][i8 delta][u32 const_limit][u8 cmp][u32 back_offset]
        Increments local by delta, compares against constant limit using
        cmp (0=LT,1=LE,2=GT,3=GE,4=NE), jumps back if true. */
-    BASL_OPCODE_FORLOOP_I32 = 132
+    BASL_OPCODE_FORLOOP_I32 = 132,
+    BASL_OPCODE_CALL_NATIVE = 133
 } basl_opcode_t;
 
 typedef struct basl_chunk {

--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -1,0 +1,81 @@
+#ifndef BASL_NATIVE_MODULE_H
+#define BASL_NATIVE_MODULE_H
+
+#include <stddef.h>
+
+#include "basl/diagnostic.h"
+#include "basl/export.h"
+#include "basl/runtime.h"
+#include "basl/source.h"
+#include "basl/status.h"
+#include "basl/value.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Describes one function exported by a native module.
+ * The compiler uses name, param_types, param_count, and return_type
+ * for type checking.  The VM uses native_fn at runtime.
+ */
+typedef struct basl_native_module_function {
+    const char *name;
+    size_t name_length;
+    basl_native_fn_t native_fn;
+    size_t param_count;
+    const int *param_types;     /* basl_type_kind_t values */
+    int return_type;            /* basl_type_kind_t */
+    size_t return_count;        /* number of return values (1 or 2 for err) */
+    const int *return_types;    /* array of basl_type_kind_t, length = return_count */
+} basl_native_module_function_t;
+
+/**
+ * Describes a native module (e.g. "fmt", "math").
+ */
+typedef struct basl_native_module {
+    const char *name;
+    size_t name_length;
+    const basl_native_module_function_t *functions;
+    size_t function_count;
+} basl_native_module_t;
+
+/**
+ * Registry of native modules, shared between compiler and VM.
+ */
+typedef struct basl_native_registry {
+    const basl_native_module_t **modules;
+    size_t module_count;
+    size_t module_capacity;
+} basl_native_registry_t;
+
+BASL_API void basl_native_registry_init(basl_native_registry_t *registry);
+BASL_API void basl_native_registry_free(basl_native_registry_t *registry);
+BASL_API basl_status_t basl_native_registry_add(
+    basl_native_registry_t *registry,
+    const basl_native_module_t *module,
+    basl_error_t *error
+);
+BASL_API const basl_native_module_t *basl_native_registry_find(
+    const basl_native_registry_t *registry,
+    const char *name,
+    size_t name_length
+);
+
+/**
+ * Extended compile API that accepts a native module registry.
+ */
+BASL_API basl_status_t basl_compile_source_with_natives(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/basl/value.h
+++ b/include/basl/value.h
@@ -31,11 +31,13 @@ typedef enum basl_object_type {
     BASL_OBJECT_ERROR = 5,
     BASL_OBJECT_ARRAY = 6,
     BASL_OBJECT_MAP = 7,
-    BASL_OBJECT_BIGINT = 8
+    BASL_OBJECT_BIGINT = 8,
+    BASL_OBJECT_NATIVE_FUNCTION = 9
 } basl_object_type_t;
 
 typedef struct basl_object basl_object_t;
 typedef struct basl_chunk basl_chunk_t;
+typedef struct basl_vm basl_vm_t;
 
 /*
  * NaN-boxed value representation.  Every value is a single uint64_t.
@@ -267,6 +269,31 @@ BASL_API int basl_map_object_remove(
     const basl_value_t *key,
     basl_value_t *out_value,
     basl_error_t *error
+);
+
+/**
+ * Native function callback.  The implementation reads `arg_count`
+ * arguments from the top of the VM stack (bottom-up, first arg is
+ * deepest) and pushes its return value(s) before returning.
+ */
+typedef basl_status_t (*basl_native_fn_t)(
+    basl_vm_t *vm,
+    size_t arg_count,
+    basl_error_t *error
+);
+
+BASL_API basl_status_t basl_native_function_object_create(
+    basl_runtime_t *runtime,
+    const char *name,
+    size_t name_length,
+    size_t arity,
+    basl_native_fn_t function,
+    basl_object_t **out_object,
+    basl_error_t *error
+);
+
+BASL_API basl_native_fn_t basl_native_function_get(
+    const basl_object_t *object
 );
 
 #ifdef __cplusplus

--- a/include/basl/vm.h
+++ b/include/basl/vm.h
@@ -47,6 +47,12 @@ BASL_API basl_status_t basl_vm_execute_function(
     basl_error_t *error
 );
 
+/* Stack access for native function implementations. */
+BASL_API basl_value_t basl_vm_stack_get(const basl_vm_t *vm, size_t index);
+BASL_API basl_status_t basl_vm_stack_push(
+    basl_vm_t *vm, const basl_value_t *value, basl_error_t *error);
+BASL_API void basl_vm_stack_pop_n(basl_vm_t *vm, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/checker.c
+++ b/src/checker.c
@@ -13,6 +13,7 @@ basl_status_t basl_check_source(
         source_id,
         BASL_COMPILE_MODE_CHECK_ONLY,
         NULL,
+        NULL,
         diagnostics,
         error
     );

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -675,6 +675,7 @@ const char *basl_opcode_name(basl_opcode_t opcode) {
         case BASL_OPCODE_INCREMENT_LOCAL_I32: return "INCREMENT_LOCAL_I32";
         case BASL_OPCODE_TAIL_CALL: return "TAIL_CALL";
         case BASL_OPCODE_FORLOOP_I32: return "FORLOOP_I32";
+        case BASL_OPCODE_CALL_NATIVE: return "CALL_NATIVE";
         default:
             return "UNKNOWN";
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -6,6 +6,7 @@
 
 #include "basl/chunk.h"
 #include "basl/lexer.h"
+#include "basl/native_module.h"
 #include "basl/string.h"
 #include "basl/token.h"
 #include "basl/type.h"
@@ -14487,6 +14488,7 @@ basl_status_t basl_compile_source_internal(
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
     basl_compile_mode_t mode,
+    const basl_native_registry_t *natives,
     basl_object_t **out_function,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
@@ -14525,6 +14527,7 @@ basl_status_t basl_compile_source_internal(
     program.registry = registry;
     program.diagnostics = diagnostics;
     program.error = error;
+    program.natives = natives;
     basl_binding_function_table_init(&program.functions, registry->runtime);
     basl_program_set_module_context(&program, source, NULL);
 
@@ -14574,6 +14577,26 @@ basl_status_t basl_compile_source(
         registry,
         source_id,
         BASL_COMPILE_MODE_BUILD_ENTRYPOINT,
+        NULL,
+        out_function,
+        diagnostics,
+        error
+    );
+}
+
+basl_status_t basl_compile_source_with_natives(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    return basl_compile_source_internal(
+        registry,
+        source_id,
+        BASL_COMPILE_MODE_BUILD_ENTRYPOINT,
+        natives,
         out_function,
         diagnostics,
         error

--- a/src/internal/basl_compiler_internal.h
+++ b/src/internal/basl_compiler_internal.h
@@ -2,6 +2,7 @@
 #define BASL_COMPILER_INTERNAL_H
 
 #include "basl/compiler.h"
+#include "basl/native_module.h"
 
 typedef enum basl_compile_mode {
     BASL_COMPILE_MODE_CHECK_ONLY = 0,
@@ -12,6 +13,7 @@ basl_status_t basl_compile_source_internal(
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
     basl_compile_mode_t mode,
+    const basl_native_registry_t *natives,
     basl_object_t **out_function,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error

--- a/src/internal/basl_compiler_types.h
+++ b/src/internal/basl_compiler_types.h
@@ -211,6 +211,7 @@ typedef struct basl_program_state {
     basl_global_variable_t *globals;
     size_t global_count;
     size_t global_capacity;
+    const struct basl_native_registry *natives;
 } basl_program_state_t;
 
 typedef struct basl_parser_state {

--- a/src/native_module.c
+++ b/src/native_module.c
@@ -1,0 +1,67 @@
+#include "basl/native_module.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void basl_native_registry_init(basl_native_registry_t *registry) {
+    if (registry == NULL) {
+        return;
+    }
+    memset(registry, 0, sizeof(*registry));
+}
+
+void basl_native_registry_free(basl_native_registry_t *registry) {
+    if (registry == NULL) {
+        return;
+    }
+    free(registry->modules);
+    memset(registry, 0, sizeof(*registry));
+}
+
+basl_status_t basl_native_registry_add(
+    basl_native_registry_t *registry,
+    const basl_native_module_t *module,
+    basl_error_t *error
+) {
+    (void)error;
+    if (registry == NULL || module == NULL) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    if (registry->module_count >= registry->module_capacity) {
+        size_t new_cap;
+        const basl_native_module_t **new_buf;
+
+        new_cap = registry->module_capacity < 8U ? 8U : registry->module_capacity * 2U;
+        new_buf = (const basl_native_module_t **)realloc(
+            registry->modules,
+            new_cap * sizeof(*new_buf)
+        );
+        if (new_buf == NULL) {
+            return BASL_STATUS_OUT_OF_MEMORY;
+        }
+        registry->modules = new_buf;
+        registry->module_capacity = new_cap;
+    }
+    registry->modules[registry->module_count] = module;
+    registry->module_count += 1U;
+    return BASL_STATUS_OK;
+}
+
+const basl_native_module_t *basl_native_registry_find(
+    const basl_native_registry_t *registry,
+    const char *name,
+    size_t name_length
+) {
+    size_t i;
+
+    if (registry == NULL || name == NULL) {
+        return NULL;
+    }
+    for (i = 0U; i < registry->module_count; i++) {
+        if (registry->modules[i]->name_length == name_length &&
+            memcmp(registry->modules[i]->name, name, name_length) == 0) {
+            return registry->modules[i];
+        }
+    }
+    return NULL;
+}

--- a/src/value.c
+++ b/src/value.c
@@ -93,6 +93,13 @@ typedef struct basl_bigint_object {
     } as;
 } basl_bigint_object_t;
 
+typedef struct basl_native_function_object {
+    basl_object_t base;
+    basl_string_t name;
+    size_t arity;
+    basl_native_fn_t function;
+} basl_native_function_object_t;
+
 static const basl_string_object_t *basl_string_object_cast(
     const basl_object_t *object
 ) {
@@ -286,6 +293,11 @@ static void basl_object_destroy(basl_object_t *object) {
             basl_map_free(&((basl_map_object_t *)object)->entries);
             break;
         case BASL_OBJECT_BIGINT:
+            break;
+        case BASL_OBJECT_NATIVE_FUNCTION:
+            basl_string_free(
+                &((basl_native_function_object_t *)object)->name
+            );
             break;
         case BASL_OBJECT_INVALID:
         default:
@@ -2154,4 +2166,55 @@ const basl_chunk_t *basl_callable_object_chunk(const basl_object_t *callable) {
     const basl_object_t *function = basl_callable_object_function(callable);
 
     return basl_function_object_chunk(function);
+}
+
+basl_status_t basl_native_function_object_create(
+    basl_runtime_t *runtime,
+    const char *name,
+    size_t name_length,
+    size_t arity,
+    basl_native_fn_t function,
+    basl_object_t **out_object,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_native_function_object_t *obj;
+    void *memory;
+
+    if (out_object == NULL || function == NULL) {
+        basl_error_set_literal(
+            error, BASL_STATUS_INVALID_ARGUMENT,
+            "native function arguments must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    *out_object = NULL;
+    memory = NULL;
+    status = basl_runtime_alloc(runtime, sizeof(*obj), &memory, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    obj = (basl_native_function_object_t *)memory;
+    memset(obj, 0, sizeof(*obj));
+    obj->base.runtime = runtime;
+    obj->base.type = BASL_OBJECT_NATIVE_FUNCTION;
+    obj->base.ref_count = 1U;
+    basl_string_init(&obj->name, runtime);
+    if (name != NULL && name_length > 0U) {
+        basl_string_assign(&obj->name, name, name_length, error);
+    }
+    obj->arity = arity;
+    obj->function = function;
+    *out_object = &obj->base;
+    return BASL_STATUS_OK;
+}
+
+basl_native_fn_t basl_native_function_get(const basl_object_t *object) {
+    const basl_native_function_object_t *native;
+
+    if (object == NULL || object->type != BASL_OBJECT_NATIVE_FUNCTION) {
+        return NULL;
+    }
+    native = (const basl_native_function_object_t *)object;
+    return native->function;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -2549,6 +2549,45 @@ size_t basl_vm_frame_depth(const basl_vm_t *vm) {
     return vm->frame_count;
 }
 
+basl_value_t basl_vm_stack_get(const basl_vm_t *vm, size_t index) {
+    if (vm == NULL || index >= vm->stack_count) {
+        basl_value_t nil;
+        basl_value_init_nil(&nil);
+        return nil;
+    }
+    return vm->stack[index];
+}
+
+basl_status_t basl_vm_stack_push(
+    basl_vm_t *vm,
+    const basl_value_t *value,
+    basl_error_t *error
+) {
+    if (vm == NULL || value == NULL) {
+        basl_error_set_literal(
+            error, BASL_STATUS_INVALID_ARGUMENT,
+            "vm and value must not be null"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    return basl_vm_push(vm, value, error);
+}
+
+void basl_vm_stack_pop_n(basl_vm_t *vm, size_t count) {
+    size_t i;
+
+    if (vm == NULL || count == 0U) {
+        return;
+    }
+    if (count > vm->stack_count) {
+        count = vm->stack_count;
+    }
+    for (i = 0U; i < count; i++) {
+        vm->stack_count -= 1U;
+        BASL_VM_VALUE_RELEASE(&vm->stack[vm->stack_count]);
+    }
+}
+
 basl_status_t basl_vm_execute(
     basl_vm_t *vm,
     const basl_chunk_t *chunk,
@@ -2782,6 +2821,7 @@ basl_status_t basl_vm_execute_function(
             [BASL_OPCODE_INCREMENT_LOCAL_I32] = &&op_INCREMENT_LOCAL_I32,
             [BASL_OPCODE_TAIL_CALL] = &&op_TAIL_CALL,
             [BASL_OPCODE_FORLOOP_I32] = &&op_FORLOOP_I32,
+            [BASL_OPCODE_CALL_NATIVE] = &&op_CALL_NATIVE,
             [BASL_OPCODE_MODULO] = &&op_MODULO,
             [BASL_OPCODE_MULTIPLY] = &&op_MULTIPLY,
             [BASL_OPCODE_NEGATE] = &&op_NEGATE,
@@ -3331,6 +3371,32 @@ basl_status_t basl_vm_execute_function(
                     goto cleanup;
                 }
                 VM_BREAK_RELOAD();
+            VM_CASE(CALL_NATIVE) {
+                uint32_t native_arg_count;
+                const basl_value_t *native_val;
+                basl_object_t *native_obj;
+                basl_native_fn_t native_fn;
+
+                BASL_VM_READ_U32(code, frame->ip, constant_index);
+                BASL_VM_READ_RAW_U32(code, frame->ip, native_arg_count);
+
+                native_val = BASL_VM_CHUNK_CONSTANT(
+                    frame->chunk, (size_t)constant_index);
+                native_obj = (basl_object_t *)basl_nanbox_decode_ptr(
+                    *native_val);
+                native_fn = basl_native_function_get(native_obj);
+                if (native_fn == NULL) {
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INTERNAL,
+                        "call target is not a native function", error);
+                    goto cleanup;
+                }
+                status = native_fn(vm, (size_t)native_arg_count, error);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
             VM_CASE(CALL_INTERFACE) {
                 size_t interface_index;
                 size_t method_index;


### PR DESCRIPTION
Prerequisites for standard library implementation.

## What's added

**Native function object type** — `BASL_OBJECT_NATIVE_FUNCTION` wraps a C function pointer (`basl_native_fn_t`) that the VM can call. Includes create/get API and proper lifecycle management.

**CALL_NATIVE opcode** — reads a native function from the constant pool and invokes its callback. Native functions interact with the VM stack through new public API: `basl_vm_stack_get`, `basl_vm_stack_push`, `basl_vm_stack_pop_n`.

**Native module registry** — `basl_native_registry_t` lets the host register modules (e.g. `fmt`, `math`) with typed function declarations. The compiler can resolve `import "fmt"` against this registry instead of requiring a `.basl` file.

**Compiler integration** — `basl_compile_source_with_natives()` threads the registry into compilation. Existing `basl_compile_source()` passes NULL (no behavior change).

## What's NOT yet wired

The compiler does not yet emit `CALL_NATIVE` — the import resolution path in `parse_qualified_symbol` still only checks the source registry. That wiring comes when the first stdlib module (`fmt`) is implemented, since it needs end-to-end testing.

## Testing

- 217/217 unit tests pass
- ASAN clean
- Portability check clean (53 core files, all pure C11)