### PR TITLE
Add Vec4 and Quaternion classes to math stdlib

### DIFF
--- a/src/stdlib/math.c
+++ b/src/stdlib/math.c
@@ -796,6 +796,411 @@ static const basl_native_class_method_t basl_vec3_methods[] = {
       BASL_TYPE_OBJECT, 1U, NULL },
 };
 
+/* ── Vec4 class ──────────────────────────────────────────────────── */
+
+static basl_status_t basl_vec4_push_new(
+    basl_vm_t *vm, double x, double y, double z, double w,
+    size_t class_index, basl_error_t *error
+) {
+    basl_runtime_t *rt = basl_vm_runtime(vm);
+    basl_value_t fields[4];
+    basl_object_t *inst;
+    basl_value_t result;
+    basl_status_t s;
+    fields[0] = basl_nanbox_encode_double(x);
+    fields[1] = basl_nanbox_encode_double(y);
+    fields[2] = basl_nanbox_encode_double(z);
+    fields[3] = basl_nanbox_encode_double(w);
+    s = basl_instance_object_new(rt, class_index, fields, 4U, &inst, error);
+    if (s != BASL_STATUS_OK) return s;
+    basl_value_init_object(&result, &inst);
+    s = basl_vm_stack_push(vm, &result, error);
+    basl_value_release(&result);
+    return s;
+}
+
+static basl_status_t basl_vec4_length(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, sqrt(x*x + y*y + z*z + w*w), error);
+}
+
+static basl_status_t basl_vec4_lengthsqr(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, x*x + y*y + z*z + w*w, error);
+}
+
+static basl_status_t basl_vec4_dot(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double r = basl_vec_get_field(vm, base, 0U) * basl_vec_get_field(vm, base+1U, 0U)
+             + basl_vec_get_field(vm, base, 1U) * basl_vec_get_field(vm, base+1U, 1U)
+             + basl_vec_get_field(vm, base, 2U) * basl_vec_get_field(vm, base+1U, 2U)
+             + basl_vec_get_field(vm, base, 3U) * basl_vec_get_field(vm, base+1U, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, r, error);
+}
+
+static basl_status_t basl_vec4_distance(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double dx = basl_vec_get_field(vm, base, 0U) - basl_vec_get_field(vm, base+1U, 0U);
+    double dy = basl_vec_get_field(vm, base, 1U) - basl_vec_get_field(vm, base+1U, 1U);
+    double dz = basl_vec_get_field(vm, base, 2U) - basl_vec_get_field(vm, base+1U, 2U);
+    double dw = basl_vec_get_field(vm, base, 3U) - basl_vec_get_field(vm, base+1U, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, sqrt(dx*dx + dy*dy + dz*dz + dw*dw), error);
+}
+
+static basl_status_t basl_vec4_vnormalize(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    double len = sqrt(x*x + y*y + z*z + w*w);
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (len == 0.0) return basl_vec4_push_new(vm, 0, 0, 0, 0, ci, error);
+    return basl_vec4_push_new(vm, x/len, y/len, z/len, w/len, ci, error);
+}
+
+static basl_status_t basl_vec4_negate(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, -x, -y, -z, -w, ci, error);
+}
+
+static basl_status_t basl_vec4_add(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double x = basl_vec_get_field(vm, base, 0U) + basl_vec_get_field(vm, base+1U, 0U);
+    double y = basl_vec_get_field(vm, base, 1U) + basl_vec_get_field(vm, base+1U, 1U);
+    double z = basl_vec_get_field(vm, base, 2U) + basl_vec_get_field(vm, base+1U, 2U);
+    double w = basl_vec_get_field(vm, base, 3U) + basl_vec_get_field(vm, base+1U, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, x, y, z, w, ci, error);
+}
+
+static basl_status_t basl_vec4_sub(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double x = basl_vec_get_field(vm, base, 0U) - basl_vec_get_field(vm, base+1U, 0U);
+    double y = basl_vec_get_field(vm, base, 1U) - basl_vec_get_field(vm, base+1U, 1U);
+    double z = basl_vec_get_field(vm, base, 2U) - basl_vec_get_field(vm, base+1U, 2U);
+    double w = basl_vec_get_field(vm, base, 3U) - basl_vec_get_field(vm, base+1U, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, x, y, z, w, ci, error);
+}
+
+static basl_status_t basl_vec4_scale(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    basl_value_t sv = basl_vm_stack_get(vm, base + 1U);
+    double s = basl_nanbox_decode_double(sv);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, x*s, y*s, z*s, w*s, ci, error);
+}
+
+static basl_status_t basl_vec4_vlerp(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double x1 = basl_vec_get_field(vm, base, 0U);
+    double y1 = basl_vec_get_field(vm, base, 1U);
+    double z1 = basl_vec_get_field(vm, base, 2U);
+    double w1 = basl_vec_get_field(vm, base, 3U);
+    double x2 = basl_vec_get_field(vm, base+1U, 0U);
+    double y2 = basl_vec_get_field(vm, base+1U, 1U);
+    double z2 = basl_vec_get_field(vm, base+1U, 2U);
+    double w2 = basl_vec_get_field(vm, base+1U, 3U);
+    basl_value_t tv = basl_vm_stack_get(vm, base + 2U);
+    double t = basl_nanbox_decode_double(tv);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm,
+        x1+(x2-x1)*t, y1+(y2-y1)*t, z1+(z2-z1)*t, w1+(w2-w1)*t, ci, error);
+}
+
+static const basl_native_class_field_t basl_vec4_fields[] = {
+    { "x", 1U, BASL_TYPE_F64 },
+    { "y", 1U, BASL_TYPE_F64 },
+    { "z", 1U, BASL_TYPE_F64 },
+    { "w", 1U, BASL_TYPE_F64 },
+};
+
+static const basl_native_class_method_t basl_vec4_methods[] = {
+    { "length",    6U, basl_vec4_length,     0U, NULL,
+      BASL_TYPE_F64, 1U, NULL },
+    { "lengthSqr", 9U, basl_vec4_lengthsqr, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL },
+    { "dot",       3U, basl_vec4_dot,        1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL },
+    { "distance",  8U, basl_vec4_distance,   1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL },
+    { "normalize", 9U, basl_vec4_vnormalize, 0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "negate",    6U, basl_vec4_negate,     0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "add",       3U, basl_vec4_add,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "sub",       3U, basl_vec4_sub,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "scale",     5U, basl_vec4_scale,      1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "lerp",      4U, basl_vec4_vlerp,      2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+};
+
+/* ── Quaternion class ─────────────────────────────────────────────── */
+
+/*
+ * Quaternion stores (x, y, z, w) where w is the scalar part.
+ * Convention: q = w + xi + yj + zk.
+ * Identity quaternion: (0, 0, 0, 1).
+ */
+
+/* Reuse basl_vec4_push_new for quaternion — same 4-field layout. */
+#define basl_quat_push_new basl_vec4_push_new
+
+static basl_status_t basl_quat_length(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, sqrt(x*x + y*y + z*z + w*w), error);
+}
+
+static basl_status_t basl_quat_vnormalize(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    double len = sqrt(x*x + y*y + z*z + w*w);
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (len == 0.0) return basl_quat_push_new(vm, 0, 0, 0, 1, ci, error);
+    return basl_quat_push_new(vm, x/len, y/len, z/len, w/len, ci, error);
+}
+
+static basl_status_t basl_quat_conjugate(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_quat_push_new(vm, -x, -y, -z, w, ci, error);
+}
+
+static basl_status_t basl_quat_inverse(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    double lsq = x*x + y*y + z*z + w*w;
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (lsq == 0.0) return basl_quat_push_new(vm, 0, 0, 0, 1, ci, error);
+    return basl_quat_push_new(vm, -x/lsq, -y/lsq, -z/lsq, w/lsq, ci, error);
+}
+
+/* Hamilton product: q1 * q2 */
+static basl_status_t basl_quat_multiply(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x1 = basl_vec_get_field(vm, base, 0U);
+    double y1 = basl_vec_get_field(vm, base, 1U);
+    double z1 = basl_vec_get_field(vm, base, 2U);
+    double w1 = basl_vec_get_field(vm, base, 3U);
+    double x2 = basl_vec_get_field(vm, base+1U, 0U);
+    double y2 = basl_vec_get_field(vm, base+1U, 1U);
+    double z2 = basl_vec_get_field(vm, base+1U, 2U);
+    double w2 = basl_vec_get_field(vm, base+1U, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_quat_push_new(vm,
+        w1*x2 + x1*w2 + y1*z2 - z1*y2,
+        w1*y2 - x1*z2 + y1*w2 + z1*x2,
+        w1*z2 + x1*y2 - y1*x2 + z1*w2,
+        w1*w2 - x1*x2 - y1*y2 - z1*z2,
+        ci, error);
+}
+
+static basl_status_t basl_quat_dot(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double r = basl_vec_get_field(vm, base, 0U) * basl_vec_get_field(vm, base+1U, 0U)
+             + basl_vec_get_field(vm, base, 1U) * basl_vec_get_field(vm, base+1U, 1U)
+             + basl_vec_get_field(vm, base, 2U) * basl_vec_get_field(vm, base+1U, 2U)
+             + basl_vec_get_field(vm, base, 3U) * basl_vec_get_field(vm, base+1U, 3U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, r, error);
+}
+
+/* Spherical linear interpolation. */
+static basl_status_t basl_quat_slerp(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x1 = basl_vec_get_field(vm, base, 0U);
+    double y1 = basl_vec_get_field(vm, base, 1U);
+    double z1 = basl_vec_get_field(vm, base, 2U);
+    double w1 = basl_vec_get_field(vm, base, 3U);
+    double x2 = basl_vec_get_field(vm, base+1U, 0U);
+    double y2 = basl_vec_get_field(vm, base+1U, 1U);
+    double z2 = basl_vec_get_field(vm, base+1U, 2U);
+    double w2 = basl_vec_get_field(vm, base+1U, 3U);
+    basl_value_t tv = basl_vm_stack_get(vm, base + 2U);
+    double t = basl_nanbox_decode_double(tv);
+    size_t ci = basl_vec_self_class(vm, base);
+    double cosHalf = x1*x2 + y1*y2 + z1*z2 + w1*w2;
+    double s1, s2, halfAngle, sinHalf;
+    basl_vm_stack_pop_n(vm, arg_count);
+    /* Take shortest path. */
+    if (cosHalf < 0.0) {
+        x2 = -x2; y2 = -y2; z2 = -z2; w2 = -w2;
+        cosHalf = -cosHalf;
+    }
+    if (cosHalf > 0.9995) {
+        /* Nearly identical — use linear interpolation. */
+        s1 = 1.0 - t; s2 = t;
+    } else {
+        halfAngle = acos(cosHalf);
+        sinHalf = sin(halfAngle);
+        s1 = sin((1.0 - t) * halfAngle) / sinHalf;
+        s2 = sin(t * halfAngle) / sinHalf;
+    }
+    return basl_quat_push_new(vm,
+        s1*x1 + s2*x2, s1*y1 + s2*y2, s1*z1 + s2*z2, s1*w1 + s2*w2,
+        ci, error);
+}
+
+/* Create quaternion from axis (Vec3-like, but passed as Quat fields) and angle. */
+static basl_status_t basl_quat_from_axis_angle(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    /* self is ignored (called on any Quat instance as factory pattern).
+     * Args: axis (object with x,y,z), angle (f64). */
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_vec_self_class(vm, base);
+    double ax = basl_vec_get_field(vm, base + 1U, 0U);
+    double ay = basl_vec_get_field(vm, base + 1U, 1U);
+    double az = basl_vec_get_field(vm, base + 1U, 2U);
+    basl_value_t av = basl_vm_stack_get(vm, base + 2U);
+    double angle = basl_nanbox_decode_double(av);
+    double half = angle * 0.5;
+    double s = sin(half);
+    double len = sqrt(ax*ax + ay*ay + az*az);
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (len != 0.0) { ax /= len; ay /= len; az /= len; }
+    return basl_quat_push_new(vm, ax*s, ay*s, az*s, cos(half), ci, error);
+}
+
+/* Convert to Euler angles (pitch, yaw, roll) in radians.
+ * Returns a Vec3 — but we can't reference Vec3's class_index here,
+ * so we return the angles as x, y, z of a new Quaternion (w=0).
+ * The user reads .x (pitch), .y (yaw), .z (roll). */
+static basl_status_t basl_quat_to_euler(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    double w = basl_vec_get_field(vm, base, 3U);
+    size_t ci = basl_vec_self_class(vm, base);
+    double sinp, pitch, yaw, roll;
+    basl_vm_stack_pop_n(vm, arg_count);
+    /* pitch (x-axis rotation) */
+    sinp = 2.0 * (w * x - y * z);
+    if (sinp >= 1.0) pitch = 3.14159265358979323846 * 0.5;
+    else if (sinp <= -1.0) pitch = -3.14159265358979323846 * 0.5;
+    else pitch = asin(sinp);
+    /* yaw (y-axis rotation) */
+    yaw = atan2(2.0 * (w * y + x * z), 1.0 - 2.0 * (x * x + y * y));
+    /* roll (z-axis rotation) */
+    roll = atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (x * x + z * z));
+    return basl_quat_push_new(vm, pitch, yaw, roll, 0.0, ci, error);
+}
+
+static const basl_native_class_field_t basl_quat_fields[] = {
+    { "x", 1U, BASL_TYPE_F64 },
+    { "y", 1U, BASL_TYPE_F64 },
+    { "z", 1U, BASL_TYPE_F64 },
+    { "w", 1U, BASL_TYPE_F64 },
+};
+
+static const basl_native_class_method_t basl_quat_methods[] = {
+    { "length",        6U, basl_quat_length,          0U, NULL,
+      BASL_TYPE_F64, 1U, NULL },
+    { "dot",           3U, basl_quat_dot,             1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL },
+    { "normalize",     9U, basl_quat_vnormalize,      0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "conjugate",     9U, basl_quat_conjugate,       0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "inverse",       7U, basl_quat_inverse,         0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "multiply",      8U, basl_quat_multiply,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "slerp",         5U, basl_quat_slerp,           2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "fromAxisAngle", 13U, basl_quat_from_axis_angle, 2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL },
+    { "toEuler",       7U, basl_quat_to_euler,        0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL },
+};
+
 static const basl_native_class_t basl_math_classes[] = {
     {
         "Vec2", 4U,
@@ -807,6 +1212,18 @@ static const basl_native_class_t basl_math_classes[] = {
         "Vec3", 4U,
         basl_vec3_fields, 3U,
         basl_vec3_methods, 13U,
+        NULL
+    },
+    {
+        "Vec4", 4U,
+        basl_vec4_fields, 4U,
+        basl_vec4_methods, 10U,
+        NULL
+    },
+    {
+        "Quaternion", 10U,
+        basl_quat_fields, 4U,
+        basl_quat_methods, 9U,
         NULL
     },
 };

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -905,4 +905,214 @@ TEST(BaslStdlibMathTest, Vec3Angle) {
     )"), 0);
 }
 
+/* ── Vec4 ────────────────────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, Vec4ConstructionAndFields) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec4 v = math.Vec4(1.0, 2.0, 3.0, 4.0);
+            if (v.x != 1.0) { return 1; }
+            if (v.y != 2.0) { return 2; }
+            if (v.z != 3.0) { return 3; }
+            if (v.w != 4.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec4LengthAndDot) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec4 v = math.Vec4(1.0, 2.0, 3.0, 4.0);
+            // length = sqrt(1+4+9+16) = sqrt(30)
+            if (math.abs(v.length() - math.sqrt(30.0)) > eps) { return 1; }
+            if (v.lengthSqr() != 30.0) { return 2; }
+            // perpendicular
+            math.Vec4 a = math.Vec4(1.0, 0.0, 0.0, 0.0);
+            math.Vec4 b = math.Vec4(0.0, 1.0, 0.0, 0.0);
+            if (a.dot(b) != 0.0) { return 3; }
+            // self dot
+            if (a.dot(a) != 1.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec4Arithmetic) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec4 a = math.Vec4(1.0, 2.0, 3.0, 4.0);
+            math.Vec4 b = math.Vec4(5.0, 6.0, 7.0, 8.0);
+            math.Vec4 c = a.add(b);
+            if (c.x != 6.0) { return 1; }
+            if (c.w != 12.0) { return 2; }
+            math.Vec4 d = a.sub(b);
+            if (d.x != -4.0) { return 3; }
+            math.Vec4 s = a.scale(2.0);
+            if (s.x != 2.0) { return 4; }
+            if (s.w != 8.0) { return 5; }
+            math.Vec4 n = a.negate();
+            if (n.x != -1.0) { return 6; }
+            if (n.w != -4.0) { return 7; }
+            // normalize
+            math.Vec4 u = a.normalize();
+            if (math.abs(u.length() - 1.0) > eps) { return 8; }
+            // distance
+            if (math.abs(a.distance(b) - math.sqrt(64.0)) > eps) { return 9; }
+            // lerp
+            math.Vec4 mid = a.lerp(b, 0.5);
+            if (mid.x != 3.0) { return 10; }
+            if (mid.w != 6.0) { return 11; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── Quaternion ──────────────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, QuaternionIdentity) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            if (math.abs(id.length() - 1.0) > eps) { return 1; }
+            // id * id = id
+            math.Quaternion r = id.multiply(id);
+            if (math.abs(r.w - 1.0) > eps) { return 2; }
+            if (math.abs(r.x) > eps) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionConjugateAndInverse) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Quaternion q = math.Quaternion(1.0, 2.0, 3.0, 4.0);
+            math.Quaternion c = q.conjugate();
+            if (c.x != -1.0) { return 1; }
+            if (c.y != -2.0) { return 2; }
+            if (c.z != -3.0) { return 3; }
+            if (c.w != 4.0) { return 4; }
+            // q * inverse(q) ~= identity
+            math.Quaternion qn = q.normalize();
+            math.Quaternion inv = qn.inverse();
+            math.Quaternion id = qn.multiply(inv);
+            if (math.abs(id.w - 1.0) > eps) { return 5; }
+            if (math.abs(id.x) > eps) { return 6; }
+            if (math.abs(id.y) > eps) { return 7; }
+            if (math.abs(id.z) > eps) { return 8; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionMultiply) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            // 90 deg around Y then 90 deg around Y = 180 deg around Y
+            math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion r180 = r90.multiply(r90);
+            // r180 should be (0, 1, 0, 0) or (0, -1, 0, 0)
+            if (math.abs(math.abs(r180.y) - 1.0) > eps) { return 1; }
+            if (math.abs(r180.x) > eps) { return 2; }
+            if (math.abs(r180.z) > eps) { return 3; }
+            if (math.abs(r180.w) > eps) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionFromAxisAngle) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            // 0 degrees -> identity
+            math.Quaternion r0 = id.fromAxisAngle(yaxis, 0.0);
+            if (math.abs(r0.w - 1.0) > eps) { return 1; }
+            if (math.abs(r0.x) > eps) { return 2; }
+            // 90 degrees around Y -> (0, sin(45), 0, cos(45))
+            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            if (math.abs(r90.length() - 1.0) > eps) { return 3; }
+            if (math.abs(r90.y - math.sin(math.deg2rad(45.0))) > eps) { return 4; }
+            if (math.abs(r90.w - math.cos(math.deg2rad(45.0))) > eps) { return 5; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionSlerp) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            // slerp t=0 -> identity
+            math.Quaternion s0 = id.slerp(r90, 0.0);
+            if (math.abs(s0.w - 1.0) > eps) { return 1; }
+            // slerp t=1 -> r90
+            math.Quaternion s1 = id.slerp(r90, 1.0);
+            if (math.abs(s1.y - r90.y) > eps) { return 2; }
+            // slerp t=0.5 -> 45 degrees
+            math.Quaternion s5 = id.slerp(r90, 0.5);
+            if (math.abs(s5.length() - 1.0) > eps) { return 3; }
+            // half of 90 = 45 deg -> y = sin(22.5 deg)
+            if (math.abs(s5.y - math.sin(math.deg2rad(22.5))) > eps) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionToEuler) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.01;
+            math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion euler = r90.toEuler();
+            // yaw (euler.y) should be ~90 degrees
+            if (math.abs(math.rad2deg(euler.y) - 90.0) > eps) { return 1; }
+            // pitch and roll should be ~0
+            if (math.abs(euler.x) > eps) { return 2; }
+            if (math.abs(euler.z) > eps) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionDotAndNormalize) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Quaternion q = math.Quaternion(1.0, 2.0, 3.0, 4.0);
+            // dot with self = lengthSqr
+            if (math.abs(q.dot(q) - 30.0) > eps) { return 1; }
+            // normalize
+            math.Quaternion n = q.normalize();
+            if (math.abs(n.length() - 1.0) > eps) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
 }  // namespace


### PR DESCRIPTION
Tier 2 math types for 3D graphics and physics.

## Vec4 (4 fields + 10 methods)

```basl
math.Vec4 color = math.Vec4(1.0, 0.5, 0.0, 1.0);  // RGBA
math.Vec4 homo = math.Vec4(x, y, z, 1.0);           // homogeneous coords
```

| Method | Signature |
|---|---|
| `length`, `lengthSqr` | `→ f64` |
| `dot`, `distance` | `(Vec4) → f64` |
| `normalize`, `negate` | `→ Vec4` |
| `add`, `sub` | `(Vec4) → Vec4` |
| `scale` | `(f64) → Vec4` |
| `lerp` | `(Vec4, f64) → Vec4` |

## Quaternion (4 fields + 9 methods)

Convention: `q = w + xi + yj + zk`. Identity: `Quaternion(0, 0, 0, 1)`.

```basl
math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
math.Vec3 yAxis = math.Vec3(0.0, 1.0, 0.0);

// Create 90° rotation around Y
math.Quaternion rot = id.fromAxisAngle(yAxis, math.deg2rad(90.0));

// Compose rotations
math.Quaternion rot180 = rot.multiply(rot);

// Smooth interpolation between rotations
math.Quaternion half = id.slerp(rot, 0.5);

// Convert to Euler angles
math.Quaternion euler = rot.toEuler();
f64 yaw = math.rad2deg(euler.y);  // 90.0
```

| Method | Signature | Description |
|---|---|---|
| `length`, `dot` | scalar queries | Magnitude, dot product |
| `normalize` | `→ Quaternion` | Unit quaternion |
| `conjugate` | `→ Quaternion` | Negate xyz, keep w |
| `inverse` | `→ Quaternion` | Conjugate / length² |
| `multiply` | `(Quaternion) → Quaternion` | Hamilton product |
| `slerp` | `(Quaternion, f64) → Quaternion` | Spherical interpolation |
| `fromAxisAngle` | `(Vec3, f64) → Quaternion` | Rotation from axis + angle |
| `toEuler` | `→ Quaternion` | Pitch/yaw/roll as x/y/z |

`slerp` handles shortest-path (negative dot) and near-identity (dot > 0.9995) edge cases.

## Testing
- 279/279 tests (10 new: 3 Vec4 + 7 Quaternion)
- ASAN+UBSAN clean
- Portability clean
- All C11 `<math.h>` — fully platform-universal