### PR TITLE
Add 9 new string methods

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -667,6 +667,15 @@ These are heavily used and part of everyday BASL style.
 | `s.substr(start, len)` | `(string, err)` |
 | `s.bytes()` | `array<u8>` |
 | `s.char_at(i)` | `(string, err)` |
+| `s.trim_left()` | `string` |
+| `s.trim_right()` | `string` |
+| `s.reverse()` | `string` |
+| `s.is_empty()` | `bool` |
+| `s.repeat(n)` | `string` |
+| `s.count(sub)` | `i32` |
+| `s.last_index_of(sub)` | `(i32, bool)` |
+| `s.trim_prefix(prefix)` | `string` |
+| `s.trim_suffix(suffix)` | `string` |
 
 ### Array
 

--- a/include/basl/chunk.h
+++ b/include/basl/chunk.h
@@ -180,7 +180,17 @@ typedef enum basl_opcode {
        Increments local by delta, compares against constant limit using
        cmp (0=LT,1=LE,2=GT,3=GE,4=NE), jumps back if true. */
     BASL_OPCODE_FORLOOP_I32 = 132,
-    BASL_OPCODE_CALL_NATIVE = 133
+    BASL_OPCODE_CALL_NATIVE = 133,
+
+    BASL_OPCODE_STRING_TRIM_LEFT = 134,
+    BASL_OPCODE_STRING_TRIM_RIGHT = 135,
+    BASL_OPCODE_STRING_REPEAT = 136,
+    BASL_OPCODE_STRING_REVERSE = 137,
+    BASL_OPCODE_STRING_IS_EMPTY = 138,
+    BASL_OPCODE_STRING_COUNT = 139,
+    BASL_OPCODE_STRING_LAST_INDEX_OF = 140,
+    BASL_OPCODE_STRING_TRIM_PREFIX = 141,
+    BASL_OPCODE_STRING_TRIM_SUFFIX = 142
 } basl_opcode_t;
 
 typedef struct basl_chunk {

--- a/src/compiler_builtins.c
+++ b/src/compiler_builtins.c
@@ -76,7 +76,11 @@ basl_status_t basl_parser_parse_string_method_call(
     if (basl_program_names_equal(method_name, method_length, "trim", 4U) ||
         basl_program_names_equal(method_name, method_length, "to_upper", 8U) ||
         basl_program_names_equal(method_name, method_length, "to_lower", 8U) ||
-        basl_program_names_equal(method_name, method_length, "bytes", 5U)) {
+        basl_program_names_equal(method_name, method_length, "bytes", 5U) ||
+        basl_program_names_equal(method_name, method_length, "trim_left", 9U) ||
+        basl_program_names_equal(method_name, method_length, "trim_right", 10U) ||
+        basl_program_names_equal(method_name, method_length, "reverse", 7U) ||
+        basl_program_names_equal(method_name, method_length, "is_empty", 8U)) {
         status = basl_parser_expect(
             state,
             BASL_TOKEN_RPAREN,
@@ -119,6 +123,50 @@ basl_status_t basl_parser_parse_string_method_call(
             );
             return BASL_STATUS_OK;
         }
+        if (basl_program_names_equal(method_name, method_length, "trim_left", 9U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_TRIM_LEFT, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_STRING)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "trim_right", 10U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_TRIM_RIGHT, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_STRING)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "reverse", 7U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_REVERSE, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_STRING)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "is_empty", 8U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_IS_EMPTY, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_BOOL)
+            );
+            return BASL_STATUS_OK;
+        }
         status = basl_program_intern_array_type(
             (basl_program_state_t *)state->program,
             basl_binding_type_primitive(BASL_TYPE_U8),
@@ -153,7 +201,11 @@ basl_status_t basl_parser_parse_string_method_call(
         basl_program_names_equal(method_name, method_length, "starts_with", 11U) ||
         basl_program_names_equal(method_name, method_length, "ends_with", 9U) ||
         basl_program_names_equal(method_name, method_length, "index_of", 8U) ||
-        basl_program_names_equal(method_name, method_length, "split", 5U)) {
+        basl_program_names_equal(method_name, method_length, "split", 5U) ||
+        basl_program_names_equal(method_name, method_length, "count", 5U) ||
+        basl_program_names_equal(method_name, method_length, "last_index_of", 13U) ||
+        basl_program_names_equal(method_name, method_length, "trim_prefix", 11U) ||
+        basl_program_names_equal(method_name, method_length, "trim_suffix", 11U)) {
         status = basl_parser_require_type(
             state,
             method_token->span,
@@ -220,6 +272,51 @@ basl_status_t basl_parser_parse_string_method_call(
                 return status;
             }
             basl_expression_result_set_type(out_result, array_type);
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "count", 5U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_COUNT, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_I32)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "last_index_of", 13U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_LAST_INDEX_OF, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_pair(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_I32),
+                basl_binding_type_primitive(BASL_TYPE_BOOL)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "trim_prefix", 11U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_TRIM_PREFIX, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_STRING)
+            );
+            return BASL_STATUS_OK;
+        }
+        if (basl_program_names_equal(method_name, method_length, "trim_suffix", 11U)) {
+            status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_TRIM_SUFFIX, method_token->span);
+            if (status != BASL_STATUS_OK) {
+                return status;
+            }
+            basl_expression_result_set_type(
+                out_result,
+                basl_binding_type_primitive(BASL_TYPE_STRING)
+            );
             return BASL_STATUS_OK;
         }
         status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_INDEX_OF, method_token->span);
@@ -369,6 +466,37 @@ basl_status_t basl_parser_parse_string_method_call(
             out_result,
             basl_binding_type_primitive(BASL_TYPE_STRING),
             basl_binding_type_primitive(BASL_TYPE_ERR)
+        );
+        return BASL_STATUS_OK;
+    }
+
+    if (basl_program_names_equal(method_name, method_length, "repeat", 6U)) {
+        status = basl_parser_require_type(
+            state,
+            method_token->span,
+            arg_result.type,
+            basl_binding_type_primitive(BASL_TYPE_I32),
+            "string repeat() argument must be i32"
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_expect(
+            state,
+            BASL_TOKEN_RPAREN,
+            "expected ')' after string method arguments",
+            NULL
+        );
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        status = basl_parser_emit_opcode(state, BASL_OPCODE_STRING_REPEAT, method_token->span);
+        if (status != BASL_STATUS_OK) {
+            return status;
+        }
+        basl_expression_result_set_type(
+            out_result,
+            basl_binding_type_primitive(BASL_TYPE_STRING)
         );
         return BASL_STATUS_OK;
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -2853,6 +2853,15 @@ basl_status_t basl_vm_execute_function(
             [BASL_OPCODE_STRING_TO_LOWER] = &&op_STRING_TO_LOWER,
             [BASL_OPCODE_STRING_TO_UPPER] = &&op_STRING_TO_UPPER,
             [BASL_OPCODE_STRING_TRIM] = &&op_STRING_TRIM,
+            [BASL_OPCODE_STRING_TRIM_LEFT] = &&op_STRING_TRIM_LEFT,
+            [BASL_OPCODE_STRING_TRIM_RIGHT] = &&op_STRING_TRIM_RIGHT,
+            [BASL_OPCODE_STRING_REPEAT] = &&op_STRING_REPEAT,
+            [BASL_OPCODE_STRING_REVERSE] = &&op_STRING_REVERSE,
+            [BASL_OPCODE_STRING_IS_EMPTY] = &&op_STRING_IS_EMPTY,
+            [BASL_OPCODE_STRING_COUNT] = &&op_STRING_COUNT,
+            [BASL_OPCODE_STRING_LAST_INDEX_OF] = &&op_STRING_LAST_INDEX_OF,
+            [BASL_OPCODE_STRING_TRIM_PREFIX] = &&op_STRING_TRIM_PREFIX,
+            [BASL_OPCODE_STRING_TRIM_SUFFIX] = &&op_STRING_TRIM_SUFFIX,
             [BASL_OPCODE_SUBTRACT] = &&op_SUBTRACT,
             [BASL_OPCODE_TO_F64] = &&op_TO_F64,
             [BASL_OPCODE_TO_I32] = &&op_TO_I32,
@@ -5077,6 +5086,343 @@ basl_status_t basl_vm_execute_function(
                     goto cleanup;
                 }
                 VM_BREAK();
+
+            /* ── New string methods ──────────────────────────────── */
+
+            VM_CASE(STRING_TRIM_LEFT)
+            VM_CASE(STRING_TRIM_RIGHT) {
+                basl_opcode_t string_opcode = (basl_opcode_t)code[frame->ip];
+                const char *text;
+                size_t length;
+
+                frame->ip += 1U;
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string method requires a string receiver", error
+                    );
+                    goto cleanup;
+                }
+
+                if (string_opcode == BASL_OPCODE_STRING_TRIM_LEFT) {
+                    size_t start = 0U;
+                    while (start < length && isspace((unsigned char)text[start])) {
+                        start += 1U;
+                    }
+                    status = basl_vm_new_string_value(
+                        vm, text + start, length - start, &value, error
+                    );
+                } else {
+                    size_t end = length;
+                    while (end > 0U && isspace((unsigned char)text[end - 1U])) {
+                        end -= 1U;
+                    }
+                    status = basl_vm_new_string_value(vm, text, end, &value, error);
+                }
+                if (status != BASL_STATUS_OK) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    goto cleanup;
+                }
+                BASL_VM_VALUE_RELEASE(&left);
+                status = basl_vm_push(vm, &value, error);
+                BASL_VM_VALUE_RELEASE(&value);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_REVERSE) {
+                const char *text;
+                size_t length;
+
+                frame->ip += 1U;
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string method requires a string receiver", error
+                    );
+                    goto cleanup;
+                }
+
+                {
+                    void *memory = NULL;
+                    char *buffer;
+                    size_t i;
+
+                    status = basl_runtime_alloc(vm->runtime, length + 1U, &memory, error);
+                    if (status == BASL_STATUS_OK) {
+                        buffer = (char *)memory;
+                        for (i = 0U; i < length; i += 1U) {
+                            buffer[i] = text[length - 1U - i];
+                        }
+                        buffer[length] = '\0';
+                        status = basl_vm_new_string_value(vm, buffer, length, &value, error);
+                        basl_runtime_free(vm->runtime, &memory);
+                    }
+                }
+                if (status != BASL_STATUS_OK) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    goto cleanup;
+                }
+                BASL_VM_VALUE_RELEASE(&left);
+                status = basl_vm_push(vm, &value, error);
+                BASL_VM_VALUE_RELEASE(&value);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_IS_EMPTY) {
+                const char *text;
+                size_t length;
+
+                frame->ip += 1U;
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string method requires a string receiver", error
+                    );
+                    goto cleanup;
+                }
+
+                BASL_VM_VALUE_RELEASE(&left);
+                basl_value_init_bool(&value, length == 0U);
+                status = basl_vm_push(vm, &value, error);
+                BASL_VM_VALUE_RELEASE(&value);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_REPEAT) {
+                const char *text;
+                size_t length;
+                int64_t count;
+
+                frame->ip += 1U;
+                right = basl_vm_pop_or_nil(vm);
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &length) ||
+                    !basl_nanbox_is_int(right)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string repeat() requires an i32 count", error
+                    );
+                    goto cleanup;
+                }
+
+                count = basl_value_as_int(&right);
+                BASL_VM_VALUE_RELEASE(&right);
+
+                if (count <= 0) {
+                    status = basl_vm_new_string_value(vm, "", 0U, &value, error);
+                } else {
+                    size_t total = length * (size_t)count;
+                    void *memory = NULL;
+                    char *buffer;
+                    int64_t i;
+
+                    status = basl_runtime_alloc(vm->runtime, total + 1U, &memory, error);
+                    if (status == BASL_STATUS_OK) {
+                        buffer = (char *)memory;
+                        for (i = 0; i < count; i += 1) {
+                            memcpy(buffer + (size_t)i * length, text, length);
+                        }
+                        buffer[total] = '\0';
+                        status = basl_vm_new_string_value(vm, buffer, total, &value, error);
+                        basl_runtime_free(vm->runtime, &memory);
+                    }
+                }
+                if (status != BASL_STATUS_OK) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    goto cleanup;
+                }
+                BASL_VM_VALUE_RELEASE(&left);
+                status = basl_vm_push(vm, &value, error);
+                BASL_VM_VALUE_RELEASE(&value);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_COUNT) {
+                const char *text;
+                size_t text_length;
+                const char *needle;
+                size_t needle_length;
+
+                frame->ip += 1U;
+                right = basl_vm_pop_or_nil(vm);
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &text_length) ||
+                    !basl_vm_get_string_parts(&right, &needle, &needle_length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string count() requires a string argument", error
+                    );
+                    goto cleanup;
+                }
+
+                {
+                    int64_t n = 0;
+                    if (needle_length > 0U && needle_length <= text_length) {
+                        const char *p = text;
+                        const char *end = text + text_length;
+                        while (p <= end - needle_length) {
+                            if (memcmp(p, needle, needle_length) == 0) {
+                                n += 1;
+                                p += needle_length;
+                            } else {
+                                p += 1;
+                            }
+                        }
+                    }
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    basl_value_init_int(&value, n);
+                    status = basl_vm_push(vm, &value, error);
+                    BASL_VM_VALUE_RELEASE(&value);
+                    if (status != BASL_STATUS_OK) {
+                        goto cleanup;
+                    }
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_LAST_INDEX_OF) {
+                const char *text;
+                size_t text_length;
+                const char *needle;
+                size_t needle_length;
+
+                frame->ip += 1U;
+                right = basl_vm_pop_or_nil(vm);
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &text_length) ||
+                    !basl_vm_get_string_parts(&right, &needle, &needle_length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string last_index_of() requires a string argument", error
+                    );
+                    goto cleanup;
+                }
+
+                {
+                    int64_t found_index = -1;
+                    if (needle_length > 0U && needle_length <= text_length) {
+                        size_t i = text_length - needle_length;
+                        for (;;) {
+                            if (memcmp(text + i, needle, needle_length) == 0) {
+                                found_index = (int64_t)i;
+                                break;
+                            }
+                            if (i == 0U) break;
+                            i -= 1U;
+                        }
+                    }
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    basl_value_init_int(&value, found_index >= 0 ? found_index : 0);
+                    status = basl_vm_push(vm, &value, error);
+                    if (status == BASL_STATUS_OK) {
+                        basl_value_t found_val;
+                        basl_value_init_bool(&found_val, found_index >= 0);
+                        status = basl_vm_push(vm, &found_val, error);
+                        BASL_VM_VALUE_RELEASE(&found_val);
+                    }
+                    BASL_VM_VALUE_RELEASE(&value);
+                    if (status != BASL_STATUS_OK) {
+                        goto cleanup;
+                    }
+                }
+                VM_BREAK();
+            }
+
+            VM_CASE(STRING_TRIM_PREFIX)
+            VM_CASE(STRING_TRIM_SUFFIX) {
+                basl_opcode_t string_opcode = (basl_opcode_t)code[frame->ip];
+                const char *text;
+                size_t text_length;
+                const char *prefix;
+                size_t prefix_length;
+
+                frame->ip += 1U;
+                right = basl_vm_pop_or_nil(vm);
+                left = basl_vm_pop_or_nil(vm);
+
+                if (!basl_vm_get_string_parts(&left, &text, &text_length) ||
+                    !basl_vm_get_string_parts(&right, &prefix, &prefix_length)) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    status = basl_vm_fail_at_ip(
+                        vm, BASL_STATUS_INVALID_ARGUMENT,
+                        "string method requires a string argument", error
+                    );
+                    goto cleanup;
+                }
+
+                if (string_opcode == BASL_OPCODE_STRING_TRIM_PREFIX) {
+                    if (prefix_length <= text_length &&
+                        memcmp(text, prefix, prefix_length) == 0) {
+                        status = basl_vm_new_string_value(
+                            vm, text + prefix_length,
+                            text_length - prefix_length, &value, error
+                        );
+                    } else {
+                        status = basl_vm_new_string_value(
+                            vm, text, text_length, &value, error
+                        );
+                    }
+                } else {
+                    if (prefix_length <= text_length &&
+                        memcmp(text + text_length - prefix_length,
+                               prefix, prefix_length) == 0) {
+                        status = basl_vm_new_string_value(
+                            vm, text, text_length - prefix_length, &value, error
+                        );
+                    } else {
+                        status = basl_vm_new_string_value(
+                            vm, text, text_length, &value, error
+                        );
+                    }
+                }
+                if (status != BASL_STATUS_OK) {
+                    BASL_VM_VALUE_RELEASE(&left);
+                    BASL_VM_VALUE_RELEASE(&right);
+                    goto cleanup;
+                }
+                BASL_VM_VALUE_RELEASE(&left);
+                BASL_VM_VALUE_RELEASE(&right);
+                status = basl_vm_push(vm, &value, error);
+                BASL_VM_VALUE_RELEASE(&value);
+                if (status != BASL_STATUS_OK) {
+                    goto cleanup;
+                }
+                VM_BREAK();
+            }
+
             VM_CASE(GET_MAP_KEY_AT)
                 frame->ip += 1U;
                 right = basl_vm_pop_or_nil(vm);

--- a/tests/stdlib_test.cpp
+++ b/tests/stdlib_test.cpp
@@ -1577,4 +1577,110 @@ TEST(BaslStdlibMathTest, Mat4Frustum) {
     )"), 0);
 }
 
+/* ── String trim_left / trim_right ────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, TrimLeftAndTrimRight) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    string s = "  hello  ";
+    if (s.trim_left() != "hello  ") { return 1; }
+    if (s.trim_right() != "  hello") { return 2; }
+    if ("nowhitespace".trim_left() != "nowhitespace") { return 3; }
+    if ("nowhitespace".trim_right() != "nowhitespace") { return 4; }
+    if ("   ".trim_left() != "") { return 5; }
+    if ("   ".trim_right() != "") { return 6; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String reverse ──────────────────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, Reverse) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    if ("hello".reverse() != "olleh") { return 1; }
+    if ("".reverse() != "") { return 2; }
+    if ("a".reverse() != "a") { return 3; }
+    if ("abcd".reverse() != "dcba") { return 4; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String is_empty ─────────────────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, IsEmpty) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    if ("".is_empty() != true) { return 1; }
+    if ("x".is_empty() != false) { return 2; }
+    if (" ".is_empty() != false) { return 3; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String repeat ───────────────────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, Repeat) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    if ("abc".repeat(i32(3)) != "abcabcabc") { return 1; }
+    if ("x".repeat(i32(0)) != "") { return 2; }
+    if ("hi".repeat(i32(1)) != "hi") { return 3; }
+    if ("".repeat(i32(5)) != "") { return 4; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String count ────────────────────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, Count) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    if ("abcabcabc".count("abc") != i32(3)) { return 1; }
+    if ("hello".count("x") != i32(0)) { return 2; }
+    if ("aaa".count("a") != i32(3)) { return 3; }
+    if ("aaaa".count("aa") != i32(2)) { return 4; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String last_index_of ────────────────────────────────────────── */
+
+TEST(BaslStdlibStringTest, LastIndexOf) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    i32 idx, bool found = "hello world".last_index_of("o");
+    if (idx != i32(7)) { return 1; }
+    if (found != true) { return 2; }
+    i32 idx2, bool found2 = "hello".last_index_of("xyz");
+    if (found2 != false) { return 3; }
+    i32 idx3, bool found3 = "abcabc".last_index_of("abc");
+    if (idx3 != i32(3)) { return 4; }
+    if (found3 != true) { return 5; }
+    return 0;
+}
+    )"), 0);
+}
+
+/* ── String trim_prefix / trim_suffix ────────────────────────────── */
+
+TEST(BaslStdlibStringTest, TrimPrefixAndTrimSuffix) {
+    EXPECT_EQ(RunWithStdlib(R"(
+fn main() -> i32 {
+    if ("hello world".trim_prefix("hello ") != "world") { return 1; }
+    if ("hello world".trim_suffix(" world") != "hello") { return 2; }
+    if ("hello".trim_prefix("xyz") != "hello") { return 3; }
+    if ("hello".trim_suffix("xyz") != "hello") { return 4; }
+    if ("hello".trim_prefix("hello") != "") { return 5; }
+    if ("hello".trim_suffix("hello") != "") { return 6; }
+    return 0;
+}
+    )"), 0);
+}
+
 }  // namespace


### PR DESCRIPTION
Adds batteries-included string support with 9 new methods, bringing the total from 13 to 22.

## New Methods

| Method | Returns | Description |
|---|---|---|
| `s.trim_left()` | `string` | Strip leading whitespace |
| `s.trim_right()` | `string` | Strip trailing whitespace |
| `s.reverse()` | `string` | Reverse the string |
| `s.is_empty()` | `bool` | True if length is zero |
| `s.repeat(n)` | `string` | Repeat string N times |
| `s.count(sub)` | `i32` | Count non-overlapping occurrences |
| `s.last_index_of(sub)` | `(i32, bool)` | Find last occurrence |
| `s.trim_prefix(prefix)` | `string` | Strip specific prefix (no-op if absent) |
| `s.trim_suffix(suffix)` | `string` | Strip specific suffix (no-op if absent) |

## Complete String API (22 methods)

| Method | Returns |
|---|---|
| `s.len()` | `i32` |
| `s.contains(sub)` | `bool` |
| `s.starts_with(prefix)` | `bool` |
| `s.ends_with(suffix)` | `bool` |
| `s.trim()` | `string` |
| `s.trim_left()` | `string` |
| `s.trim_right()` | `string` |
| `s.trim_prefix(prefix)` | `string` |
| `s.trim_suffix(suffix)` | `string` |
| `s.to_upper()` | `string` |
| `s.to_lower()` | `string` |
| `s.replace(old, new)` | `string` |
| `s.split(sep)` | `array<string>` |
| `s.index_of(sub)` | `(i32, bool)` |
| `s.last_index_of(sub)` | `(i32, bool)` |
| `s.count(sub)` | `i32` |
| `s.substr(start, len)` | `(string, err)` |
| `s.char_at(i)` | `(string, err)` |
| `s.bytes()` | `array<u8>` |
| `s.reverse()` | `string` |
| `s.is_empty()` | `bool` |
| `s.repeat(n)` | `string` |

## Implementation

Each method is a dedicated VM opcode (134-142), with compiler support in `compiler_builtins.c` and VM execution in `vm.c`. This follows the same pattern as the existing 13 string methods.

## Testing
- 310/310 tests (7 new)
- ASAN+UBSAN clean
- Portability clean