### PR TITLE
Add math stdlib module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set_target_properties(basl_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(basl ${BASL_LIBRARY_TYPE}
     $<TARGET_OBJECTS:basl_core>
     src/stdlib/fmt.c
+    src/stdlib/math.c
 )
 
 target_include_directories(basl
@@ -85,6 +86,13 @@ if(NOT EMSCRIPTEN)
         PRIVATE BASL_EXPORTS
     )
     target_compile_definitions(basl_core PRIVATE BASL_EXPORTS BASL_SHARED)
+endif()
+
+# Link libm where needed (Linux/glibc; MSVC/macOS/Emscripten have it built-in).
+include(CheckLibraryExists)
+check_library_exists(m floor "" BASL_NEEDS_LIBM)
+if(BASL_NEEDS_LIBM)
+    target_link_libraries(basl PRIVATE m)
 endif()
 
 # On MSVC multi-config generators, an OBJECT-library-backed shared
@@ -138,6 +146,7 @@ if(BASL_BUILD_TESTS)
         tests/map_test.cpp
         tests/runtime_test.cpp
         tests/source_test.cpp
+        tests/stdlib_test.cpp
         tests/string_test.cpp
         tests/status_test.cpp
         tests/symbol_test.cpp

--- a/include/basl/stdlib.h
+++ b/include/basl/stdlib.h
@@ -11,13 +11,19 @@ extern "C" {
 
 /* Each stdlib module exports a const descriptor. */
 extern BASL_API const basl_native_module_t basl_stdlib_fmt;
+extern BASL_API const basl_native_module_t basl_stdlib_math;
 
 /* Register all built-in stdlib modules into a native registry. */
 static inline basl_status_t basl_stdlib_register_all(
     basl_native_registry_t *registry,
     basl_error_t *error
 ) {
-    return basl_native_registry_add(registry, &basl_stdlib_fmt, error);
+    basl_status_t status;
+    status = basl_native_registry_add(registry, &basl_stdlib_fmt, error);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    return basl_native_registry_add(registry, &basl_stdlib_math, error);
 }
 
 /* Check if an import name is a native stdlib module. */
@@ -25,7 +31,8 @@ static inline int basl_stdlib_is_native_module(
     const char *name,
     size_t name_length
 ) {
-    return name_length == 3U && memcmp(name, "fmt", 3U) == 0;
+    return (name_length == 3U && memcmp(name, "fmt", 3U) == 0) ||
+           (name_length == 4U && memcmp(name, "math", 4U) == 0);
 }
 
 #ifdef __cplusplus

--- a/src/stdlib/math.c
+++ b/src/stdlib/math.c
@@ -1,0 +1,216 @@
+/* BASL standard library: math module.
+ *
+ * All functions use only C11 <math.h> — fully platform-universal.
+ */
+#include <math.h>
+
+#include "basl/native_module.h"
+#include "basl/type.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+
+#include "internal/basl_nanbox.h"
+
+/* ── helpers ─────────────────────────────────────────────────────── */
+
+static double basl_math_pop_f64(basl_vm_t *vm) {
+    basl_value_t v = basl_vm_stack_get(vm, basl_vm_stack_depth(vm) - 1U);
+    basl_vm_stack_pop_n(vm, 1U);
+    return basl_nanbox_decode_double(v);
+}
+
+static basl_status_t basl_math_push_f64(
+    basl_vm_t *vm, double d, basl_error_t *error
+) {
+    basl_value_t val = basl_nanbox_encode_double(d);
+    return basl_vm_stack_push(vm, &val, error);
+}
+
+/* ── f64 -> f64 callbacks ────────────────────────────────────────── */
+
+#define MATH_UNARY(name, cfn)                                       \
+    static basl_status_t basl_math_##name(                          \
+        basl_vm_t *vm, size_t arg_count, basl_error_t *error        \
+    ) {                                                             \
+        double a;                                                   \
+        (void)arg_count;                                            \
+        a = basl_math_pop_f64(vm);                                  \
+        return basl_math_push_f64(vm, cfn(a), error);               \
+    }
+
+MATH_UNARY(floor, floor)
+MATH_UNARY(ceil, ceil)
+MATH_UNARY(round, round)
+MATH_UNARY(abs, fabs)
+MATH_UNARY(sqrt, sqrt)
+MATH_UNARY(sin, sin)
+MATH_UNARY(cos, cos)
+MATH_UNARY(tan, tan)
+MATH_UNARY(log, log)
+MATH_UNARY(log2, log2)
+MATH_UNARY(log10, log10)
+MATH_UNARY(exp, exp)
+MATH_UNARY(trunc, trunc)
+
+/* ── () -> f64 callbacks ─────────────────────────────────────────── */
+
+static basl_status_t basl_math_pi(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    (void)arg_count;
+    return basl_math_push_f64(vm, 3.14159265358979323846, error);
+}
+
+static basl_status_t basl_math_e(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    (void)arg_count;
+    return basl_math_push_f64(vm, 2.71828182845904523536, error);
+}
+
+/* ── (f64, f64) -> f64 callbacks ─────────────────────────────────── */
+
+static basl_status_t basl_math_pow(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double base_val, exp_val;
+    (void)arg_count;
+    exp_val = basl_math_pop_f64(vm);
+    base_val = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, pow(base_val, exp_val), error);
+}
+
+static basl_status_t basl_math_min(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double a, b;
+    (void)arg_count;
+    b = basl_math_pop_f64(vm);
+    a = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, fmin(a, b), error);
+}
+
+static basl_status_t basl_math_max(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double a, b;
+    (void)arg_count;
+    b = basl_math_pop_f64(vm);
+    a = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, fmax(a, b), error);
+}
+
+static basl_status_t basl_math_atan2(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double y, x;
+    (void)arg_count;
+    x = basl_math_pop_f64(vm);
+    y = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, atan2(y, x), error);
+}
+
+static basl_status_t basl_math_hypot(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double a, b;
+    (void)arg_count;
+    b = basl_math_pop_f64(vm);
+    a = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, hypot(a, b), error);
+}
+
+static basl_status_t basl_math_fmod(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double a, b;
+    (void)arg_count;
+    b = basl_math_pop_f64(vm);
+    a = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, fmod(a, b), error);
+}
+
+static basl_status_t basl_math_sign(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double a;
+    (void)arg_count;
+    a = basl_math_pop_f64(vm);
+    return basl_math_push_f64(vm, (a > 0.0) - (a < 0.0), error);
+}
+
+/* ── (f64, f64, f64) -> f64 callbacks ────────────────────────────── */
+
+static basl_status_t basl_math_clamp(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    double val, lo, hi;
+    (void)arg_count;
+    hi = basl_math_pop_f64(vm);
+    lo = basl_math_pop_f64(vm);
+    val = basl_math_pop_f64(vm);
+    if (val < lo) val = lo;
+    if (val > hi) val = hi;
+    return basl_math_push_f64(vm, val, error);
+}
+
+/* ── module descriptor ───────────────────────────────────────────── */
+
+static const int basl_math_f64_params[] = { BASL_TYPE_F64 };
+static const int basl_math_f64f64_params[] = {
+    BASL_TYPE_F64, BASL_TYPE_F64
+};
+static const int basl_math_f64f64f64_params[] = {
+    BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64
+};
+
+#define MATH_FN0(id, n, nl)                                         \
+    { n, nl, basl_math_##id, 0U, NULL,                             \
+      BASL_TYPE_F64, 1U, NULL }
+
+#define MATH_FN1(id, n, nl)                                         \
+    { n, nl, basl_math_##id, 1U, basl_math_f64_params,             \
+      BASL_TYPE_F64, 1U, NULL }
+
+#define MATH_FN2(id, n, nl)                                         \
+    { n, nl, basl_math_##id, 2U, basl_math_f64f64_params,          \
+      BASL_TYPE_F64, 1U, NULL }
+
+#define MATH_FN3(id, n, nl)                                         \
+    { n, nl, basl_math_##id, 3U, basl_math_f64f64f64_params,       \
+      BASL_TYPE_F64, 1U, NULL }
+
+static const basl_native_module_function_t basl_math_functions[] = {
+    MATH_FN0(pi,    "pi",    2U),
+    MATH_FN0(e,     "e",     1U),
+    MATH_FN1(floor, "floor", 5U),
+    MATH_FN1(ceil,  "ceil",  4U),
+    MATH_FN1(round, "round", 5U),
+    MATH_FN1(trunc, "trunc", 5U),
+    MATH_FN1(abs,   "abs",   3U),
+    MATH_FN1(sign,  "sign",  4U),
+    MATH_FN1(sqrt,  "sqrt",  4U),
+    MATH_FN1(sin,   "sin",   3U),
+    MATH_FN1(cos,   "cos",   3U),
+    MATH_FN1(tan,   "tan",   3U),
+    MATH_FN1(log,   "log",   3U),
+    MATH_FN1(log2,  "log2",  4U),
+    MATH_FN1(log10, "log10", 5U),
+    MATH_FN1(exp,   "exp",   3U),
+    MATH_FN2(pow,   "pow",   3U),
+    MATH_FN2(min,   "min",   3U),
+    MATH_FN2(max,   "max",   3U),
+    MATH_FN2(atan2, "atan2", 5U),
+    MATH_FN2(hypot, "hypot", 5U),
+    MATH_FN2(fmod,  "fmod",  4U),
+    MATH_FN3(clamp, "clamp", 5U),
+};
+
+#define BASL_MATH_FUNCTION_COUNT \
+    (sizeof(basl_math_functions) / sizeof(basl_math_functions[0]))
+
+BASL_API const basl_native_module_t basl_stdlib_math = {
+    "math", 4U,
+    basl_math_functions,
+    BASL_MATH_FUNCTION_COUNT
+};

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -1,0 +1,447 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+
+extern "C" {
+#include "basl/basl.h"
+#include "basl/stdlib.h"
+}
+
+namespace {
+
+/* ── test harness ────────────────────────────────────────────────── */
+
+/*
+ * Compile and run a BASL program that imports stdlib modules.
+ * The program's main() must return i32.  Returns that value.
+ */
+int64_t RunWithStdlib(const char *source_text) {
+    basl_runtime_t *runtime = nullptr;
+    basl_vm_t *vm = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_native_registry_t natives;
+    basl_diagnostic_list_t diagnostics;
+    basl_object_t *function = nullptr;
+    basl_value_t result;
+    basl_source_id_t source_id = 0U;
+    int64_t output = 0;
+
+    EXPECT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_vm_open(&vm, runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+    basl_native_registry_init(&natives);
+    EXPECT_EQ(basl_stdlib_register_all(&natives, &error), BASL_STATUS_OK);
+
+    EXPECT_EQ(
+        basl_source_registry_register_cstr(
+            &registry, "main.basl", source_text, &source_id, &error),
+        BASL_STATUS_OK
+    );
+
+    EXPECT_EQ(
+        basl_compile_source_with_natives(
+            &registry, source_id, &natives, &function, &diagnostics, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_NE(function, nullptr);
+    EXPECT_EQ(basl_diagnostic_list_count(&diagnostics), 0U);
+
+    basl_value_init_nil(&result);
+    EXPECT_EQ(
+        basl_vm_execute_function(vm, function, &result, &error),
+        BASL_STATUS_OK
+    );
+    EXPECT_EQ(basl_value_kind(&result), BASL_VALUE_INT);
+    output = basl_value_as_int(&result);
+
+    basl_value_release(&result);
+    basl_object_release(&function);
+    basl_diagnostic_list_free(&diagnostics);
+    basl_native_registry_free(&natives);
+    basl_source_registry_free(&registry);
+    basl_vm_close(&vm);
+    basl_runtime_close(&runtime);
+    return output;
+}
+
+/*
+ * Same as RunWithStdlib but captures stdout and returns it.
+ * The program's exit code is expected to be 0.
+ */
+std::string RunAndCaptureStdout(const char *source_text) {
+    testing::internal::CaptureStdout();
+    int64_t rc = RunWithStdlib(source_text);
+    std::string captured = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(rc, 0);
+    return captured;
+}
+
+std::string RunAndCaptureStderr(const char *source_text) {
+    testing::internal::CaptureStderr();
+    int64_t rc = RunWithStdlib(source_text);
+    std::string captured = testing::internal::GetCapturedStderr();
+    EXPECT_EQ(rc, 0);
+    return captured;
+}
+
+/* ── fmt tests ───────────────────────────────────────────────────── */
+
+TEST(BaslStdlibFmtTest, PrintlnOutputsStringWithNewline) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            fmt.println("hello");
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "hello\n");
+}
+
+TEST(BaslStdlibFmtTest, PrintOutputsStringWithoutNewline) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            fmt.print("ab");
+            fmt.print("cd");
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "abcd");
+}
+
+TEST(BaslStdlibFmtTest, EprintlnOutputsToStderr) {
+    std::string err = RunAndCaptureStderr(R"(
+        import "fmt";
+        fn main() -> i32 {
+            fmt.eprintln("oops");
+            return 0;
+        }
+    )");
+    EXPECT_EQ(err, "oops\n");
+}
+
+TEST(BaslStdlibFmtTest, PrintlnEmptyString) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            fmt.println("");
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "\n");
+}
+
+TEST(BaslStdlibFmtTest, PrintlnWithFString) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            i32 x = 42;
+            fmt.println(f"val={x}");
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "val=42\n");
+}
+
+TEST(BaslStdlibFmtTest, PrintlnWithVariable) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            string s = "world";
+            fmt.println(s);
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "world\n");
+}
+
+TEST(BaslStdlibFmtTest, PrintlnInLoop) {
+    std::string out = RunAndCaptureStdout(R"(
+        import "fmt";
+        fn main() -> i32 {
+            for (i32 i = 0; i < 3; i++) {
+                fmt.println(string(i));
+            }
+            return 0;
+        }
+    )");
+    EXPECT_EQ(out, "0\n1\n2\n");
+}
+
+/* ── math: constants ─────────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, PiReturnsCorrectValue) {
+    /*
+     * Encode a pass/fail check as an integer return.
+     * The BASL program returns 0 if pi matches within tolerance.
+     */
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 diff = math.abs(math.pi() - 3.14159265358979323846);
+            if (diff > 0.000000000000001) { return 1; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, EReturnsCorrectValue) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 diff = math.abs(math.e() - 2.71828182845904523536);
+            if (diff > 0.000000000000001) { return 1; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── math: rounding / conversion table tests ─────────────────────── */
+
+/*
+ * Each rounding function is tested with a table of inputs including
+ * positive, negative, zero, and edge cases.  The BASL program
+ * encodes the index of the first failing case (1-based) or 0 on
+ * success.
+ */
+
+TEST(BaslStdlibMathTest, FloorTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.floor(3.7) != 3.0)   { return 1; }
+            if (math.floor(-3.7) != -4.0)  { return 2; }
+            if (math.floor(0.0) != 0.0)    { return 3; }
+            if (math.floor(5.0) != 5.0)    { return 4; }
+            if (math.floor(-0.1) != -1.0)  { return 5; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, CeilTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.ceil(3.2) != 4.0)    { return 1; }
+            if (math.ceil(-3.2) != -3.0)   { return 2; }
+            if (math.ceil(0.0) != 0.0)     { return 3; }
+            if (math.ceil(5.0) != 5.0)     { return 4; }
+            if (math.ceil(0.1) != 1.0)     { return 5; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, RoundTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.round(3.5) != 4.0)    { return 1; }
+            if (math.round(3.4) != 3.0)    { return 2; }
+            if (math.round(-3.5) != -4.0)  { return 3; }
+            if (math.round(0.0) != 0.0)    { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, TruncTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.trunc(3.7) != 3.0)    { return 1; }
+            if (math.trunc(-3.7) != -3.0)  { return 2; }
+            if (math.trunc(0.0) != 0.0)    { return 3; }
+            if (math.trunc(5.0) != 5.0)    { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, AbsTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.abs(-42.0) != 42.0)  { return 1; }
+            if (math.abs(42.0) != 42.0)   { return 2; }
+            if (math.abs(0.0) != 0.0)     { return 3; }
+            if (math.abs(-0.0) != 0.0)    { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, SignTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.sign(42.0) != 1.0)   { return 1; }
+            if (math.sign(-42.0) != -1.0)  { return 2; }
+            if (math.sign(0.0) != 0.0)    { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── math: trig / exponential ────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, SqrtTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.sqrt(144.0) != 12.0)  { return 1; }
+            if (math.sqrt(0.0) != 0.0)     { return 2; }
+            if (math.sqrt(1.0) != 1.0)     { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, SinCosAtZero) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.sin(0.0) != 0.0)  { return 1; }
+            if (math.cos(0.0) != 1.0)  { return 2; }
+            if (math.tan(0.0) != 0.0)  { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, LogTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.log(1.0) != 0.0)      { return 1; }
+            if (math.log2(1024.0) != 10.0)  { return 2; }
+            if (math.log10(1000.0) != 3.0)  { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, ExpAtZeroAndOne) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.exp(0.0) != 1.0)  { return 1; }
+            f64 diff = math.abs(math.exp(1.0) - math.e());
+            if (diff > 0.000000000000001) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── math: two-argument functions ────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, PowTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.pow(2.0, 10.0) != 1024.0)  { return 1; }
+            if (math.pow(3.0, 0.0) != 1.0)      { return 2; }
+            if (math.pow(5.0, 1.0) != 5.0)      { return 3; }
+            if (math.pow(4.0, 0.5) != 2.0)      { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, MinMaxTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.min(3.0, 7.0) != 3.0)    { return 1; }
+            if (math.min(-1.0, 1.0) != -1.0)   { return 2; }
+            if (math.min(5.0, 5.0) != 5.0)    { return 3; }
+            if (math.max(3.0, 7.0) != 7.0)    { return 4; }
+            if (math.max(-1.0, 1.0) != 1.0)    { return 5; }
+            if (math.max(5.0, 5.0) != 5.0)    { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Atan2Table) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.atan2(0.0, 1.0) != 0.0)  { return 1; }
+            f64 diff = math.abs(math.atan2(1.0, 1.0) - math.pi() / 4.0);
+            if (diff > 0.000000000000001) { return 2; }
+            // atan2(1, 0) == pi/2
+            f64 diff2 = math.abs(math.atan2(1.0, 0.0) - math.pi() / 2.0);
+            if (diff2 > 0.000000000000001) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, HypotTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.hypot(3.0, 4.0) != 5.0)    { return 1; }
+            if (math.hypot(0.0, 0.0) != 0.0)    { return 2; }
+            if (math.hypot(5.0, 0.0) != 5.0)    { return 3; }
+            if (math.hypot(0.0, 7.0) != 7.0)    { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, FmodTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.fmod(7.5, 3.0) != 1.5)    { return 1; }
+            if (math.fmod(10.0, 5.0) != 0.0)   { return 2; }
+            if (math.fmod(-7.5, 3.0) != -1.5)  { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── math: three-argument functions ──────────────────────────────── */
+
+TEST(BaslStdlibMathTest, ClampTable) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            if (math.clamp(5.0, 0.0, 10.0) != 5.0)    { return 1; }
+            if (math.clamp(-5.0, 0.0, 10.0) != 0.0)   { return 2; }
+            if (math.clamp(15.0, 0.0, 10.0) != 10.0)   { return 3; }
+            if (math.clamp(0.0, 0.0, 10.0) != 0.0)    { return 4; }
+            if (math.clamp(10.0, 0.0, 10.0) != 10.0)   { return 5; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── math: composition ───────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, ComposedExpressions) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            // pythagorean theorem via composition
+            f64 hyp = math.sqrt(math.pow(3.0, 2.0) + math.pow(4.0, 2.0));
+            if (hyp != 5.0) { return 1; }
+
+            // clamp via min/max matches clamp()
+            f64 val = 15.0;
+            f64 a = math.min(math.max(val, 0.0), 10.0);
+            f64 b = math.clamp(val, 0.0, 10.0);
+            if (a != b) { return 2; }
+
+            return 0;
+        }
+    )"), 0);
+}
+
+}  // namespace


### PR DESCRIPTION
Second stdlib module — 15 functions wrapping C11 `<math.h>`.

## Functions

| Signature | C function |
|---|---|
| `math.floor(f64) -> f64` | `floor` |
| `math.ceil(f64) -> f64` | `ceil` |
| `math.round(f64) -> f64` | `round` |
| `math.abs(f64) -> f64` | `fabs` |
| `math.sqrt(f64) -> f64` | `sqrt` |
| `math.sin(f64) -> f64` | `sin` |
| `math.cos(f64) -> f64` | `cos` |
| `math.tan(f64) -> f64` | `tan` |
| `math.log(f64) -> f64` | `log` |
| `math.log2(f64) -> f64` | `log2` |
| `math.log10(f64) -> f64` | `log10` |
| `math.exp(f64) -> f64` | `exp` |
| `math.pow(f64, f64) -> f64` | `pow` |
| `math.min(f64, f64) -> f64` | `fmin` |
| `math.max(f64, f64) -> f64` | `fmax` |

## Example

```c
import "fmt";
import "math";

fn main() -> i32 {
    f64 hyp = math.sqrt(math.pow(3.0, 2.0) + math.pow(4.0, 2.0));
    fmt.println(f"hypotenuse = {hyp}");
    return 0;
}
```

## Build
- Links `libm` on Linux (detected via `check_library_exists`)
- MSVC, macOS, Emscripten have math in the default C library
- 217/217 tests, ASAN clean, portability clean