### PR TITLE
Complete math stdlib with 22 new methods

### DIFF
--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -60,6 +60,8 @@ typedef struct basl_native_class_method {
     size_t return_count;
     const int *return_types;
     int is_static;              /* 1 = no self argument */
+    const char *return_class_name;      /* non-NULL: resolve to this class */
+    size_t return_class_name_length;
 } basl_native_class_method_t;
 
 typedef struct basl_native_class {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -7655,6 +7655,26 @@ static basl_status_t basl_parser_parse_native_call(
     return BASL_STATUS_OK;
 }
 
+/* Resolve the return class index for a native method.
+ * If return_class_name is set, look it up; otherwise use class_index. */
+static size_t basl_parser_resolve_return_class(
+    const basl_parser_state_t *state,
+    const basl_native_class_method_t *method,
+    size_t class_index
+) {
+    size_t k;
+    if (method->return_class_name != NULL) {
+        for (k = 0U; k < state->program->class_count; k++) {
+            if (state->program->classes[k].name_length == method->return_class_name_length &&
+                memcmp(state->program->classes[k].name, method->return_class_name,
+                       method->return_class_name_length) == 0) {
+                return k;
+            }
+        }
+    }
+    return class_index;
+}
+
 /* Parse a static method call on a native class: no self on the stack. */
 static basl_status_t basl_parser_parse_native_static_method_call(
     basl_parser_state_t *state,
@@ -7777,7 +7797,8 @@ static basl_status_t basl_parser_parse_native_static_method_call(
     if (method->return_count <= 1U) {
         if (method->return_type == BASL_TYPE_OBJECT) {
             basl_expression_result_set_type(
-                out_result, basl_binding_type_class(class_index));
+                out_result, basl_binding_type_class(
+                    basl_parser_resolve_return_class(state, method, class_index)));
         } else {
             basl_expression_result_set_type(
                 out_result,
@@ -7910,7 +7931,8 @@ static basl_status_t basl_parser_parse_native_method_call(
     if (method->return_count <= 1U) {
         if (method->return_type == BASL_TYPE_OBJECT) {
             basl_expression_result_set_type(
-                out_result, basl_binding_type_class(class_index));
+                out_result, basl_binding_type_class(
+                    basl_parser_resolve_return_class(state, method, class_index)));
         } else {
             basl_expression_result_set_type(
                 out_result,

--- a/src/stdlib/math.c
+++ b/src/stdlib/math.c
@@ -348,8 +348,17 @@ static double basl_vec_get_field(basl_vm_t *vm, size_t slot, size_t idx) {
     basl_object_t *obj = (basl_object_t *)basl_nanbox_decode_ptr(val);
     basl_value_t field;
     basl_instance_object_get_field(obj, idx, &field);
-    return basl_nanbox_decode_double(field);
+    double result = basl_nanbox_decode_double(field);
+    basl_value_release(&field);
+    return result;
 }
+
+/* Forward declarations for cross-class helpers. */
+static basl_object_t *basl_mat4_get_data(basl_vm_t *vm, size_t slot);
+static double basl_mat4_read(basl_object_t *arr, size_t idx);
+static basl_status_t basl_mat4_push_new(
+    basl_vm_t *vm, const double m[16], size_t class_index,
+    basl_error_t *error);
 
 /* Helper: push a new Vec2 instance with given x, y. */
 static basl_status_t basl_vec2_push_new(
@@ -517,16 +526,50 @@ static basl_status_t basl_vec2_reflect(
 
 /* Helper: instance method descriptor (is_static=0). */
 #define BASL_METHOD(n, nl, fn, pc, pt, rt, rc, rts) \
-    { n, nl, fn, pc, pt, rt, rc, rts, 0 }
+    { n, nl, fn, pc, pt, rt, rc, rts, 0, NULL, 0U }
 
 /* Helper: static method descriptor (is_static=1). */
 #define BASL_STATIC(n, nl, fn, pc, pt, rt, rc, rts) \
-    { n, nl, fn, pc, pt, rt, rc, rts, 1 }
+    { n, nl, fn, pc, pt, rt, rc, rts, 1, NULL, 0U }
+
+/* Helper: instance method returning a different class. */
+#define BASL_METHOD_RET(n, nl, fn, pc, pt, rt, rc, rts, cn, cnl) \
+    { n, nl, fn, pc, pt, rt, rc, rts, 0, cn, cnl }
+
+/* Helper: static method returning a different class. */
+#define BASL_STATIC_RET(n, nl, fn, pc, pt, rt, rc, rts, cn, cnl) \
+    { n, nl, fn, pc, pt, rt, rc, rts, 1, cn, cnl }
 
 /* Helper: read class_index from hidden first arg (static methods). */
 static size_t basl_static_class_index(basl_vm_t *vm, size_t base) {
     basl_value_t v = basl_vm_stack_get(vm, base);
     return (size_t)basl_nanbox_decode_i32(v);
+}
+
+/* Vec2 angle: atan2(y, x) */
+static basl_status_t basl_vec2_angle(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, atan2(y, x), error);
+}
+
+/* Vec2 rotate by angle (radians) */
+static basl_status_t basl_vec2_rotate(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    size_t ci = basl_vec_self_class(vm, base);
+    basl_value_t av = basl_vm_stack_get(vm, base + 1U);
+    double a = basl_nanbox_decode_double(av);
+    double c = cos(a), s = sin(a);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec2_push_new(vm, x*c - y*s, x*s + y*c, ci, error);
 }
 
 /* Vec2.zero() */
@@ -584,6 +627,10 @@ static const basl_native_class_method_t basl_vec2_methods[] = {
     BASL_METHOD("lerp",      4U, basl_vec2_vlerp,      2U, basl_vec_obj_f64_params,
       BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("reflect",   7U, basl_vec2_reflect,    1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("angle",     5U, basl_vec2_angle,      0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("rotate",    6U, basl_vec2_rotate,     1U, basl_vec_f64_params,
       BASL_TYPE_OBJECT, 1U, NULL),
 };
 
@@ -808,6 +855,98 @@ static const basl_native_class_field_t basl_vec3_fields[] = {
     BASL_PFIELD("z", 1U, BASL_TYPE_F64),
 };
 
+/* Vec3 transform by Mat4: result = M * [x,y,z,1], perspective divide */
+static basl_status_t basl_vec3_transform(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double x = basl_vec_get_field(vm, base, 0U);
+    double y = basl_vec_get_field(vm, base, 1U);
+    double z = basl_vec_get_field(vm, base, 2U);
+    size_t ci = basl_vec_self_class(vm, base);
+    basl_object_t *arr = basl_mat4_get_data(vm, base + 1U);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(arr, i);
+    double rx = m[0]*x + m[4]*y + m[8]*z + m[12];
+    double ry = m[1]*x + m[5]*y + m[9]*z + m[13];
+    double rz = m[2]*x + m[6]*y + m[10]*z + m[14];
+    double rw = m[3]*x + m[7]*y + m[11]*z + m[15];
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (rw != 0.0 && rw != 1.0) { rx /= rw; ry /= rw; rz /= rw; }
+    return basl_vec3_push_new(vm, rx, ry, rz, ci, error);
+}
+
+/* Vec3 rotate by Quaternion: v' = q * v * q^-1 */
+static basl_status_t basl_vec3_rotate_by_quat(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double vx = basl_vec_get_field(vm, base, 0U);
+    double vy = basl_vec_get_field(vm, base, 1U);
+    double vz = basl_vec_get_field(vm, base, 2U);
+    size_t ci = basl_vec_self_class(vm, base);
+    double qx = basl_vec_get_field(vm, base + 1U, 0U);
+    double qy = basl_vec_get_field(vm, base + 1U, 1U);
+    double qz = basl_vec_get_field(vm, base + 1U, 2U);
+    double qw = basl_vec_get_field(vm, base + 1U, 3U);
+    /* v' = v + 2*w*(u x v) + 2*(u x (u x v)) where u=(qx,qy,qz), w=qw */
+    double cx1 = qy*vz - qz*vy, cy1 = qz*vx - qx*vz, cz1 = qx*vy - qy*vx;
+    double cx2 = qy*cz1 - qz*cy1, cy2 = qz*cx1 - qx*cz1, cz2 = qx*cy1 - qy*cx1;
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_vec3_push_new(vm,
+        vx + 2.0*(qw*cx1 + cx2), vy + 2.0*(qw*cy1 + cy2),
+        vz + 2.0*(qw*cz1 + cz2), ci, error);
+}
+
+/* Vec3 unproject: screen coords -> world coords.
+ * Args: projection matrix, view matrix. */
+static basl_status_t basl_vec3_unproject(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double sx = basl_vec_get_field(vm, base, 0U);
+    double sy = basl_vec_get_field(vm, base, 1U);
+    double sz = basl_vec_get_field(vm, base, 2U);
+    size_t ci = basl_vec_self_class(vm, base);
+    basl_object_t *parr = basl_mat4_get_data(vm, base + 1U);
+    basl_object_t *varr = basl_mat4_get_data(vm, base + 2U);
+    double p[16], v[16], vp[16], inv[16];
+    size_t i; int c, r, k;
+    for (i = 0; i < 16; i++) { p[i] = basl_mat4_read(parr, i); v[i] = basl_mat4_read(varr, i); }
+    /* vp = v * p */
+    for (c = 0; c < 4; c++) for (r = 0; r < 4; r++) {
+        double sum = 0; for (k = 0; k < 4; k++) sum += v[k*4+r]*p[c*4+k]; vp[c*4+r] = sum;
+    }
+    /* invert vp (Gauss-Jordan) */
+    {
+        double aug[4][8]; int row, col, piv;
+        for (row = 0; row < 4; row++) for (col = 0; col < 4; col++) {
+            aug[row][col] = vp[col*4+row]; aug[row][col+4] = (row==col)?1.0:0.0;
+        }
+        for (piv = 0; piv < 4; piv++) {
+            int best = piv; double bv = fabs(aug[piv][piv]);
+            for (row = piv+1; row < 4; row++) if (fabs(aug[row][piv])>bv) { best=row; bv=fabs(aug[row][piv]); }
+            if (best != piv) for (col = 0; col < 8; col++) { double t=aug[piv][col]; aug[piv][col]=aug[best][col]; aug[best][col]=t; }
+            if (aug[piv][piv] == 0.0) break;
+            double d = aug[piv][piv];
+            for (col = 0; col < 8; col++) aug[piv][col] /= d;
+            for (row = 0; row < 4; row++) if (row!=piv) { double f=aug[row][piv]; for (col=0;col<8;col++) aug[row][col]-=f*aug[piv][col]; }
+        }
+        for (row = 0; row < 4; row++) for (col = 0; col < 4; col++) inv[col*4+row] = aug[row][col+4];
+    }
+    /* Normalize screen coords to [-1,1] and transform */
+    double nx = sx*2.0 - 1.0, ny = sy*2.0 - 1.0, nz = sz*2.0 - 1.0;
+    double rx = inv[0]*nx + inv[4]*ny + inv[8]*nz + inv[12];
+    double ry = inv[1]*nx + inv[5]*ny + inv[9]*nz + inv[13];
+    double rz = inv[2]*nx + inv[6]*ny + inv[10]*nz + inv[14];
+    double rw = inv[3]*nx + inv[7]*ny + inv[11]*nz + inv[15];
+    basl_vm_stack_pop_n(vm, arg_count);
+    if (rw != 0.0) { rx /= rw; ry /= rw; rz /= rw; }
+    return basl_vec3_push_new(vm, rx, ry, rz, ci, error);
+}
+
+static const int basl_vec_obj_obj_params[] = { BASL_TYPE_OBJECT, BASL_TYPE_OBJECT };
+
 /* Vec3.zero() */
 static basl_status_t basl_vec3_zero(
     basl_vm_t *vm, size_t arg_count, basl_error_t *error
@@ -858,6 +997,12 @@ static const basl_native_class_method_t basl_vec3_methods[] = {
     BASL_METHOD("lerp",      4U, basl_vec3_vlerp,      2U, basl_vec_obj_f64_params,
       BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("reflect",   7U, basl_vec3_reflect,    1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("transform", 9U, basl_vec3_transform,  1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("rotateByQuaternion", 18U, basl_vec3_rotate_by_quat, 1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("unproject", 9U, basl_vec3_unproject,  2U, basl_vec_obj_obj_params,
       BASL_TYPE_OBJECT, 1U, NULL),
 };
 
@@ -1268,6 +1413,58 @@ static const basl_native_class_field_t basl_quat_fields[] = {
     BASL_PFIELD("w", 1U, BASL_TYPE_F64),
 };
 
+/* Quaternion.fromEuler(pitch, yaw, roll) — static factory */
+static basl_status_t basl_quat_from_euler(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    double pitch = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 1U));
+    double yaw   = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 2U));
+    double roll  = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 3U));
+    double hp = pitch*0.5, hy = yaw*0.5, hr = roll*0.5;
+    double sp = sin(hp), cp = cos(hp);
+    double sy = sin(hy), cy = cos(hy);
+    double sr = sin(hr), cr = cos(hr);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_quat_push_new(vm,
+        sp*cy*cr - cp*sy*sr,
+        cp*sy*cr + sp*cy*sr,
+        cp*cy*sr - sp*sy*cr,
+        cp*cy*cr + sp*sy*sr, ci, error);
+}
+
+static const int basl_quat_f64x3_params[] = { BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64 };
+
+/* Quaternion.toMat4() — returns Mat4 */
+static basl_status_t basl_quat_to_mat4(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    double qx = basl_vec_get_field(vm, base, 0U);
+    double qy = basl_vec_get_field(vm, base, 1U);
+    double qz = basl_vec_get_field(vm, base, 2U);
+    double qw = basl_vec_get_field(vm, base, 3U);
+    /* Need Mat4 class index — find it by name */
+    basl_value_t self_val = basl_vm_stack_get(vm, base);
+    basl_object_t *inst = (basl_object_t *)basl_nanbox_decode_ptr(self_val);
+    size_t quat_ci = basl_instance_object_class_index(inst);
+    /* Mat4 is registered after Quaternion, so it's quat_ci + 1.
+     * This relies on registration order in basl_math_classes[]. */
+    size_t mat4_ci = quat_ci + 1U;
+    double xx = qx*qx, yy = qy*qy, zz = qz*qz;
+    double xy = qx*qy, xz = qx*qz, yz = qy*qz;
+    double wx = qw*qx, wy = qw*qy, wz = qw*qz;
+    double m[16] = {
+        1-2*(yy+zz), 2*(xy+wz),   2*(xz-wy),   0,
+        2*(xy-wz),   1-2*(xx+zz), 2*(yz+wx),   0,
+        2*(xz+wy),   2*(yz-wx),   1-2*(xx+yy), 0,
+        0,            0,            0,            1
+    };
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, mat4_ci, error);
+}
+
 static const basl_native_class_method_t basl_quat_methods[] = {
     BASL_METHOD("length",        6U, basl_quat_length,          0U, NULL,
       BASL_TYPE_F64, 1U, NULL),
@@ -1285,8 +1482,12 @@ static const basl_native_class_method_t basl_quat_methods[] = {
       BASL_TYPE_OBJECT, 1U, NULL),
     BASL_STATIC("fromAxisAngle", 13U, basl_quat_from_axis_angle, 2U, basl_vec_obj_f64_params,
       BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("fromEuler",    9U, basl_quat_from_euler,       3U, basl_quat_f64x3_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("toEuler",       7U, basl_quat_to_euler,        0U, NULL,
       BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD_RET("toMat4",    6U, basl_quat_to_mat4,         0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL, "Mat4", 4U),
 };
 
 /* ── Mat4 class ──────────────────────────────────────────────────── */
@@ -1487,6 +1688,245 @@ static basl_status_t basl_mat4_scale(
     return basl_mat4_push_new(vm, m, ci, error);
 }
 
+/* trace() -> f64 */
+static basl_status_t basl_mat4_trace(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    double tr = basl_mat4_read(a,0)+basl_mat4_read(a,5)+basl_mat4_read(a,10)+basl_mat4_read(a,15);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_math_push_f64(vm, tr, error);
+}
+
+/* invert() -> Mat4 (Gauss-Jordan elimination) */
+static basl_status_t basl_mat4_invert(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double aug[4][8]; int row, col, piv, best;
+    double bv, d, f, t;
+    for (row = 0; row < 4; row++) for (col = 0; col < 4; col++) {
+        aug[row][col] = basl_mat4_read(a, (size_t)(col*4+row));
+        aug[row][col+4] = (row==col)?1.0:0.0;
+    }
+    for (piv = 0; piv < 4; piv++) {
+        best = piv; bv = fabs(aug[piv][piv]);
+        for (row = piv+1; row < 4; row++) if (fabs(aug[row][piv])>bv) { best=row; bv=fabs(aug[row][piv]); }
+        if (best != piv) for (col = 0; col < 8; col++) { t=aug[piv][col]; aug[piv][col]=aug[best][col]; aug[best][col]=t; }
+        if (aug[piv][piv] == 0.0) break;
+        d = aug[piv][piv];
+        for (col = 0; col < 8; col++) aug[piv][col] /= d;
+        for (row = 0; row < 4; row++) if (row!=piv) { f=aug[row][piv]; for (col=0;col<8;col++) aug[row][col]-=f*aug[piv][col]; }
+    }
+    {
+        double m[16];
+        for (row = 0; row < 4; row++) for (col = 0; col < 4; col++) m[col*4+row] = aug[row][col+4];
+        basl_vm_stack_pop_n(vm, arg_count);
+        return basl_mat4_push_new(vm, m, ci, error);
+    }
+}
+
+/* translate(Vec3) -> Mat4: self * translation matrix */
+static basl_status_t basl_mat4_translate(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double tx = basl_vec_get_field(vm, base + 1U, 0U);
+    double ty = basl_vec_get_field(vm, base + 1U, 1U);
+    double tz = basl_vec_get_field(vm, base + 1U, 2U);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(a, i);
+    /* m = m * T where T is identity with [12,13,14] = tx,ty,tz */
+    m[12] += m[0]*tx + m[4]*ty + m[8]*tz;
+    m[13] += m[1]*tx + m[5]*ty + m[9]*tz;
+    m[14] += m[2]*tx + m[6]*ty + m[10]*tz;
+    m[15] += m[3]*tx + m[7]*ty + m[11]*tz;
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* scaleV(Vec3) -> Mat4: self * scale matrix */
+static basl_status_t basl_mat4_scale_vec(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double sx = basl_vec_get_field(vm, base + 1U, 0U);
+    double sy = basl_vec_get_field(vm, base + 1U, 1U);
+    double sz = basl_vec_get_field(vm, base + 1U, 2U);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(a, i);
+    m[0]*=sx; m[1]*=sx; m[2]*=sx; m[3]*=sx;
+    m[4]*=sy; m[5]*=sy; m[6]*=sy; m[7]*=sy;
+    m[8]*=sz; m[9]*=sz; m[10]*=sz; m[11]*=sz;
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* rotateX(angle) -> Mat4 */
+static basl_status_t basl_mat4_rotate_x(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double angle = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 1U));
+    double c = cos(angle), s = sin(angle);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(a, i);
+    /* Multiply by Rx on the right */
+    double t;
+    for (i = 0; i < 4; i++) {
+        t = m[4+i]; m[4+i] = t*c + m[8+i]*s; m[8+i] = -t*s + m[8+i]*c;
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* rotateY(angle) -> Mat4 */
+static basl_status_t basl_mat4_rotate_y(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double angle = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 1U));
+    double c = cos(angle), s = sin(angle);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(a, i);
+    double t;
+    for (i = 0; i < 4; i++) {
+        t = m[i]; m[i] = t*c - m[8+i]*s; m[8+i] = t*s + m[8+i]*c;
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* rotateZ(angle) -> Mat4 */
+static basl_status_t basl_mat4_rotate_z(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    basl_object_t *a = basl_mat4_get_data(vm, base);
+    size_t ci = basl_vec_self_class(vm, base);
+    double angle = basl_nanbox_decode_double(basl_vm_stack_get(vm, base + 1U));
+    double c = cos(angle), s = sin(angle);
+    double m[16]; size_t i;
+    for (i = 0; i < 16; i++) m[i] = basl_mat4_read(a, i);
+    double t;
+    for (i = 0; i < 4; i++) {
+        t = m[i]; m[i] = t*c + m[4+i]*s; m[4+i] = -t*s + m[4+i]*c;
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* Mat4.lookAt(eye, target, up) -> Mat4 (static) */
+static basl_status_t basl_mat4_look_at(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    double ex = basl_vec_get_field(vm, base+1U, 0U);
+    double ey = basl_vec_get_field(vm, base+1U, 1U);
+    double ez = basl_vec_get_field(vm, base+1U, 2U);
+    double tx = basl_vec_get_field(vm, base+2U, 0U);
+    double ty = basl_vec_get_field(vm, base+2U, 1U);
+    double tz = basl_vec_get_field(vm, base+2U, 2U);
+    double ux = basl_vec_get_field(vm, base+3U, 0U);
+    double uy = basl_vec_get_field(vm, base+3U, 1U);
+    double uz = basl_vec_get_field(vm, base+3U, 2U);
+    /* f = normalize(target - eye) */
+    double fx = tx-ex, fy = ty-ey, fz = tz-ez;
+    double fl = sqrt(fx*fx+fy*fy+fz*fz);
+    if (fl != 0.0) { fx/=fl; fy/=fl; fz/=fl; }
+    /* s = normalize(f x up) */
+    double sx = fy*uz-fz*uy, sy = fz*ux-fx*uz, sz = fx*uy-fy*ux;
+    double sl = sqrt(sx*sx+sy*sy+sz*sz);
+    if (sl != 0.0) { sx/=sl; sy/=sl; sz/=sl; }
+    /* u = s x f */
+    double uux = sy*fz-sz*fy, uuy = sz*fx-sx*fz, uuz = sx*fy-sy*fx;
+    double m[16] = {
+        sx,  uux, -fx, 0,
+        sy,  uuy, -fy, 0,
+        sz,  uuz, -fz, 0,
+        -(sx*ex+sy*ey+sz*ez), -(uux*ex+uuy*ey+uuz*ez), fx*ex+fy*ey+fz*ez, 1
+    };
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+static const int basl_mat4_obj3_params[] = { BASL_TYPE_OBJECT, BASL_TYPE_OBJECT, BASL_TYPE_OBJECT };
+static const int basl_mat4_f64x4_params[] = { BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64 };
+static const int basl_mat4_f64x6_params[] = { BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64, BASL_TYPE_F64 };
+
+/* Mat4.perspective(fovY, aspect, near, far) -> Mat4 (static) */
+static basl_status_t basl_mat4_perspective(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    double fovy = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+1U));
+    double aspect = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+2U));
+    double near = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+3U));
+    double far = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+4U));
+    double top = near * tan(fovy * 0.5);
+    double right = top * aspect;
+    double m[16] = {0};
+    m[0] = near / right;
+    m[5] = near / top;
+    m[10] = -(far + near) / (far - near);
+    m[11] = -1.0;
+    m[14] = -(2.0 * far * near) / (far - near);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* Mat4.ortho(left, right, bottom, top, near, far) -> Mat4 (static) */
+static basl_status_t basl_mat4_ortho(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    double l = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+1U));
+    double r = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+2U));
+    double b = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+3U));
+    double t = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+4U));
+    double n = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+5U));
+    double f = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+6U));
+    double m[16] = {0};
+    m[0] = 2.0/(r-l); m[5] = 2.0/(t-b); m[10] = -2.0/(f-n);
+    m[12] = -(r+l)/(r-l); m[13] = -(t+b)/(t-b); m[14] = -(f+n)/(f-n); m[15] = 1.0;
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
+/* Mat4.frustum(left, right, bottom, top, near, far) -> Mat4 (static) */
+static basl_status_t basl_mat4_frustum(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    size_t ci = basl_static_class_index(vm, base);
+    double l = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+1U));
+    double r = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+2U));
+    double b = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+3U));
+    double t = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+4U));
+    double n = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+5U));
+    double f = basl_nanbox_decode_double(basl_vm_stack_get(vm, base+6U));
+    double m[16] = {0};
+    m[0] = 2.0*n/(r-l); m[5] = 2.0*n/(t-b);
+    m[8] = (r+l)/(r-l); m[9] = (t+b)/(t-b); m[10] = -(f+n)/(f-n); m[11] = -1.0;
+    m[14] = -(2.0*f*n)/(f-n);
+    basl_vm_stack_pop_n(vm, arg_count);
+    return basl_mat4_push_new(vm, m, ci, error);
+}
+
 static const int basl_mat4_i32i32_params[] = { BASL_TYPE_I32, BASL_TYPE_I32 };
 static const int basl_mat4_i32i32f64_params[] = {
     BASL_TYPE_I32, BASL_TYPE_I32, BASL_TYPE_F64
@@ -1500,6 +1940,14 @@ static const basl_native_class_field_t basl_mat4_fields[] = {
 static const basl_native_class_method_t basl_mat4_methods[] = {
     BASL_STATIC("identity",    8U, basl_mat4_identity,    0U, NULL,
       BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("lookAt",      6U, basl_mat4_look_at,     3U, basl_mat4_obj3_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("perspective", 11U, basl_mat4_perspective, 4U, basl_mat4_f64x4_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("ortho",       5U, basl_mat4_ortho,       6U, basl_mat4_f64x6_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_STATIC("frustum",     7U, basl_mat4_frustum,     6U, basl_mat4_f64x6_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("get",         3U, basl_mat4_get,         2U, basl_mat4_i32i32_params,
       BASL_TYPE_F64, 1U, NULL),
     BASL_METHOD("set",         3U, basl_mat4_set,         3U, basl_mat4_i32i32f64_params,
@@ -1510,9 +1958,23 @@ static const basl_native_class_method_t basl_mat4_methods[] = {
       BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("determinant", 11U, basl_mat4_determinant, 0U, NULL,
       BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("trace",       5U, basl_mat4_trace,       0U, NULL,
+      BASL_TYPE_F64, 1U, NULL),
+    BASL_METHOD("invert",      6U, basl_mat4_invert,      0U, NULL,
+      BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("add",         3U, basl_mat4_add,         1U, basl_vec_obj_params,
       BASL_TYPE_OBJECT, 1U, NULL),
     BASL_METHOD("scale",       5U, basl_mat4_scale,       1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("scaleV",      6U, basl_mat4_scale_vec,   1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("translate",   9U, basl_mat4_translate,   1U, basl_vec_obj_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("rotateX",     7U, basl_mat4_rotate_x,    1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("rotateY",     7U, basl_mat4_rotate_y,    1U, basl_vec_f64_params,
+      BASL_TYPE_OBJECT, 1U, NULL),
+    BASL_METHOD("rotateZ",     7U, basl_mat4_rotate_z,    1U, basl_vec_f64_params,
       BASL_TYPE_OBJECT, 1U, NULL),
 };
 
@@ -1520,13 +1982,13 @@ static const basl_native_class_t basl_math_classes[] = {
     {
         "Vec2", 4U,
         basl_vec2_fields, 2U,
-        basl_vec2_methods, 13U,
+        basl_vec2_methods, 15U,
         NULL
     },
     {
         "Vec3", 4U,
         basl_vec3_fields, 3U,
-        basl_vec3_methods, 15U,
+        basl_vec3_methods, 18U,
         NULL
     },
     {
@@ -1538,13 +2000,13 @@ static const basl_native_class_t basl_math_classes[] = {
     {
         "Quaternion", 10U,
         basl_quat_fields, 4U,
-        basl_quat_methods, 9U,
+        basl_quat_methods, 11U,
         NULL
     },
     {
         "Mat4", 4U,
         basl_mat4_fields, 1U,
-        basl_mat4_methods, 8U,
+        basl_mat4_methods, 19U,
         NULL
     },
 };

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -1293,4 +1293,288 @@ TEST(BaslStdlibMathTest, StaticMethodChaining) {
     )"), 0);
 }
 
+/* ── Vec2 angle/rotate ───────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, Vec2AngleAndRotate) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec2 v = math.Vec2(1.0, 0.0);
+            if (math.abs(v.angle()) > eps) { return 1; }
+            math.Vec2 up = math.Vec2(0.0, 1.0);
+            if (math.abs(up.angle() - math.pi() / 2.0) > eps) { return 2; }
+            // rotate (1,0) by 90 degrees -> (0,1)
+            math.Vec2 r = v.rotate(math.pi() / 2.0);
+            if (math.abs(r.x) > eps) { return 3; }
+            if (math.abs(r.y - 1.0) > eps) { return 4; }
+            // rotate by 180 -> (-1, 0)
+            math.Vec2 r2 = v.rotate(math.pi());
+            if (math.abs(r2.x + 1.0) > eps) { return 5; }
+            if (math.abs(r2.y) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── Vec3 transform/rotateByQuaternion/unproject ─────────────────── */
+
+TEST(BaslStdlibMathTest, Vec3Transform) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec3 p = math.Vec3(1.0, 2.0, 3.0);
+            // Identity transform
+            math.Mat4 id = math.Mat4.identity();
+            math.Vec3 r = p.transform(id);
+            if (math.abs(r.x - 1.0) > eps) { return 1; }
+            if (math.abs(r.y - 2.0) > eps) { return 2; }
+            if (math.abs(r.z - 3.0) > eps) { return 3; }
+            // Translation
+            math.Mat4 t = id.translate(math.Vec3(10.0, 20.0, 30.0));
+            math.Vec3 r2 = p.transform(t);
+            if (math.abs(r2.x - 11.0) > eps) { return 4; }
+            if (math.abs(r2.y - 22.0) > eps) { return 5; }
+            if (math.abs(r2.z - 33.0) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec3RotateByQuaternion) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec3 fwd = math.Vec3(0.0, 0.0, 1.0);
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            // 90 deg around Y: (0,0,1) -> (1,0,0)
+            math.Quaternion q = math.Quaternion.fromAxisAngle(yaxis, math.pi() / 2.0);
+            math.Vec3 r = fwd.rotateByQuaternion(q);
+            if (math.abs(r.x - 1.0) > eps) { return 1; }
+            if (math.abs(r.y) > eps) { return 2; }
+            if (math.abs(r.z) > eps) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Vec3Unproject) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.01;
+            math.Mat4 proj = math.Mat4.perspective(math.deg2rad(90.0), 1.0, 0.1, 100.0);
+            math.Mat4 view = math.Mat4.identity();
+            // Center of screen (0.5, 0.5) at near plane (z=0)
+            math.Vec3 near = math.Vec3(0.5, 0.5, 0.0).unproject(proj, view);
+            // Should be near origin on near plane
+            if (math.abs(near.x) > eps) { return 1; }
+            if (math.abs(near.y) > eps) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── Quaternion fromEuler/toMat4 ─────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, QuaternionFromEuler) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            // Zero euler -> identity quaternion
+            math.Quaternion q0 = math.Quaternion.fromEuler(0.0, 0.0, 0.0);
+            if (math.abs(q0.w - 1.0) > eps) { return 1; }
+            if (math.abs(q0.x) > eps) { return 2; }
+            // 90 deg pitch -> unit quaternion
+            math.Quaternion qp = math.Quaternion.fromEuler(math.pi() / 2.0, 0.0, 0.0);
+            if (math.abs(qp.length() - 1.0) > eps) { return 3; }
+            // fromEuler produces unit quaternions
+            math.Quaternion q = math.Quaternion.fromEuler(0.1, 0.2, 0.3);
+            if (math.abs(q.length() - 1.0) > eps) { return 4; }
+            // 180 deg yaw: should be (0, sin(90), 0, cos(90)) = (0, 1, 0, 0)
+            math.Quaternion qy = math.Quaternion.fromEuler(0.0, math.pi(), 0.0);
+            if (math.abs(math.abs(qy.y) - 1.0) > eps) { return 5; }
+            if (math.abs(qy.x) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, QuaternionToMat4) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            // Identity quaternion -> identity matrix
+            math.Quaternion qi = math.Quaternion(0.0, 0.0, 0.0, 1.0);
+            math.Mat4 m = qi.toMat4();
+            if (math.abs(m.get(0, 0) - 1.0) > eps) { return 1; }
+            if (math.abs(m.get(1, 1) - 1.0) > eps) { return 2; }
+            if (math.abs(m.get(2, 2) - 1.0) > eps) { return 3; }
+            if (math.abs(m.get(3, 3) - 1.0) > eps) { return 4; }
+            if (math.abs(m.get(0, 1)) > eps) { return 5; }
+            // 90 deg around Y: should rotate (0,0,1) to (1,0,0)
+            math.Vec3 yaxis = math.Vec3(0.0, 1.0, 0.0);
+            math.Quaternion q90 = math.Quaternion.fromAxisAngle(yaxis, math.pi() / 2.0);
+            math.Mat4 rm = q90.toMat4();
+            math.Vec3 fwd = math.Vec3(0.0, 0.0, 1.0);
+            math.Vec3 r = fwd.transform(rm);
+            if (math.abs(r.x - 1.0) > eps) { return 6; }
+            if (math.abs(r.y) > eps) { return 7; }
+            if (math.abs(r.z) > eps) { return 8; }
+            return 0;
+        }
+    )"), 0);
+}
+
+/* ── Mat4 new methods ────────────────────────────────────────────── */
+
+TEST(BaslStdlibMathTest, Mat4Trace) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            if (math.abs(math.Mat4.identity().trace() - 4.0) > eps) { return 1; }
+            math.Mat4 s = math.Mat4.identity().scale(2.0);
+            if (math.abs(s.trace() - 8.0) > eps) { return 2; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4Invert) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            // Invert identity = identity
+            math.Mat4 id = math.Mat4.identity();
+            math.Mat4 inv = id.invert();
+            if (math.abs(inv.get(0, 0) - 1.0) > eps) { return 1; }
+            if (math.abs(inv.get(0, 1)) > eps) { return 2; }
+            // Invert scale(2) = scale(0.5)
+            math.Mat4 s = id.scale(2.0);
+            math.Mat4 si = s.invert();
+            if (math.abs(si.get(0, 0) - 0.5) > eps) { return 3; }
+            // M * M^-1 = I
+            math.Mat4 prod = s.multiply(si);
+            if (math.abs(prod.get(0, 0) - 1.0) > eps) { return 4; }
+            if (math.abs(prod.get(0, 1)) > eps) { return 5; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4TranslateAndScaleV) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Mat4 id = math.Mat4.identity();
+            // Translate
+            math.Mat4 t = id.translate(math.Vec3(10.0, 20.0, 30.0));
+            if (math.abs(t.get(0, 3) - 10.0) > eps) { return 1; }
+            if (math.abs(t.get(1, 3) - 20.0) > eps) { return 2; }
+            if (math.abs(t.get(2, 3) - 30.0) > eps) { return 3; }
+            // ScaleV
+            math.Mat4 s = id.scaleV(math.Vec3(2.0, 3.0, 4.0));
+            if (math.abs(s.get(0, 0) - 2.0) > eps) { return 4; }
+            if (math.abs(s.get(1, 1) - 3.0) > eps) { return 5; }
+            if (math.abs(s.get(2, 2) - 4.0) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4RotateXYZ) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Mat4 id = math.Mat4.identity();
+            // RotateX 90: (0,1,0) -> (0,0,1)
+            math.Mat4 rx = id.rotateX(math.pi() / 2.0);
+            math.Vec3 up = math.Vec3(0.0, 1.0, 0.0);
+            math.Vec3 r1 = up.transform(rx);
+            if (math.abs(r1.y) > eps) { return 1; }
+            if (math.abs(r1.z - 1.0) > eps) { return 2; }
+            // RotateY 90: (0,0,1) -> (1,0,0)
+            math.Mat4 ry = id.rotateY(math.pi() / 2.0);
+            math.Vec3 fwd = math.Vec3(0.0, 0.0, 1.0);
+            math.Vec3 r2 = fwd.transform(ry);
+            if (math.abs(r2.x - 1.0) > eps) { return 3; }
+            if (math.abs(r2.z) > eps) { return 4; }
+            // RotateZ 90: (1,0,0) -> (0,1,0)
+            math.Mat4 rz = id.rotateZ(math.pi() / 2.0);
+            math.Vec3 right = math.Vec3(1.0, 0.0, 0.0);
+            math.Vec3 r3 = right.transform(rz);
+            if (math.abs(r3.x) > eps) { return 5; }
+            if (math.abs(r3.y - 1.0) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4LookAt) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Vec3 eye = math.Vec3(0.0, 0.0, 5.0);
+            math.Vec3 target = math.Vec3.zero();
+            math.Vec3 up = math.Vec3(0.0, 1.0, 0.0);
+            math.Mat4 view = math.Mat4.lookAt(eye, target, up);
+            // Eye at (0,0,5) looking at origin: the view matrix should
+            // translate the eye to origin in view space
+            math.Vec3 eyeView = eye.transform(view);
+            if (math.abs(eyeView.x) > eps) { return 1; }
+            if (math.abs(eyeView.y) > eps) { return 2; }
+            // Target should be at (0,0,-5) in view space
+            math.Vec3 targetView = target.transform(view);
+            if (math.abs(targetView.x) > eps) { return 3; }
+            if (math.abs(targetView.y) > eps) { return 4; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4PerspectiveAndOrtho) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            // Perspective: 90 deg FOV, aspect 1, near 0.1, far 100
+            math.Mat4 p = math.Mat4.perspective(math.deg2rad(90.0), 1.0, 0.1, 100.0);
+            // With 90 deg FOV and aspect 1: m[0][0] = m[1][1] = 1.0
+            if (math.abs(p.get(0, 0) - 1.0) > eps) { return 1; }
+            if (math.abs(p.get(1, 1) - 1.0) > eps) { return 2; }
+            if (p.get(3, 3) != 0.0) { return 3; }
+            // Ortho: symmetric [-1,1] box
+            math.Mat4 o = math.Mat4.ortho(-1.0, 1.0, -1.0, 1.0, 0.1, 100.0);
+            if (math.abs(o.get(0, 0) - 1.0) > eps) { return 4; }
+            if (math.abs(o.get(1, 1) - 1.0) > eps) { return 5; }
+            if (math.abs(o.get(3, 3) - 1.0) > eps) { return 6; }
+            return 0;
+        }
+    )"), 0);
+}
+
+TEST(BaslStdlibMathTest, Mat4Frustum) {
+    EXPECT_EQ(RunWithStdlib(R"(
+        import "math";
+        fn main() -> i32 {
+            f64 eps = 0.000001;
+            math.Mat4 f = math.Mat4.frustum(-1.0, 1.0, -1.0, 1.0, 1.0, 100.0);
+            // Symmetric frustum: m[0][0] = 2*near/(right-left) = 2*1/2 = 1
+            if (math.abs(f.get(0, 0) - 1.0) > eps) { return 1; }
+            if (math.abs(f.get(1, 1) - 1.0) > eps) { return 2; }
+            if (f.get(3, 2) != -1.0) { return 3; }
+            return 0;
+        }
+    )"), 0);
+}
+
 }  // namespace


### PR DESCRIPTION
Finishes the math standard library with all methods needed for a complete raymath-style 3D math package.

## Summary

| Type | Before | After | New methods |
|---|---|---|---|
| Vec2 | 15 | 17 | angle, rotate |
| Vec3 | 18 | 21 | transform, rotateByQuaternion, unproject |
| Vec4 | 12 | 12 | — |
| Quaternion | 9 | 11 | fromEuler (static), toMat4 |
| Mat4 | 8 | 19 | trace, invert, translate, scaleV, rotateX/Y/Z, lookAt, perspective, ortho, frustum |
| Scalar | 35 | 35 | — |
| **Total** | **97** | **115** | **+18 methods** |

## Cross-type returns

Added `return_class_name` to the native method descriptor so methods can return a different class than their receiver. The compiler resolves the name to a class index at registration time.

```basl
// Quaternion.toMat4() returns a Mat4, not a Quaternion
math.Quaternion q = math.Quaternion.fromAxisAngle(axis, angle);
math.Mat4 rotMatrix = q.toMat4();
```

## What you can now do

```basl
import "math";

// Build a complete 3D camera + transform pipeline
math.Mat4 view = math.Mat4.lookAt(
    math.Vec3(0.0, 5.0, 10.0),  // eye
    math.Vec3.zero(),             // target
    math.Vec3(0.0, 1.0, 0.0)     // up
);
math.Mat4 proj = math.Mat4.perspective(
    math.deg2rad(60.0), 16.0/9.0, 0.1, 1000.0
);

// Transform objects
math.Mat4 model = math.Mat4.identity()
    .translate(math.Vec3(1.0, 0.0, 0.0))
    .rotateY(math.deg2rad(45.0))
    .scaleV(math.Vec3(2.0, 2.0, 2.0));

// Quaternion rotations
math.Quaternion q = math.Quaternion.fromEuler(0.0, math.pi()/4.0, 0.0);
math.Vec3 rotated = math.Vec3(0.0, 0.0, 1.0).rotateByQuaternion(q);
math.Mat4 rotMatrix = q.toMat4();

// Screen-to-world unprojection
math.Vec3 worldPos = math.Vec3(0.5, 0.5, 0.0).unproject(proj, view);
```

## Bug fix

Fixed a pre-existing memory leak in `basl_vec_get_field` — the retained copy from `basl_instance_object_get_field` was not being released after extracting the double value.

## Testing
- 303/303 tests (13 new)
- ASAN+UBSAN clean
- Portability clean