### PR TITLE
Support static methods on native classes

### DIFF
--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -54,11 +54,12 @@ typedef struct basl_native_class_method {
     const char *name;
     size_t name_length;
     basl_native_fn_t native_fn;
-    size_t param_count;         /* excluding self */
+    size_t param_count;         /* excluding self for instance methods */
     const int *param_types;     /* basl_type_kind_t values, excluding self */
     int return_type;            /* basl_type_kind_t */
     size_t return_count;
     const int *return_types;
+    int is_static;              /* 1 = no self argument */
 } basl_native_class_method_t;
 
 typedef struct basl_native_class {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -7655,6 +7655,148 @@ static basl_status_t basl_parser_parse_native_call(
     return BASL_STATUS_OK;
 }
 
+/* Parse a static method call on a native class: no self on the stack. */
+static basl_status_t basl_parser_parse_native_static_method_call(
+    basl_parser_state_t *state,
+    const basl_token_t *method_token,
+    const basl_native_class_method_t *method,
+    size_t class_index,
+    basl_expression_result_t *out_result
+) {
+    basl_status_t status;
+    basl_expression_result_t arg_result;
+    size_t arg_count;
+    size_t i;
+    basl_object_t *native_obj;
+    basl_value_t native_val;
+    basl_value_t ci_val;
+
+    basl_expression_result_clear(&arg_result);
+
+    /* Push class_index as hidden first arg so the C impl can create
+     * instances of the correct class. */
+    basl_value_init_int(&ci_val, (int64_t)class_index);
+    status = basl_chunk_write_constant(
+        &state->chunk, &ci_val, method_token->span, NULL,
+        state->program->error);
+    basl_value_release(&ci_val);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    status = basl_parser_expect(
+        state, BASL_TOKEN_LPAREN, "expected '(' after method name", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+
+    arg_count = 0U;
+    if (!basl_parser_check(state, BASL_TOKEN_RPAREN)) {
+        while (1) {
+            status = basl_parser_parse_expression(state, &arg_result);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            status = basl_parser_require_scalar_expression(
+                state, method_token->span, &arg_result,
+                "call arguments must be single values"
+            );
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            if (arg_count < method->param_count &&
+                method->param_types[arg_count] != BASL_TYPE_OBJECT) {
+                status = basl_parser_require_type(
+                    state, method_token->span, arg_result.type,
+                    basl_binding_type_primitive(
+                        (basl_type_kind_t)method->param_types[arg_count]),
+                    "call argument type does not match parameter type"
+                );
+                if (status != BASL_STATUS_OK) {
+                    return status;
+                }
+            }
+            arg_count += 1U;
+            if (!basl_parser_match(state, BASL_TOKEN_COMMA)) {
+                break;
+            }
+        }
+    }
+    status = basl_parser_expect(
+        state, BASL_TOKEN_RPAREN, "expected ')' after argument list", NULL);
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    if (arg_count != method->param_count) {
+        return basl_parser_report(
+            state, method_token->span,
+            "call argument count does not match method signature"
+        );
+    }
+
+    native_obj = NULL;
+    status = basl_native_function_object_create(
+        state->program->registry->runtime,
+        method->name, method->name_length,
+        method->param_count + 1U, method->native_fn,
+        &native_obj, state->program->error
+    );
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
+    basl_value_init_object(&native_val, &native_obj);
+    {
+        size_t const_idx = 0U;
+
+        status = basl_chunk_add_constant(
+            &state->chunk, &native_val, &const_idx,
+            state->program->error
+        );
+        basl_value_release(&native_val);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_opcode(
+            state, BASL_OPCODE_CALL_NATIVE, method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)const_idx, method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_u32(
+            state, (uint32_t)(arg_count + 1U), method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+    }
+
+    /* Set return type. */
+    if (method->return_count <= 1U) {
+        if (method->return_type == BASL_TYPE_OBJECT) {
+            basl_expression_result_set_type(
+                out_result, basl_binding_type_class(class_index));
+        } else {
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive((basl_type_kind_t)method->return_type)
+            );
+        }
+    } else {
+        basl_parser_type_t ret_types[2];
+        size_t rc = method->return_count > 2U ? 2U : method->return_count;
+        for (i = 0U; i < rc; i++) {
+            ret_types[i] = basl_binding_type_primitive(
+                (basl_type_kind_t)method->return_types[i]);
+        }
+        basl_expression_result_set_return_types(
+            out_result, ret_types[0], ret_types, rc);
+    }
+    return BASL_STATUS_OK;
+}
+
 static basl_status_t basl_parser_parse_native_method_call(
     basl_parser_state_t *state,
     const basl_token_t *method_token,
@@ -7903,6 +8045,50 @@ static basl_status_t basl_parser_parse_qualified_symbol(
         }
         basl_expression_result_set_type(out_result, basl_binding_type_enum(enum_index));
         return BASL_STATUS_OK;
+    }
+
+    /* Static method call: module.ClassName.method(...) */
+    if (
+        basl_parser_check(state, BASL_TOKEN_DOT) &&
+        BASL_IS_NATIVE_SOURCE_ID(source_id) &&
+        state->program->natives != NULL &&
+        basl_program_find_class_in_source(
+            state->program, source_id,
+            member_name, member_name_length,
+            &class_index, &class_decl
+        ) &&
+        class_decl->native_class != NULL
+    ) {
+        const basl_native_class_t *nc = class_decl->native_class;
+        const basl_token_t *static_method_token;
+        const char *sm_name;
+        size_t sm_len;
+        size_t smi;
+
+        basl_parser_advance(state); /* consume '.' */
+        status = basl_parser_expect(
+            state, BASL_TOKEN_IDENTIFIER,
+            "expected static method name after '.'",
+            &static_method_token
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        sm_name = basl_parser_token_text(state, static_method_token, &sm_len);
+        for (smi = 0U; smi < nc->method_count; smi++) {
+            if (nc->methods[smi].is_static &&
+                nc->methods[smi].name_length == sm_len &&
+                memcmp(nc->methods[smi].name, sm_name, sm_len) == 0) {
+                return basl_parser_parse_native_static_method_call(
+                    state, static_method_token,
+                    &nc->methods[smi], class_index, out_result
+                );
+            }
+        }
+        return basl_parser_report(
+            state, static_method_token->span,
+            "unknown static method"
+        );
     }
 
     if (basl_parser_check(state, BASL_TOKEN_LPAREN)) {
@@ -8490,6 +8676,12 @@ static basl_status_t basl_parser_parse_postfix_suffixes(
                         );
                     }
                     if (class_decl->native_class != NULL) {
+                        if (class_decl->native_class->methods[method_index].is_static) {
+                            return basl_parser_report(
+                                state, field_token->span,
+                                "static method cannot be called on an instance"
+                            );
+                        }
                         status = basl_parser_parse_native_method_call(
                             state, field_token,
                             class_decl->native_class,

--- a/src/stdlib/math.c
+++ b/src/stdlib/math.c
@@ -515,6 +515,40 @@ static basl_status_t basl_vec2_reflect(
 /* Helper: primitive field descriptor (object_kind=0, no class/element). */
 #define BASL_PFIELD(n, nl, t) { n, nl, t, 0, NULL, 0U, 0 }
 
+/* Helper: instance method descriptor (is_static=0). */
+#define BASL_METHOD(n, nl, fn, pc, pt, rt, rc, rts) \
+    { n, nl, fn, pc, pt, rt, rc, rts, 0 }
+
+/* Helper: static method descriptor (is_static=1). */
+#define BASL_STATIC(n, nl, fn, pc, pt, rt, rc, rts) \
+    { n, nl, fn, pc, pt, rt, rc, rts, 1 }
+
+/* Helper: read class_index from hidden first arg (static methods). */
+static size_t basl_static_class_index(basl_vm_t *vm, size_t base) {
+    basl_value_t v = basl_vm_stack_get(vm, base);
+    return (size_t)basl_nanbox_decode_i32(v);
+}
+
+/* Vec2.zero() */
+static basl_status_t basl_vec2_zero(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec2_push_new(vm, 0.0, 0.0, ci, error);
+}
+
+/* Vec2.one() */
+static basl_status_t basl_vec2_one(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec2_push_new(vm, 1.0, 1.0, ci, error);
+}
+
 static const basl_native_class_field_t basl_vec2_fields[] = {
     BASL_PFIELD("x", 1U, BASL_TYPE_F64),
     BASL_PFIELD("y", 1U, BASL_TYPE_F64),
@@ -525,28 +559,32 @@ static const int basl_vec_f64_params[] = { BASL_TYPE_F64 };
 static const int basl_vec_obj_f64_params[] = { BASL_TYPE_OBJECT, BASL_TYPE_F64 };
 
 static const basl_native_class_method_t basl_vec2_methods[] = {
-    { "length",    6U, basl_vec2_length,     0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "lengthSqr", 9U, basl_vec2_lengthsqr, 0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "dot",       3U, basl_vec2_dot,        1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "distance",  8U, basl_vec2_distance,   1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "normalize", 9U, basl_vec2_vnormalize, 0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "negate",    6U, basl_vec2_negate,     0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "add",       3U, basl_vec2_add,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "sub",       3U, basl_vec2_sub,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "scale",     5U, basl_vec2_scale,      1U, basl_vec_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "lerp",      4U, basl_vec2_vlerp,      2U, basl_vec_obj_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "reflect",   7U, basl_vec2_reflect,    1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
+    BASL_STATIC("zero",      4U, basl_vec2_zero,       0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("one",       3U, basl_vec2_one,        0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("length",    6U, basl_vec2_length,     0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("lengthSqr", 9U, basl_vec2_lengthsqr, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("dot",       3U, basl_vec2_dot,        1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("distance",  8U, basl_vec2_distance,   1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("normalize", 9U, basl_vec2_vnormalize, 0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("negate",    6U, basl_vec2_negate,     0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("add",       3U, basl_vec2_add,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("sub",       3U, basl_vec2_sub,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("scale",     5U, basl_vec2_scale,      1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("lerp",      4U, basl_vec2_vlerp,      2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("reflect",   7U, basl_vec2_reflect,    1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
 };
 
 /* ── Vec3 class ──────────────────────────────────────────────────── */
@@ -770,33 +808,57 @@ static const basl_native_class_field_t basl_vec3_fields[] = {
     BASL_PFIELD("z", 1U, BASL_TYPE_F64),
 };
 
+/* Vec3.zero() */
+static basl_status_t basl_vec3_zero(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec3_push_new(vm, 0.0, 0.0, 0.0, ci, error);
+}
+
+/* Vec3.one() */
+static basl_status_t basl_vec3_one(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec3_push_new(vm, 1.0, 1.0, 1.0, ci, error);
+}
+
 static const basl_native_class_method_t basl_vec3_methods[] = {
-    { "length",    6U, basl_vec3_length,     0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "lengthSqr", 9U, basl_vec3_lengthsqr, 0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "dot",       3U, basl_vec3_dot,        1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "distance",  8U, basl_vec3_distance,   1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "angle",     5U, basl_vec3_angle,      1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "cross",     5U, basl_vec3_cross,      1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "normalize", 9U, basl_vec3_vnormalize, 0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "negate",    6U, basl_vec3_negate,     0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "add",       3U, basl_vec3_add,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "sub",       3U, basl_vec3_sub,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "scale",     5U, basl_vec3_scale,      1U, basl_vec_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "lerp",      4U, basl_vec3_vlerp,      2U, basl_vec_obj_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "reflect",   7U, basl_vec3_reflect,    1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
+    BASL_STATIC("zero",      4U, basl_vec3_zero,       0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("one",       3U, basl_vec3_one,        0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("length",    6U, basl_vec3_length,     0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("lengthSqr", 9U, basl_vec3_lengthsqr, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("dot",       3U, basl_vec3_dot,        1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("distance",  8U, basl_vec3_distance,   1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("angle",     5U, basl_vec3_angle,      1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("cross",     5U, basl_vec3_cross,      1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("normalize", 9U, basl_vec3_vnormalize, 0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("negate",    6U, basl_vec3_negate,     0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("add",       3U, basl_vec3_add,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("sub",       3U, basl_vec3_sub,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("scale",     5U, basl_vec3_scale,      1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("lerp",      4U, basl_vec3_vlerp,      2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("reflect",   7U, basl_vec3_reflect,    1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
 };
 
 /* ── Vec4 class ──────────────────────────────────────────────────── */
@@ -966,27 +1028,51 @@ static const basl_native_class_field_t basl_vec4_fields[] = {
     BASL_PFIELD("w", 1U, BASL_TYPE_F64),
 };
 
+/* Vec4.zero() */
+static basl_status_t basl_vec4_zero(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, 0.0, 0.0, 0.0, 0.0, ci, error);
+}
+
+/* Vec4.one() */
+static basl_status_t basl_vec4_one(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec4_push_new(vm, 1.0, 1.0, 1.0, 1.0, ci, error);
+}
+
 static const basl_native_class_method_t basl_vec4_methods[] = {
-    { "length",    6U, basl_vec4_length,     0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "lengthSqr", 9U, basl_vec4_lengthsqr, 0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "dot",       3U, basl_vec4_dot,        1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "distance",  8U, basl_vec4_distance,   1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "normalize", 9U, basl_vec4_vnormalize, 0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "negate",    6U, basl_vec4_negate,     0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "add",       3U, basl_vec4_add,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "sub",       3U, basl_vec4_sub,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "scale",     5U, basl_vec4_scale,      1U, basl_vec_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "lerp",      4U, basl_vec4_vlerp,      2U, basl_vec_obj_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
+    BASL_STATIC("zero",      4U, basl_vec4_zero,       0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("one",       3U, basl_vec4_one,        0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("length",    6U, basl_vec4_length,     0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("lengthSqr", 9U, basl_vec4_lengthsqr, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("dot",       3U, basl_vec4_dot,        1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("distance",  8U, basl_vec4_distance,   1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("normalize", 9U, basl_vec4_vnormalize, 0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("negate",    6U, basl_vec4_negate,     0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("add",       3U, basl_vec4_add,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("sub",       3U, basl_vec4_sub,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("scale",     5U, basl_vec4_scale,      1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("lerp",      4U, basl_vec4_vlerp,      2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
 };
 
 /* ── Quaternion class ─────────────────────────────────────────────── */
@@ -1132,10 +1218,9 @@ static basl_status_t basl_quat_slerp(
 static basl_status_t basl_quat_from_axis_angle(
     basl_vm_t *vm, size_t arg_count, basl_error_t *error
 ) {
-    /* self is ignored (called on any Quat instance as factory pattern).
-     * Args: axis (object with x,y,z), angle (f64). */
+    /* Static: stack = [class_index, axis_vec3, angle_f64]. */
     size_t base = basl_vm_stack_depth(vm) - arg_count;
-    size_t ci = basl_vec_self_class(vm, base);
+    size_t ci = basl_static_class_index(vm, base);
     double ax = basl_vec_get_field(vm, base + 1U, 0U);
     double ay = basl_vec_get_field(vm, base + 1U, 1U);
     double az = basl_vec_get_field(vm, base + 1U, 2U);
@@ -1184,24 +1269,24 @@ static const basl_native_class_field_t basl_quat_fields[] = {
 };
 
 static const basl_native_class_method_t basl_quat_methods[] = {
-    { "length",        6U, basl_quat_length,          0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "dot",           3U, basl_quat_dot,             1U, basl_vec_obj_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "normalize",     9U, basl_quat_vnormalize,      0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "conjugate",     9U, basl_quat_conjugate,       0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "inverse",       7U, basl_quat_inverse,         0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "multiply",      8U, basl_quat_multiply,        1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "slerp",         5U, basl_quat_slerp,           2U, basl_vec_obj_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "fromAxisAngle", 13U, basl_quat_from_axis_angle, 2U, basl_vec_obj_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "toEuler",       7U, basl_quat_to_euler,        0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
+    BASL_METHOD("length",        6U, basl_quat_length,          0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("dot",           3U, basl_quat_dot,             1U, basl_vec_obj_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("normalize",     9U, basl_quat_vnormalize,      0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("conjugate",     9U, basl_quat_conjugate,       0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("inverse",       7U, basl_quat_inverse,         0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("multiply",      8U, basl_quat_multiply,        1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("slerp",         5U, basl_quat_slerp,           2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("fromAxisAngle", 13U, basl_quat_from_axis_angle, 2U, basl_vec_obj_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("toEuler",       7U, basl_quat_to_euler,        0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
 };
 
 /* ── Mat4 class ──────────────────────────────────────────────────── */
@@ -1265,12 +1350,12 @@ static basl_status_t basl_mat4_push_new(
     return s;
 }
 
-/* identity(): returns identity matrix */
+/* identity(): static factory, returns identity matrix */
 static basl_status_t basl_mat4_identity(
     basl_vm_t *vm, size_t arg_count, basl_error_t *error
 ) {
     size_t base = basl_vm_stack_depth(vm) - arg_count;
-    size_t ci = basl_vec_self_class(vm, base);
+    size_t ci = basl_static_class_index(vm, base);
     double m[16] = {
         1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
     };
@@ -1413,41 +1498,41 @@ static const basl_native_class_field_t basl_mat4_fields[] = {
 };
 
 static const basl_native_class_method_t basl_mat4_methods[] = {
-    { "identity",    8U, basl_mat4_identity,    0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "get",         3U, basl_mat4_get,         2U, basl_mat4_i32i32_params,
-      BASL_TYPE_F64, 1U, NULL },
-    { "set",         3U, basl_mat4_set,         3U, basl_mat4_i32i32f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "multiply",    8U, basl_mat4_multiply,    1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "transpose",   9U, basl_mat4_transpose,   0U, NULL,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "determinant", 11U, basl_mat4_determinant, 0U, NULL,
-      BASL_TYPE_F64, 1U, NULL },
-    { "add",         3U, basl_mat4_add,         1U, basl_vec_obj_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
-    { "scale",       5U, basl_mat4_scale,       1U, basl_vec_f64_params,
-      BASL_TYPE_OBJECT, 1U, NULL },
+    BASL_STATIC("identity",    8U, basl_mat4_identity,    0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("get",         3U, basl_mat4_get,         2U, basl_mat4_i32i32_params,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("set",         3U, basl_mat4_set,         3U, basl_mat4_i32i32f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("multiply",    8U, basl_mat4_multiply,    1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("transpose",   9U, basl_mat4_transpose,   0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("determinant", 11U, basl_mat4_determinant, 0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("add",         3U, basl_mat4_add,         1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("scale",       5U, basl_mat4_scale,       1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
 };
 
 static const basl_native_class_t basl_math_classes[] = {
     {
         "Vec2", 4U,
         basl_vec2_fields, 2U,
-        basl_vec2_methods, 11U,
+        basl_vec2_methods, 13U,
         NULL
     },
     {
         "Vec3", 4U,
         basl_vec3_fields, 3U,
-        basl_vec3_methods, 13U,
+        basl_vec3_methods, 15U,
         NULL
     },
     {
         "Vec4", 4U,
         basl_vec4_fields, 4U,
-        basl_vec4_methods, 10U,
+        basl_vec4_methods, 12U,
         NULL
     },
     {

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -1023,7 +1023,7 @@ TEST(BaslStdlibMathTest, QuaternionMultiply) {
             // 90 deg around Y then 90 deg around Y = 180 deg around Y
             math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
             math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
-            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion r90 = math.Quaternion.fromAxisAngle(yaxis, math.deg2rad(90.0));
             math.Quaternion r180 = r90.multiply(r90);
             // r180 should be (0, 1, 0, 0) or (0, -1, 0, 0)
             if (math.abs(math.abs(r180.y) - 1.0) > eps) { return 1; }
@@ -1043,11 +1043,11 @@ TEST(BaslStdlibMathTest, QuaternionFromAxisAngle) {
             math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
             math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
             // 0 degrees -> identity
-            math.Quaternion r0 = id.fromAxisAngle(yaxis, 0.0);
+            math.Quaternion r0 = math.Quaternion.fromAxisAngle(yaxis, 0.0);
             if (math.abs(r0.w - 1.0) > eps) { return 1; }
             if (math.abs(r0.x) > eps) { return 2; }
             // 90 degrees around Y -> (0, sin(45), 0, cos(45))
-            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion r90 = math.Quaternion.fromAxisAngle(yaxis, math.deg2rad(90.0));
             if (math.abs(r90.length() - 1.0) > eps) { return 3; }
             if (math.abs(r90.y - math.sin(math.deg2rad(45.0))) > eps) { return 4; }
             if (math.abs(r90.w - math.cos(math.deg2rad(45.0))) > eps) { return 5; }
@@ -1063,7 +1063,7 @@ TEST(BaslStdlibMathTest, QuaternionSlerp) {
             f64 eps = 0.000001;
             math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
             math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
-            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion r90 = math.Quaternion.fromAxisAngle(yaxis, math.deg2rad(90.0));
             // slerp t=0 -> identity
             math.Quaternion s0 = id.slerp(r90, 0.0);
             if (math.abs(s0.w - 1.0) > eps) { return 1; }
@@ -1087,7 +1087,7 @@ TEST(BaslStdlibMathTest, QuaternionToEuler) {
             f64 eps = 0.01;
             math.Quaternion id = math.Quaternion(0.0, 0.0, 0.0, 1.0);
             math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
-            math.Quaternion r90 = id.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            math.Quaternion r90 = math.Quaternion.fromAxisAngle(yaxis, math.deg2rad(90.0));
             math.Quaternion euler = r90.toEuler();
             // yaw (euler.y) should be ~90 degrees
             if (math.abs(math.rad2deg(euler.y) - 90.0) > eps) { return 1; }
@@ -1137,9 +1137,7 @@ TEST(BaslStdlibMathTest, Mat4Identity) {
     EXPECT_EQ(RunWithStdlib(R"(
         import "math";
         fn main() -> i32 {
-            array<f64> z = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
-            math.Mat4 m = math.Mat4(z);
-            math.Mat4 id = m.identity();
+            math.Mat4 id = math.Mat4.identity();
             if (id.get(0, 0) != 1.0) { return 1; }
             if (id.get(1, 1) != 1.0) { return 2; }
             if (id.get(2, 2) != 1.0) { return 3; }
@@ -1155,8 +1153,7 @@ TEST(BaslStdlibMathTest, Mat4GetSetTranspose) {
     EXPECT_EQ(RunWithStdlib(R"(
         import "math";
         fn main() -> i32 {
-            array<f64> z = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
-            math.Mat4 id = math.Mat4(z).identity();
+            math.Mat4 id = math.Mat4.identity();
             // set(0,1) = 5 -> get(0,1) = 5
             math.Mat4 m = id.set(0, 1, 5.0);
             if (m.get(0, 1) != 5.0) { return 1; }
@@ -1175,8 +1172,7 @@ TEST(BaslStdlibMathTest, Mat4MultiplyAndDeterminant) {
         import "math";
         fn main() -> i32 {
             f64 eps = 0.000001;
-            array<f64> z = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
-            math.Mat4 id = math.Mat4(z).identity();
+            math.Mat4 id = math.Mat4.identity();
             // id * id = id
             math.Mat4 r = id.multiply(id);
             if (r.get(0, 0) != 1.0) { return 1; }
@@ -1195,14 +1191,103 @@ TEST(BaslStdlibMathTest, Mat4AddAndScale) {
     EXPECT_EQ(RunWithStdlib(R"(
         import "math";
         fn main() -> i32 {
-            array<f64> z = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
-            math.Mat4 id = math.Mat4(z).identity();
+            math.Mat4 id = math.Mat4.identity();
             math.Mat4 sum = id.add(id);
             if (sum.get(0, 0) != 2.0) { return 1; }
             if (sum.get(0, 1) != 0.0) { return 2; }
             math.Mat4 s = id.scale(3.0);
             if (s.get(0, 0) != 3.0) { return 3; }
             if (s.get(1, 1) != 3.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── Static methods ──────────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, Vec2StaticZeroAndOne) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec2 z = math.Vec2.zero();
+            if (z.x != 0.0) { return 1; }
+            if (z.y != 0.0) { return 2; }
+            math.Vec2 o = math.Vec2.one();
+            if (o.x != 1.0) { return 3; }
+            if (o.y != 1.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec3StaticZeroAndOne) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec3 z = math.Vec3.zero();
+            if (z.x != 0.0) { return 1; }
+            if (z.y != 0.0) { return 2; }
+            if (z.z != 0.0) { return 3; }
+            math.Vec3 o = math.Vec3.one();
+            if (o.x != 1.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec4StaticZeroAndOne) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Vec4 z = math.Vec4.zero();
+            if (z.x != 0.0) { return 1; }
+            if (z.w != 0.0) { return 2; }
+            math.Vec4 o = math.Vec4.one();
+            if (o.x != 1.0) { return 3; }
+            if (o.w != 1.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4StaticIdentity) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            math.Mat4 id = math.Mat4.identity();
+            if (id.get(0, 0) != 1.0) { return 1; }
+            if (id.get(1, 1) != 1.0) { return 2; }
+            if (id.get(0, 1) != 0.0) { return 3; }
+            if (id.determinant() != 1.0) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionStaticFromAxisAngle) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            math.Quaternion q = math.Quaternion.fromAxisAngle(yaxis, math.deg2rad(90.0));
+            if (math.abs(q.length() - 1.0) > eps) { return 1; }
+            if (math.abs(q.y - math.sin(math.deg2rad(45.0))) > eps) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, StaticMethodChaining) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            // Static factory -> instance method chain
+            math.Vec3 v = math.Vec3.one().scale(3.0);
+            if (v.x != 3.0) { return 1; }
+            if (v.y != 3.0) { return 2; }
+            math.Mat4 m = math.Mat4.identity().scale(2.0);
+            if (m.get(0, 0) != 2.0) { return 3; }
             return 0;
         }
     )"), 0);


### PR DESCRIPTION
Adds `Type.method()` syntax for native class static methods, eliminating the need to construct throwaway instances for factory functions.

## The problem

Native class methods always required `self` on the stack. To call a factory like `identity()` or `fromAxisAngle()`, you had to construct a dummy instance first:

```basl
// Before: awkward
array<f64> z = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
math.Mat4 dummy = math.Mat4(z);
math.Mat4 id = dummy.identity();

math.Quaternion tmp = math.Quaternion(0.0, 0.0, 0.0, 1.0);
math.Quaternion q = tmp.fromAxisAngle(axis, angle);
```

## The fix

Added `is_static` flag to `basl_native_class_method_t`. The compiler now handles `module.Class.method()` syntax:

```basl
// After: clean
math.Mat4 id = math.Mat4.identity();
math.Vec3 origin = math.Vec3.zero();
math.Quaternion q = math.Quaternion.fromAxisAngle(axis, angle);

// Chaining works too
math.Vec3 v = math.Vec3.one().scale(3.0);
```

### How it works

1. Compiler sees `module.ClassName.` followed by an identifier
2. Looks up the method in the native class descriptor, checks `is_static`
3. Pushes a hidden `class_index` constant as the first stack argument
4. Emits `CALL_NATIVE` with arg_count + 1 (for the hidden arg)
5. The C implementation reads the class index via `basl_static_class_index()`

Calling a static method on an instance is a compile error:
```
error: static method cannot be called on an instance
```

### Descriptor macros

```c
BASL_METHOD("length", 6U, fn, 0U, NULL, BASL_TYPE_F64, 1U, NULL)  // instance
BASL_STATIC("zero",   4U, fn, 0U, NULL, BASL_TYPE_OBJECT, 1U, NULL)  // static
```

## New static methods

| Class | Method | Signature |
|---|---|---|
| Vec2 | `zero()` | `→ Vec2` |
| Vec2 | `one()` | `→ Vec2` |
| Vec3 | `zero()` | `→ Vec3` |
| Vec3 | `one()` | `→ Vec3` |
| Vec4 | `zero()` | `→ Vec4` |
| Vec4 | `one()` | `→ Vec4` |
| Mat4 | `identity()` | `→ Mat4` (converted from instance) |
| Quaternion | `fromAxisAngle(Vec3, f64)` | `→ Quaternion` (converted from instance) |

## Testing
- 290/290 tests (6 new static method tests)
- ASAN+UBSAN clean
- Portability clean