### PR TITLE
Implement fmt stdlib module — end-to-end native function pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,15 +63,18 @@ target_compile_features(basl_core PUBLIC c_std_11)
 set_target_properties(basl_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # ── Public shared/static library ────────────────────────────────────
-# Today this is just the core.  Future stdlib modules will be added
-# here (or as a basl_stdlib OBJECT library linked alongside).
+# Today this is the core plus stdlib modules.  Stdlib modules may use
+# platform-specific headers; the core (basl_core) stays pure C11.
 add_library(basl ${BASL_LIBRARY_TYPE}
     $<TARGET_OBJECTS:basl_core>
+    src/stdlib/fmt.c
 )
 
 target_include_directories(basl
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 target_compile_features(basl PUBLIC c_std_11)

--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -61,6 +61,18 @@ BASL_API const basl_native_module_t *basl_native_registry_find(
     const char *name,
     size_t name_length
 );
+BASL_API int basl_native_registry_find_index(
+    const basl_native_registry_t *registry,
+    const char *name,
+    size_t name_length,
+    size_t *out_index
+);
+
+/* Synthetic source IDs for native modules: 0xFFFF0000 + index. */
+#define BASL_NATIVE_SOURCE_ID_BASE ((basl_source_id_t)0xFFFF0000U)
+#define BASL_NATIVE_SOURCE_ID(idx) (BASL_NATIVE_SOURCE_ID_BASE + (basl_source_id_t)(idx))
+#define BASL_IS_NATIVE_SOURCE_ID(id) ((id) >= BASL_NATIVE_SOURCE_ID_BASE)
+#define BASL_NATIVE_SOURCE_INDEX(id) ((size_t)((id) - BASL_NATIVE_SOURCE_ID_BASE))
 
 /**
  * Extended compile API that accepts a native module registry.

--- a/include/basl/stdlib.h
+++ b/include/basl/stdlib.h
@@ -1,0 +1,35 @@
+#ifndef BASL_STDLIB_H
+#define BASL_STDLIB_H
+
+#include <string.h>
+
+#include "basl/native_module.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Each stdlib module exports a const descriptor. */
+extern BASL_API const basl_native_module_t basl_stdlib_fmt;
+
+/* Register all built-in stdlib modules into a native registry. */
+static inline basl_status_t basl_stdlib_register_all(
+    basl_native_registry_t *registry,
+    basl_error_t *error
+) {
+    return basl_native_registry_add(registry, &basl_stdlib_fmt, error);
+}
+
+/* Check if an import name is a native stdlib module. */
+static inline int basl_stdlib_is_native_module(
+    const char *name,
+    size_t name_length
+) {
+    return name_length == 3U && memcmp(name, "fmt", 3U) == 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/scripts/check_core_portability.py
+++ b/scripts/check_core_portability.py
@@ -61,7 +61,7 @@ def main() -> int:
     core_dirs = [root / "src", root / "include" / "basl"]
     core_globs = ["*.c", "*.h"]
     # Exclude the CLI — it's allowed to have platform code.
-    exclude = {root / "src" / "cli"}
+    exclude = {root / "src" / "cli", root / "src" / "stdlib"}
 
     errors: list[str] = []
     for d in core_dirs:

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "basl/basl.h"
+#include "basl/stdlib.h"
 
 typedef enum basl_cli_mode {
     BASL_CLI_MODE_RUN = 0,
@@ -463,6 +464,13 @@ static int basl_register_source_tree(
                 break;
             }
 
+            /* Skip native stdlib modules — they don't have .basl files. */
+            if (basl_stdlib_is_native_module(
+                    import_text + 1U, import_length - 2U)) {
+                cursor += 1U;
+                continue;
+            }
+
             basl_string_init(&import_path, runtime);
             if (
                 basl_resolve_import_path(
@@ -538,7 +546,17 @@ static int basl_run_script(
     basl_status_t status;
 
     function = NULL;
-    status = basl_compile_source(registry, source_id, &function, diagnostics, error);
+    {
+        basl_native_registry_t natives;
+
+        basl_native_registry_init(&natives);
+        basl_stdlib_register_all(&natives, error);
+        status = basl_compile_source_with_natives(
+            registry, source_id, &natives,
+            &function, diagnostics, error
+        );
+        basl_native_registry_free(&natives);
+    }
     if (status != BASL_STATUS_OK) {
         if (basl_diagnostic_list_count(diagnostics) != 0U) {
             basl_object_release(&function);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2419,12 +2419,16 @@ static basl_status_t basl_program_parse_import(
     basl_string_t import_path;
     basl_source_id_t imported_source_id;
     basl_program_module_t *module;
+    size_t native_idx;
+    int native_found;
 
     alias_token = NULL;
     alias_text = NULL;
     alias_length = 0U;
     imported_source_id = 0U;
     module = NULL;
+    native_idx = 0U;
+    native_found = 0;
     basl_string_init(&import_path, program->registry->runtime);
 
     token = basl_program_token_at(program, *cursor);
@@ -2439,6 +2443,30 @@ static basl_status_t basl_program_parse_import(
     *cursor += 1U;
 
     token = basl_program_token_at(program, *cursor);
+    {
+        const char *raw_import;
+        size_t raw_import_len;
+
+        raw_import = basl_program_token_text(program, token, &raw_import_len);
+        /* Strip quotes from the string literal. */
+        if (raw_import != NULL && raw_import_len >= 2U) {
+            raw_import += 1U;
+            raw_import_len -= 2U;
+        }
+        /* Check native module registry first — skip file resolution. */
+        if (
+            program->natives != NULL &&
+            raw_import != NULL &&
+            basl_native_registry_find_index(
+                program->natives,
+                raw_import, raw_import_len,
+                &native_idx
+            )
+        ) {
+            native_found = 1;
+            imported_source_id = BASL_NATIVE_SOURCE_ID(native_idx);
+        }
+    }
     status = basl_program_parse_import_target(program, token, &import_path);
     if (status != BASL_STATUS_OK) {
         basl_string_free(&import_path);
@@ -2474,6 +2502,7 @@ static basl_status_t basl_program_parse_import(
     *cursor += 1U;
 
     if (
+        !native_found &&
         !basl_program_find_source_by_path(
             program,
             basl_string_c_str(&import_path),
@@ -2500,12 +2529,17 @@ static basl_status_t basl_program_parse_import(
         return BASL_STATUS_INTERNAL;
     }
     if (alias_text == NULL) {
-        basl_program_import_default_alias(
-            basl_string_c_str(&import_path),
-            basl_string_length(&import_path),
-            &alias_text,
-            &alias_length
-        );
+        if (native_found) {
+            alias_text = program->natives->modules[native_idx]->name;
+            alias_length = program->natives->modules[native_idx]->name_length;
+        } else {
+            basl_program_import_default_alias(
+                basl_string_c_str(&import_path),
+                basl_string_length(&import_path),
+                &alias_text,
+                &alias_length
+            );
+        }
     }
     status = basl_program_add_module_import(
         program,
@@ -2520,7 +2554,9 @@ static basl_status_t basl_program_parse_import(
         return status;
     }
 
-    status = basl_program_parse_source(program, imported_source_id);
+    if (!native_found) {
+        status = basl_program_parse_source(program, imported_source_id);
+    }
     basl_string_free(&import_path);
     return status;
 }
@@ -7361,6 +7397,160 @@ static basl_status_t basl_parser_parse_constructor_resolved(
     return BASL_STATUS_OK;
 }
 
+static basl_status_t basl_parser_parse_native_call(
+    basl_parser_state_t *state,
+    const basl_token_t *member_token,
+    basl_source_id_t source_id,
+    const char *member_name,
+    size_t member_name_length,
+    basl_expression_result_t *out_result
+) {
+    basl_status_t status;
+    basl_expression_result_t arg_result;
+    const basl_native_module_t *mod;
+    const basl_native_module_function_t *fn;
+    size_t mod_idx;
+    size_t i;
+    size_t arg_count;
+    basl_object_t *native_obj;
+    basl_value_t native_val;
+
+    mod_idx = BASL_NATIVE_SOURCE_INDEX(source_id);
+    if (mod_idx >= state->program->natives->module_count) {
+        return basl_parser_report(state, member_token->span, "unknown native module");
+    }
+    mod = state->program->natives->modules[mod_idx];
+
+    /* Find the function in the native module. */
+    fn = NULL;
+    for (i = 0U; i < mod->function_count; i++) {
+        if (mod->functions[i].name_length == member_name_length &&
+            memcmp(mod->functions[i].name, member_name, member_name_length) == 0) {
+            fn = &mod->functions[i];
+            break;
+        }
+    }
+    if (fn == NULL) {
+        return basl_parser_report(state, member_token->span, "unknown function");
+    }
+
+    /* Parse arguments. */
+    basl_expression_result_clear(&arg_result);
+    status = basl_parser_expect(
+        state, BASL_TOKEN_LPAREN, "expected '(' after function name", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    arg_count = 0U;
+    if (!basl_parser_check(state, BASL_TOKEN_RPAREN)) {
+        while (1) {
+            status = basl_parser_parse_expression(state, &arg_result);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            status = basl_parser_require_scalar_expression(
+                state, member_token->span, &arg_result,
+                "call arguments must be single values"
+            );
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            if (arg_count < fn->param_count) {
+                status = basl_parser_require_type(
+                    state, member_token->span, arg_result.type,
+                    basl_binding_type_primitive(
+                        (basl_type_kind_t)fn->param_types[arg_count]),
+                    "call argument type does not match parameter type"
+                );
+                if (status != BASL_STATUS_OK) {
+                    return status;
+                }
+            }
+            arg_count += 1U;
+            if (!basl_parser_match(state, BASL_TOKEN_COMMA)) {
+                break;
+            }
+        }
+    }
+    status = basl_parser_expect(
+        state, BASL_TOKEN_RPAREN, "expected ')' after argument list", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    if (arg_count != fn->param_count) {
+        return basl_parser_report(
+            state, member_token->span,
+            "call argument count does not match function signature"
+        );
+    }
+
+    /* Create native function object and store in constant pool. */
+    native_obj = NULL;
+    status = basl_native_function_object_create(
+        state->program->registry->runtime,
+        fn->name, fn->name_length,
+        fn->param_count, fn->native_fn,
+        &native_obj, state->program->error
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    basl_value_init_object(&native_val, &native_obj);
+    {
+        size_t const_idx;
+
+        const_idx = 0U;
+        status = basl_chunk_add_constant(
+            &state->chunk, &native_val, &const_idx,
+            state->program->error
+        );
+        basl_value_release(&native_val);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_opcode(
+            state, BASL_OPCODE_CALL_NATIVE, member_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)const_idx, member_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)arg_count, member_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    }
+
+    /* Set return type. */
+    if (fn->return_count <= 1U) {
+        basl_expression_result_set_type(
+            out_result,
+            basl_binding_type_primitive((basl_type_kind_t)fn->return_type)
+        );
+    } else {
+        /* Multi-return: build return_types array on the stack. */
+        basl_parser_type_t ret_types[2];
+        size_t rc;
+
+        rc = fn->return_count > 2U ? 2U : fn->return_count;
+        for (i = 0U; i < rc; i++) {
+            ret_types[i] = basl_binding_type_primitive(
+                (basl_type_kind_t)fn->return_types[i]);
+        }
+        basl_expression_result_set_return_types(
+            out_result,
+            ret_types[0],
+            ret_types,
+            rc
+        );
+    }
+    return BASL_STATUS_OK;
+}
+
 static basl_status_t basl_parser_parse_qualified_symbol(
     basl_parser_state_t *state,
     const basl_token_t *module_token,
@@ -7479,6 +7669,13 @@ static basl_status_t basl_parser_parse_qualified_symbol(
     }
 
     if (basl_parser_check(state, BASL_TOKEN_LPAREN)) {
+        /* Native module function call. */
+        if (BASL_IS_NATIVE_SOURCE_ID(source_id) && state->program->natives != NULL) {
+            return basl_parser_parse_native_call(
+                state, member_token, source_id, member_name,
+                member_name_length, out_result
+            );
+        }
         if (
             basl_program_find_top_level_function_name_in_source(
                 state->program,

--- a/src/native_module.c
+++ b/src/native_module.c
@@ -65,3 +65,24 @@ const basl_native_module_t *basl_native_registry_find(
     }
     return NULL;
 }
+
+int basl_native_registry_find_index(
+    const basl_native_registry_t *registry,
+    const char *name,
+    size_t name_length,
+    size_t *out_index
+) {
+    size_t i;
+
+    if (registry == NULL || name == NULL || out_index == NULL) {
+        return 0;
+    }
+    for (i = 0U; i < registry->module_count; i++) {
+        if (registry->modules[i]->name_length == name_length &&
+            memcmp(registry->modules[i]->name, name, name_length) == 0) {
+            *out_index = i;
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/stdlib/fmt.c
+++ b/src/stdlib/fmt.c
@@ -1,0 +1,137 @@
+/* BASL standard library: fmt module.
+ *
+ * Platform-specific stdlib modules live in src/stdlib/.  They may use
+ * any system headers needed for their platform.  The core interpreter
+ * in src/ never includes these files.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "basl/native_module.h"
+#include "basl/type.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+
+#include "internal/basl_nanbox.h"
+
+/* ── helpers ─────────────────────────────────────────────────────── */
+
+static void basl_fmt_print_value(FILE *stream, basl_value_t v) {
+    if (basl_nanbox_is_int(v)) {
+        fprintf(stream, "%lld", (long long)basl_nanbox_decode_int(v));
+    } else if (basl_nanbox_is_double(v)) {
+        fprintf(stream, "%g", basl_nanbox_decode_double(v));
+    } else if (basl_nanbox_is_bool(v)) {
+        fprintf(stream, "%s", basl_nanbox_decode_bool(v) ? "true" : "false");
+    } else if (basl_nanbox_is_nil(v)) {
+        fprintf(stream, "nil");
+    } else if (basl_nanbox_is_object(v)) {
+        const basl_object_t *obj =
+            (const basl_object_t *)basl_nanbox_decode_ptr(v);
+        if (obj != NULL && basl_object_type(obj) == BASL_OBJECT_STRING) {
+            const char *text = basl_string_object_c_str(obj);
+            size_t len = basl_string_object_length(obj);
+
+            if (text != NULL) {
+                fwrite(text, 1U, len, stream);
+                return;
+            }
+        }
+        fprintf(stream, "<object>");
+    }
+}
+
+/* ── native callbacks ────────────────────────────────────────────── */
+
+static basl_status_t basl_fmt_println(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base;
+    size_t i;
+
+    (void)error;
+    base = basl_vm_stack_depth(vm) - arg_count;
+    for (i = 0U; i < arg_count; i++) {
+        if (i > 0U) {
+            fputc(' ', stdout);
+        }
+        basl_fmt_print_value(stdout, basl_vm_stack_get(vm, base + i));
+    }
+    fputc('\n', stdout);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t basl_fmt_print(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base;
+    size_t i;
+
+    (void)error;
+    base = basl_vm_stack_depth(vm) - arg_count;
+    for (i = 0U; i < arg_count; i++) {
+        if (i > 0U) {
+            fputc(' ', stdout);
+        }
+        basl_fmt_print_value(stdout, basl_vm_stack_get(vm, base + i));
+    }
+    fflush(stdout);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t basl_fmt_eprintln(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base;
+    size_t i;
+
+    (void)error;
+    base = basl_vm_stack_depth(vm) - arg_count;
+    for (i = 0U; i < arg_count; i++) {
+        if (i > 0U) {
+            fputc(' ', stderr);
+        }
+        basl_fmt_print_value(stderr, basl_vm_stack_get(vm, base + i));
+    }
+    fputc('\n', stderr);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return BASL_STATUS_OK;
+}
+
+/* ── module descriptor ───────────────────────────────────────────── */
+
+static const int basl_fmt_println_params[] = { BASL_TYPE_STRING };
+static const int basl_fmt_print_params[] = { BASL_TYPE_STRING };
+static const int basl_fmt_eprintln_params[] = { BASL_TYPE_STRING };
+
+static const basl_native_module_function_t basl_fmt_functions[] = {
+    {
+        "println", 7U,
+        basl_fmt_println,
+        1U, basl_fmt_println_params,
+        BASL_TYPE_VOID, 0U, NULL
+    },
+    {
+        "print", 5U,
+        basl_fmt_print,
+        1U, basl_fmt_print_params,
+        BASL_TYPE_VOID, 0U, NULL
+    },
+    {
+        "eprintln", 8U,
+        basl_fmt_eprintln,
+        1U, basl_fmt_eprintln_params,
+        BASL_TYPE_VOID, 0U, NULL
+    },
+};
+
+#define BASL_FMT_FUNCTION_COUNT \
+    (sizeof(basl_fmt_functions) / sizeof(basl_fmt_functions[0]))
+
+BASL_API const basl_native_module_t basl_stdlib_fmt = {
+    "fmt", 3U,
+    basl_fmt_functions,
+    BASL_FMT_FUNCTION_COUNT
+};


### PR DESCRIPTION
First standard library module. Proves the entire native function pipeline end-to-end.

## What works

```c
import "fmt";

fn main() -> i32 {
    fmt.println("hello, world!");
    fmt.print("no newline");
    fmt.eprintln("to stderr");
    return 0;
}
```

## Architecture

```
src/stdlib/fmt.c          ← platform layer (may use <stdio.h>)
include/basl/stdlib.h     ← module registry (inline, C11)
src/compiler.c            ← import resolution + CALL_NATIVE emission (core)
src/vm.c                  ← CALL_NATIVE handler (core)
```

The pipeline: `import "fmt"` → native registry lookup → synthetic source ID → `fmt.println(...)` → type-check args → create native function object in constant pool → emit `CALL_NATIVE` → VM invokes C callback → callback reads args from stack via public API.

## Onboarding new stdlib modules

Adding a new module (e.g. `math`) requires:
1. Create `src/stdlib/math.c` with native callbacks and a `basl_native_module_t` descriptor
2. Add `extern` declaration to `include/basl/stdlib.h`
3. Add to `basl_stdlib_register_all()` and `basl_stdlib_is_native_module()`
4. Add the .c file to `CMakeLists.txt` in the `basl` library target

Platform-specific modules use whatever system headers they need. The core interpreter never sees them. The portability check enforces this boundary.

## Testing
- 217/217 unit tests pass
- ASAN clean
- Portability check clean (54 core files)
- Manual tests: println, print, eprintln, f-strings, loops, variables