### PR TITLE
Add native class support for stdlib modules

### DIFF
--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -33,11 +33,41 @@ typedef struct basl_native_module_function {
 /**
  * Describes a native module (e.g. "fmt", "math").
  */
+
+typedef struct basl_native_class_field {
+    const char *name;
+    size_t name_length;
+    int type;                   /* basl_type_kind_t */
+} basl_native_class_field_t;
+
+typedef struct basl_native_class_method {
+    const char *name;
+    size_t name_length;
+    basl_native_fn_t native_fn;
+    size_t param_count;         /* excluding self */
+    const int *param_types;     /* basl_type_kind_t values, excluding self */
+    int return_type;            /* basl_type_kind_t */
+    size_t return_count;
+    const int *return_types;
+} basl_native_class_method_t;
+
+typedef struct basl_native_class {
+    const char *name;
+    size_t name_length;
+    const basl_native_class_field_t *fields;
+    size_t field_count;
+    const basl_native_class_method_t *methods;
+    size_t method_count;
+    basl_native_fn_t constructor;   /* NULL = default (field-per-arg) */
+} basl_native_class_t;
+
 typedef struct basl_native_module {
     const char *name;
     size_t name_length;
     const basl_native_module_function_t *functions;
     size_t function_count;
+    const basl_native_class_t *classes;
+    size_t class_count;
 } basl_native_module_t;
 
 /**

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2407,6 +2407,73 @@ static basl_status_t basl_program_parse_import_target(
     return basl_program_resolve_import_path(program, text + 1U, length - 2U, out_path);
 }
 
+static basl_status_t basl_program_register_native_classes(
+    basl_program_state_t *program,
+    const basl_native_module_t *mod,
+    basl_source_id_t source_id
+) {
+    basl_status_t status;
+    size_t ci;
+    size_t fi;
+    size_t mi;
+
+    for (ci = 0U; ci < mod->class_count; ci++) {
+        const basl_native_class_t *nc = &mod->classes[ci];
+        basl_class_decl_t *decl;
+
+        status = basl_program_grow_classes(program, program->class_count + 1U);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        decl = &program->classes[program->class_count];
+        memset(decl, 0, sizeof(*decl));
+        decl->constructor_function_index = (size_t)-1;
+        decl->source_id = source_id;
+        decl->name = nc->name;
+        decl->name_length = nc->name_length;
+        decl->is_public = 1;
+        decl->native_class = nc;
+
+        /* Register fields. */
+        if (nc->field_count > 0U) {
+            status = basl_class_decl_grow_fields(
+                program, decl, nc->field_count);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            for (fi = 0U; fi < nc->field_count; fi++) {
+                basl_class_field_t *f = &decl->fields[fi];
+                f->name = nc->fields[fi].name;
+                f->name_length = nc->fields[fi].name_length;
+                f->is_public = 1;
+                f->type = basl_binding_type_primitive(
+                    (basl_type_kind_t)nc->fields[fi].type);
+            }
+            decl->field_count = nc->field_count;
+        }
+
+        /* Register method stubs (function_index unused for native). */
+        if (nc->method_count > 0U) {
+            status = basl_class_decl_grow_methods(
+                program, decl, nc->method_count);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            for (mi = 0U; mi < nc->method_count; mi++) {
+                basl_class_method_t *m = &decl->methods[mi];
+                m->name = nc->methods[mi].name;
+                m->name_length = nc->methods[mi].name_length;
+                m->is_public = 1;
+                m->function_index = (size_t)-1;
+            }
+            decl->method_count = nc->method_count;
+        }
+
+        program->class_count += 1U;
+    }
+    return BASL_STATUS_OK;
+}
+
 static basl_status_t basl_program_parse_import(
     basl_program_state_t *program,
     size_t *cursor
@@ -2556,6 +2623,12 @@ static basl_status_t basl_program_parse_import(
 
     if (!native_found) {
         status = basl_program_parse_source(program, imported_source_id);
+    } else if (program->natives->modules[native_idx]->class_count > 0U) {
+        status = basl_program_register_native_classes(
+            program,
+            program->natives->modules[native_idx],
+            imported_source_id
+        );
     }
     basl_string_free(&import_path);
     return status;
@@ -7551,6 +7624,133 @@ static basl_status_t basl_parser_parse_native_call(
     return BASL_STATUS_OK;
 }
 
+static basl_status_t basl_parser_parse_native_method_call(
+    basl_parser_state_t *state,
+    const basl_token_t *method_token,
+    const basl_native_class_t *nc,
+    const basl_native_class_method_t *method,
+    basl_expression_result_t *out_result
+) {
+    basl_status_t status;
+    basl_expression_result_t arg_result;
+    size_t arg_count;
+    size_t i;
+    basl_object_t *native_obj;
+    basl_value_t native_val;
+
+    (void)nc;
+    basl_expression_result_clear(&arg_result);
+    status = basl_parser_expect(
+        state, BASL_TOKEN_LPAREN, "expected '(' after method name", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    /* self is already on the stack; parse remaining args. */
+    arg_count = 0U;
+    if (!basl_parser_check(state, BASL_TOKEN_RPAREN)) {
+        while (1) {
+            status = basl_parser_parse_expression(state, &arg_result);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            status = basl_parser_require_scalar_expression(
+                state, method_token->span, &arg_result,
+                "call arguments must be single values"
+            );
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            if (arg_count < method->param_count &&
+                method->param_types[arg_count] != BASL_TYPE_OBJECT) {
+                status = basl_parser_require_type(
+                    state, method_token->span, arg_result.type,
+                    basl_binding_type_primitive(
+                        (basl_type_kind_t)method->param_types[arg_count]),
+                    "call argument type does not match parameter type"
+                );
+                if (status != BASL_STATUS_OK) {
+                    return status;
+                }
+            }
+            arg_count += 1U;
+            if (!basl_parser_match(state, BASL_TOKEN_COMMA)) {
+                break;
+            }
+        }
+    }
+    status = basl_parser_expect(
+        state, BASL_TOKEN_RPAREN, "expected ')' after argument list", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    if (arg_count != method->param_count) {
+        return basl_parser_report(
+            state, method_token->span,
+            "call argument count does not match method signature"
+        );
+    }
+
+    /* Create native function object and emit CALL_NATIVE.
+     * arg_count + 1 accounts for self on the stack. */
+    native_obj = NULL;
+    status = basl_native_function_object_create(
+        state->program->registry->runtime,
+        method->name, method->name_length,
+        method->param_count + 1U, method->native_fn,
+        &native_obj, state->program->error
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    basl_value_init_object(&native_val, &native_obj);
+    {
+        size_t const_idx = 0U;
+
+        status = basl_chunk_add_constant(
+            &state->chunk, &native_val, &const_idx,
+            state->program->error
+        );
+        basl_value_release(&native_val);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_opcode(
+            state, BASL_OPCODE_CALL_NATIVE, method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)const_idx, method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)(arg_count + 1U), method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    }
+
+    /* Set return type. */
+    if (method->return_count <= 1U) {
+        basl_expression_result_set_type(
+            out_result,
+            basl_binding_type_primitive((basl_type_kind_t)method->return_type)
+        );
+    } else {
+        basl_parser_type_t ret_types[2];
+        size_t rc = method->return_count > 2U ? 2U : method->return_count;
+        for (i = 0U; i < rc; i++) {
+            ret_types[i] = basl_binding_type_primitive(
+                (basl_type_kind_t)method->return_types[i]);
+        }
+        basl_expression_result_set_return_types(
+            out_result, ret_types[0], ret_types, rc);
+    }
+    return BASL_STATUS_OK;
+}
+
 static basl_status_t basl_parser_parse_qualified_symbol(
     basl_parser_state_t *state,
     const basl_token_t *module_token,
@@ -7671,10 +7871,27 @@ static basl_status_t basl_parser_parse_qualified_symbol(
     if (basl_parser_check(state, BASL_TOKEN_LPAREN)) {
         /* Native module function call. */
         if (BASL_IS_NATIVE_SOURCE_ID(source_id) && state->program->natives != NULL) {
-            return basl_parser_parse_native_call(
-                state, member_token, source_id, member_name,
-                member_name_length, out_result
-            );
+            /* Check if it's a function first; if not, fall through to class lookup. */
+            const basl_native_module_t *nmod;
+            size_t nmod_idx = BASL_NATIVE_SOURCE_INDEX(source_id);
+            int is_native_fn = 0;
+            if (nmod_idx < state->program->natives->module_count) {
+                size_t ni;
+                nmod = state->program->natives->modules[nmod_idx];
+                for (ni = 0U; ni < nmod->function_count; ni++) {
+                    if (nmod->functions[ni].name_length == member_name_length &&
+                        memcmp(nmod->functions[ni].name, member_name, member_name_length) == 0) {
+                        is_native_fn = 1;
+                        break;
+                    }
+                }
+            }
+            if (is_native_fn) {
+                return basl_parser_parse_native_call(
+                    state, member_token, source_id, member_name,
+                    member_name_length, out_result
+                );
+            }
         }
         if (
             basl_program_find_top_level_function_name_in_source(
@@ -8235,7 +8452,15 @@ static basl_status_t basl_parser_parse_postfix_suffixes(
                             "class method is not public"
                         );
                     }
-                    status = basl_parser_parse_method_call(state, field_token, class_method, out_result);
+                    if (class_decl->native_class != NULL) {
+                        status = basl_parser_parse_native_method_call(
+                            state, field_token,
+                            class_decl->native_class,
+                            &class_decl->native_class->methods[method_index],
+                            out_result);
+                    } else {
+                        status = basl_parser_parse_method_call(state, field_token, class_method, out_result);
+                    }
                     if (status != BASL_STATUS_OK) {
                         return status;
                     }

--- a/src/internal/basl_compiler_types.h
+++ b/src/internal/basl_compiler_types.h
@@ -3,6 +3,7 @@
 
 #include "basl/chunk.h"
 #include "basl/diagnostic.h"
+#include "basl/native_module.h"
 #include "basl/source.h"
 #include "basl/token.h"
 #include "basl/value.h"
@@ -66,6 +67,7 @@ typedef struct basl_class_decl {
     size_t interface_impl_count;
     size_t interface_impl_capacity;
     size_t constructor_function_index;
+    const basl_native_class_t *native_class;  /* non-NULL = native */
 } basl_class_decl_t;
 
 typedef struct basl_interface_decl {

--- a/src/stdlib/fmt.c
+++ b/src/stdlib/fmt.c
@@ -133,5 +133,6 @@ static const basl_native_module_function_t basl_fmt_functions[] = {
 BASL_API const basl_native_module_t basl_stdlib_fmt = {
     "fmt", 3U,
     basl_fmt_functions,
-    BASL_FMT_FUNCTION_COUNT
+    BASL_FMT_FUNCTION_COUNT,
+    NULL, 0U
 };

--- a/src/stdlib/math.c
+++ b/src/stdlib/math.c
@@ -209,8 +209,79 @@ static const basl_native_module_function_t basl_math_functions[] = {
 #define BASL_MATH_FUNCTION_COUNT \
     (sizeof(basl_math_functions) / sizeof(basl_math_functions[0]))
 
+/* ── Vec2 class ──────────────────────────────────────────────────── */
+
+/*
+ * Vec2 methods receive self (the instance) as the first stack arg.
+ * self is at stack[base], additional args follow.
+ */
+
+static double basl_vec2_get_field(basl_vm_t *vm, size_t base, size_t idx) {
+    basl_value_t self_val = basl_vm_stack_get(vm, base);
+    basl_object_t *obj = (basl_object_t *)basl_nanbox_decode_ptr(self_val);
+    basl_value_t field;
+    basl_instance_object_get_field(obj, idx, &field);
+    return basl_nanbox_decode_double(field);
+}
+
+static basl_status_t basl_vec2_length(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec2_get_field(vm, base, 0U);
+    double y = basl_vec2_get_field(vm, base, 1U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, sqrt(x * x + y * y), error);
+}
+
+static basl_status_t basl_vec2_dot(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x1 = basl_vec2_get_field(vm, base, 0U);
+    double y1 = basl_vec2_get_field(vm, base, 1U);
+    /* second arg is also a Vec2 instance */
+    basl_value_t other_val = basl_vm_stack_get(vm, base + 1U);
+    basl_object_t *other = (basl_object_t *)basl_nanbox_decode_ptr(other_val);
+    basl_value_t fx, fy;
+    basl_instance_object_get_field(other, 0U, &fx);
+    basl_instance_object_get_field(other, 1U, &fy);
+    double x2 = basl_nanbox_decode_double(fx);
+    double y2 = basl_nanbox_decode_double(fy);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, x1 * x2 + y1 * y2, error);
+}
+
+static const basl_native_class_field_t basl_vec2_fields[] = {
+    { "x", 1U, BASL_TYPE_F64 },
+    { "y", 1U, BASL_TYPE_F64 },
+};
+
+static const int basl_vec2_dot_params[] = { BASL_TYPE_OBJECT };
+
+static const basl_native_class_method_t basl_vec2_methods[] = {
+    { "length", 6U, basl_vec2_length, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL },
+    { "dot", 3U, basl_vec2_dot, 1U, basl_vec2_dot_params,
+      BASL_TYPE_F64, 1U, NULL },
+};
+
+static const basl_native_class_t basl_math_classes[] = {
+    {
+        "Vec2", 4U,
+        basl_vec2_fields, 2U,
+        basl_vec2_methods, 2U,
+        NULL
+    },
+};
+
+#define BASL_MATH_CLASS_COUNT \
+    (sizeof(basl_math_classes) / sizeof(basl_math_classes[0]))
+
 BASL_API const basl_native_module_t basl_stdlib_math = {
     "math", 4U,
     basl_math_functions,
-    BASL_MATH_FUNCTION_COUNT
+    BASL_MATH_FUNCTION_COUNT,
+    basl_math_classes,
+    BASL_MATH_CLASS_COUNT
 };

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -444,4 +444,76 @@ TEST(BaslStdlibMathTest, ComposedExpressions) {
     )"), 0);
 }
 
+/* ── native class: Vec2 ──────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, Vec2ConstructionAndFields) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 v = math.Vec2(3.0, 4.0);
+            if (v.x != 3.0) { return 1; }
+            if (v.y != 4.0) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec2FieldMutation) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 v = math.Vec2(1.0, 2.0);
+            v.x = 10.0;
+            v.y = 20.0;
+            if (v.x != 10.0) { return 1; }
+            if (v.y != 20.0) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec2Length) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 v = math.Vec2(3.0, 4.0);
+            if (v.length() != 5.0) { return 1; }
+            math.Vec2 zero = math.Vec2(0.0, 0.0);
+            if (zero.length() != 0.0) { return 2; }
+            math.Vec2 unit = math.Vec2(1.0, 0.0);
+            if (unit.length() != 1.0) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec2Dot) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 a = math.Vec2(3.0, 4.0);
+            math.Vec2 b = math.Vec2(1.0, 0.0);
+            if (a.dot(b) != 3.0) { return 1; }
+            // perpendicular vectors: dot == 0
+            math.Vec2 c = math.Vec2(0.0, 1.0);
+            if (b.dot(c) != 0.0) { return 2; }
+            // self dot
+            if (a.dot(a) != 25.0) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec2WithScalarMath) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 v = math.Vec2(3.0, 4.0);
+            f64 len = v.length();
+            if (math.sqrt(math.pow(len, 2.0)) != 5.0) { return 1; }
+            return 0;
+        }
+    )"), 0);
+}
+
 }  // namespace


### PR DESCRIPTION
Extends the native module system to support classes with fields and methods. This enables C#-style composite types in the standard library.

## What's new

Native modules can now declare classes alongside functions:

```c
import "math";

fn main() -> i32 {
    math.Vec2 v = math.Vec2(3.0, 4.0);
    fmt.println(f"({v.x}, {v.y})");    // field access
    v.x = 10.0;                         // field mutation
    f64 len = v.length();               // native method call
    f64 d = v.dot(other);               // method with class param
    return 0;
}
```

## Architecture

```
Native module descriptor          Compiler                          VM
─────────────────────────         ────────                          ──
basl_native_class_t               import "math" →                   NEW_INSTANCE:
  fields[]                          synthesize class_decl_t           create instance
  methods[]                         with native_class ptr             from stack args
  constructor (optional)          v.length() →
                                    native_class != NULL →          CALL_NATIVE:
                                    emit CALL_NATIVE                  callback reads self
                                    (self + args)                     via stack API
```

Key design decisions:
- Native classes reuse existing VM opcodes (NEW_INSTANCE, GET_FIELD, SET_FIELD)
- Only method dispatch changes: CALL_NATIVE instead of CALL
- The `native_class` pointer on `basl_class_decl_t` is the single dispatch flag
- `BASL_TYPE_OBJECT` in method params accepts any class instance (duck typing for native methods)

## Proof: math.Vec2

| Member | Type |
|---|---|
| `x` | `f64` (field) |
| `y` | `f64` (field) |
| `length()` | `-> f64` (method) |
| `dot(Vec2)` | `-> f64` (method) |

## Adding a native class to a module

1. Define field/method descriptors (`basl_native_class_field_t`, `basl_native_class_method_t`)
2. Define the class descriptor (`basl_native_class_t`)
3. Add to the module's `classes` array
4. Write C callbacks — self is first stack arg, use `basl_instance_object_get_field` for field access

## Testing
- 248/248 tests (5 new Vec2 tests)
- ASAN clean
- Portability clean