### PR TITLE
Add debug info infrastructure for debugger and LSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(basl_core OBJECT
     src/checker.c
     src/chunk.c
     src/compiler.c
+    src/debug_info.c
     src/compiler_program.c
     src/compiler_builtins.c
     src/compiler_strings.c
@@ -140,6 +141,7 @@ if(BASL_BUILD_TESTS)
         tests/checker_test.cpp
         tests/chunk_test.cpp
         tests/compiler_test.cpp
+        tests/debug_info_test.cpp
         tests/diagnostic_test.cpp
         tests/lexer_test.cpp
         tests/log_test.cpp

--- a/include/basl/chunk.h
+++ b/include/basl/chunk.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "basl/array.h"
+#include "basl/debug_info.h"
 #include "basl/export.h"
 #include "basl/source.h"
 #include "basl/status.h"
@@ -202,6 +203,7 @@ typedef struct basl_chunk {
     basl_value_t *constants;
     size_t constant_count;
     size_t constant_capacity;
+    basl_debug_local_table_t debug_locals;
 } basl_chunk_t;
 
 BASL_API void basl_chunk_init(basl_chunk_t *chunk, basl_runtime_t *runtime);

--- a/include/basl/debug_info.h
+++ b/include/basl/debug_info.h
@@ -1,0 +1,121 @@
+#ifndef BASL_DEBUG_INFO_H
+#define BASL_DEBUG_INFO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "basl/export.h"
+#include "basl/runtime.h"
+#include "basl/source.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Per-chunk local variable debug info ─────────────────────────── */
+
+typedef struct basl_debug_local {
+    const char *name;
+    size_t name_length;
+    size_t slot;
+    size_t scope_start_ip;  /* IP when local comes into scope */
+    size_t scope_end_ip;    /* IP when local goes out of scope */
+} basl_debug_local_t;
+
+typedef struct basl_debug_local_table {
+    basl_runtime_t *runtime;
+    basl_debug_local_t *locals;
+    size_t count;
+    size_t capacity;
+} basl_debug_local_table_t;
+
+BASL_API void basl_debug_local_table_init(
+    basl_debug_local_table_t *table,
+    basl_runtime_t *runtime
+);
+BASL_API void basl_debug_local_table_free(basl_debug_local_table_t *table);
+BASL_API basl_status_t basl_debug_local_table_add(
+    basl_debug_local_table_t *table,
+    const char *name,
+    size_t name_length,
+    size_t slot,
+    size_t scope_start_ip,
+    basl_error_t *error
+);
+BASL_API void basl_debug_local_table_close_scope(
+    basl_debug_local_table_t *table,
+    size_t min_slot,
+    size_t scope_end_ip
+);
+BASL_API const basl_debug_local_t *basl_debug_local_table_find(
+    const basl_debug_local_table_t *table,
+    size_t ip
+);
+BASL_API size_t basl_debug_local_table_count(
+    const basl_debug_local_table_t *table
+);
+BASL_API const basl_debug_local_t *basl_debug_local_table_get(
+    const basl_debug_local_table_t *table,
+    size_t index
+);
+
+/* ── Program-level symbol table ──────────────────────────────────── */
+
+typedef enum basl_debug_symbol_kind {
+    BASL_DEBUG_SYMBOL_FUNCTION = 0,
+    BASL_DEBUG_SYMBOL_CLASS = 1,
+    BASL_DEBUG_SYMBOL_INTERFACE = 2,
+    BASL_DEBUG_SYMBOL_ENUM = 3,
+    BASL_DEBUG_SYMBOL_ENUM_MEMBER = 4,
+    BASL_DEBUG_SYMBOL_FIELD = 5,
+    BASL_DEBUG_SYMBOL_METHOD = 6,
+    BASL_DEBUG_SYMBOL_GLOBAL_CONST = 7,
+    BASL_DEBUG_SYMBOL_GLOBAL_VAR = 8
+} basl_debug_symbol_kind_t;
+
+typedef struct basl_debug_symbol {
+    basl_debug_symbol_kind_t kind;
+    const char *name;
+    size_t name_length;
+    basl_source_span_t span;
+    int is_public;
+    size_t parent_index;    /* index of owning class/interface/enum, or SIZE_MAX */
+} basl_debug_symbol_t;
+
+typedef struct basl_debug_symbol_table {
+    basl_runtime_t *runtime;
+    basl_debug_symbol_t *symbols;
+    size_t count;
+    size_t capacity;
+} basl_debug_symbol_table_t;
+
+BASL_API void basl_debug_symbol_table_init(
+    basl_debug_symbol_table_t *table,
+    basl_runtime_t *runtime
+);
+BASL_API void basl_debug_symbol_table_free(
+    basl_debug_symbol_table_t *table
+);
+BASL_API basl_status_t basl_debug_symbol_table_add(
+    basl_debug_symbol_table_t *table,
+    basl_debug_symbol_kind_t kind,
+    const char *name,
+    size_t name_length,
+    basl_source_span_t span,
+    int is_public,
+    size_t parent_index,
+    basl_error_t *error
+);
+BASL_API size_t basl_debug_symbol_table_count(
+    const basl_debug_symbol_table_t *table
+);
+BASL_API const basl_debug_symbol_t *basl_debug_symbol_table_get(
+    const basl_debug_symbol_table_t *table,
+    size_t index
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/basl/native_module.h
+++ b/include/basl/native_module.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 
+#include "basl/debug_info.h"
 #include "basl/diagnostic.h"
 #include "basl/export.h"
 #include "basl/runtime.h"
@@ -126,6 +127,23 @@ BASL_API basl_status_t basl_compile_source_with_natives(
     const basl_native_registry_t *natives,
     basl_object_t **out_function,
     basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+);
+
+/**
+ * Compile with debug symbol table output.
+ * If out_symbols is non-NULL, it will be populated with all program-level
+ * symbol definitions (functions, classes, interfaces, enums, fields,
+ * methods, globals). The caller must free it with
+ * basl_debug_symbol_table_free().
+ */
+BASL_API basl_status_t basl_compile_source_with_debug_info(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_debug_symbol_table_t *out_symbols,
     basl_error_t *error
 );
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -362,6 +362,7 @@ void basl_chunk_init(basl_chunk_t *chunk, basl_runtime_t *runtime) {
     memset(chunk, 0, sizeof(*chunk));
     chunk->runtime = runtime;
     basl_byte_buffer_init(&chunk->code, runtime);
+    basl_debug_local_table_init(&chunk->debug_locals, runtime);
 }
 
 void basl_chunk_clear(basl_chunk_t *chunk) {
@@ -399,6 +400,8 @@ void basl_chunk_free(basl_chunk_t *chunk) {
     if (chunk->runtime != NULL) {
         basl_runtime_free(chunk->runtime, &memory);
     }
+
+    basl_debug_local_table_free(&chunk->debug_locals);
 
     memset(chunk, 0, sizeof(*chunk));
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -6187,6 +6187,7 @@ static basl_status_t basl_parser_declare_local_symbol(
     basl_status_t status;
     const char *name;
     size_t name_length;
+    size_t slot;
 
     name = basl_parser_token_text(state, name_token, &name_length);
     status = basl_binding_scope_stack_declare_local(
@@ -6205,8 +6206,22 @@ static basl_status_t basl_parser_declare_local_symbol(
             "local variable is already declared in this scope"
         );
     }
+    if (status != BASL_STATUS_OK) {
+        return status;
+    }
 
-    return status;
+    /* Record debug info for this local. */
+    slot = basl_binding_scope_stack_count(&state->locals) - 1U;
+    (void)basl_debug_local_table_add(
+        &state->chunk.debug_locals,
+        name,
+        name_length,
+        slot,
+        basl_chunk_code_size(&state->chunk),
+        state->program->error
+    );
+
+    return BASL_STATUS_OK;
 }
 
 static int basl_parser_token_is_discard_identifier(
@@ -6965,12 +6980,25 @@ static basl_status_t basl_parser_end_scope(basl_parser_state_t *state) {
     basl_source_span_t span;
     size_t popped_count;
     size_t index;
+    size_t locals_before;
+    size_t end_ip;
 
     if (basl_binding_scope_stack_depth(&state->locals) == 0U) {
         return BASL_STATUS_OK;
     }
 
+    locals_before = basl_binding_scope_stack_count(&state->locals);
     basl_binding_scope_stack_end_scope(&state->locals, &popped_count);
+
+    end_ip = basl_chunk_code_size(&state->chunk);
+    if (popped_count > 0U) {
+        basl_debug_local_table_close_scope(
+            &state->chunk.debug_locals,
+            locals_before - popped_count,
+            end_ip
+        );
+    }
+
     for (index = 0U; index < popped_count; index += 1U) {
         span = basl_parser_fallback_span(state);
         status = basl_parser_emit_opcode(state, BASL_OPCODE_POP, span);
@@ -15275,4 +15303,198 @@ basl_status_t basl_compile_source_with_natives(
         diagnostics,
         error
     );
+}
+
+/* ── Debug symbol table extraction ───────────────────────────────── */
+
+static basl_status_t basl_compile_emit_symbols(
+    const basl_program_state_t *program,
+    basl_debug_symbol_table_t *out_symbols,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    size_t i;
+    size_t j;
+    size_t class_sym_index;
+
+    if (out_symbols == NULL) return BASL_STATUS_OK;
+
+    /* Functions. */
+    for (i = 0U; i < program->functions.count; i += 1U) {
+        const basl_binding_function_t *fn = &program->functions.functions[i];
+        if (fn->is_local) continue;
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_FUNCTION,
+            fn->name, fn->name_length, fn->name_span,
+            fn->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+    }
+
+    /* Classes with fields and methods. */
+    for (i = 0U; i < program->class_count; i += 1U) {
+        const basl_class_decl_t *cls = &program->classes[i];
+        if (cls->native_class != NULL) continue;
+        class_sym_index = out_symbols->count;
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_CLASS,
+            cls->name, cls->name_length, cls->name_span,
+            cls->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+        for (j = 0U; j < cls->field_count; j += 1U) {
+            const basl_class_field_t *f = &cls->fields[j];
+            status = basl_debug_symbol_table_add(
+                out_symbols, BASL_DEBUG_SYMBOL_FIELD,
+                f->name, f->name_length, f->name_span,
+                f->is_public, class_sym_index, error
+            );
+            if (status != BASL_STATUS_OK) return status;
+        }
+        for (j = 0U; j < cls->method_count; j += 1U) {
+            const basl_class_method_t *m = &cls->methods[j];
+            status = basl_debug_symbol_table_add(
+                out_symbols, BASL_DEBUG_SYMBOL_METHOD,
+                m->name, m->name_length, m->name_span,
+                m->is_public, class_sym_index, error
+            );
+            if (status != BASL_STATUS_OK) return status;
+        }
+    }
+
+    /* Interfaces. */
+    for (i = 0U; i < program->interface_count; i += 1U) {
+        const basl_interface_decl_t *iface = &program->interfaces[i];
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_INTERFACE,
+            iface->name, iface->name_length, iface->name_span,
+            iface->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+    }
+
+    /* Enums with members. */
+    for (i = 0U; i < program->enum_count; i += 1U) {
+        const basl_enum_decl_t *en = &program->enums[i];
+        size_t enum_sym_index = out_symbols->count;
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_ENUM,
+            en->name, en->name_length, en->name_span,
+            en->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+        for (j = 0U; j < en->member_count; j += 1U) {
+            const basl_enum_member_t *m = &en->members[j];
+            status = basl_debug_symbol_table_add(
+                out_symbols, BASL_DEBUG_SYMBOL_ENUM_MEMBER,
+                m->name, m->name_length, m->name_span,
+                1, enum_sym_index, error
+            );
+            if (status != BASL_STATUS_OK) return status;
+        }
+    }
+
+    /* Global constants. */
+    for (i = 0U; i < program->constant_count; i += 1U) {
+        const basl_global_constant_t *c = &program->constants[i];
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_GLOBAL_CONST,
+            c->name, c->name_length, c->name_span,
+            c->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+    }
+
+    /* Global variables. */
+    for (i = 0U; i < program->global_count; i += 1U) {
+        const basl_global_variable_t *g = &program->globals[i];
+        status = basl_debug_symbol_table_add(
+            out_symbols, BASL_DEBUG_SYMBOL_GLOBAL_VAR,
+            g->name, g->name_length, g->name_span,
+            g->is_public, SIZE_MAX, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+    }
+
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_compile_source_with_debug_info(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_debug_symbol_table_t *out_symbols,
+    basl_error_t *error
+) {
+    basl_status_t status;
+    basl_program_state_t program;
+    const basl_source_file_t *source;
+
+    basl_error_clear(error);
+    if (out_function != NULL) {
+        *out_function = NULL;
+    }
+
+    status = basl_compile_validate_inputs(
+        registry, diagnostics, out_function,
+        BASL_COMPILE_MODE_BUILD_ENTRYPOINT, error
+    );
+    if (status != BASL_STATUS_OK) return status;
+
+    source = basl_source_registry_get(registry, source_id);
+    if (source == NULL) {
+        basl_error_set_literal(
+            error, BASL_STATUS_INVALID_ARGUMENT,
+            "source_id must reference a registered source file"
+        );
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    memset(&program, 0, sizeof(program));
+    program.registry = registry;
+    program.diagnostics = diagnostics;
+    program.error = error;
+    program.natives = natives;
+    basl_binding_function_table_init(&program.functions, registry->runtime);
+    basl_program_set_module_context(&program, source, NULL);
+
+    status = basl_program_parse_source(&program, source_id);
+    if (status != BASL_STATUS_OK) {
+        basl_program_free(&program);
+        return status;
+    }
+
+    basl_program_set_module_context(&program, source, NULL);
+    if (!program.functions.has_main) {
+        status = basl_compile_report(
+            &program, basl_program_eof_span(&program),
+            "expected top-level function 'main'"
+        );
+        basl_program_free(&program);
+        return status;
+    }
+
+    status = basl_compile_all_functions(&program);
+    if (status != BASL_STATUS_OK) {
+        basl_program_free(&program);
+        return status;
+    }
+
+    /* Extract symbols before freeing the program state. */
+    status = basl_compile_emit_symbols(&program, out_symbols, error);
+    if (status != BASL_STATUS_OK) {
+        basl_program_free(&program);
+        return status;
+    }
+
+    status = basl_compile_attach_entrypoint(&program, out_function);
+    if (status != BASL_STATUS_OK) {
+        basl_program_free(&program);
+        return status;
+    }
+
+    basl_program_free(&program);
+    return BASL_STATUS_OK;
 }

--- a/src/debug_info.c
+++ b/src/debug_info.c
@@ -1,0 +1,208 @@
+/* BASL debug info: local variable tables and program symbol tables.
+ *
+ * Used by debuggers (variable inspection) and LSP (go-to-definition,
+ * find-references, hover).
+ */
+#include <string.h>
+
+#include "basl/debug_info.h"
+#include "basl/status.h"
+
+/* ── Local variable table ────────────────────────────────────────── */
+
+void basl_debug_local_table_init(
+    basl_debug_local_table_t *table,
+    basl_runtime_t *runtime
+) {
+    if (table == NULL) return;
+    memset(table, 0, sizeof(*table));
+    table->runtime = runtime;
+}
+
+void basl_debug_local_table_free(basl_debug_local_table_t *table) {
+    void *memory;
+    if (table == NULL) return;
+    if (table->locals != NULL) {
+        memory = table->locals;
+        basl_runtime_free(table->runtime, &memory);
+        table->locals = NULL;
+    }
+    table->count = 0U;
+    table->capacity = 0U;
+}
+
+basl_status_t basl_debug_local_table_add(
+    basl_debug_local_table_t *table,
+    const char *name,
+    size_t name_length,
+    size_t slot,
+    size_t scope_start_ip,
+    basl_error_t *error
+) {
+    basl_debug_local_t *entry;
+
+    if (table == NULL) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (table->count >= table->capacity) {
+        size_t new_cap = table->capacity == 0U ? 8U : table->capacity * 2U;
+        void *memory = NULL;
+        basl_status_t status = basl_runtime_alloc(
+            table->runtime,
+            new_cap * sizeof(basl_debug_local_t),
+            &memory,
+            error
+        );
+        if (status != BASL_STATUS_OK) return status;
+        if (table->locals != NULL) {
+            memcpy(memory, table->locals,
+                   table->count * sizeof(basl_debug_local_t));
+            void *old = table->locals;
+            basl_runtime_free(table->runtime, &old);
+        }
+        table->locals = (basl_debug_local_t *)memory;
+        table->capacity = new_cap;
+    }
+
+    entry = &table->locals[table->count];
+    entry->name = name;
+    entry->name_length = name_length;
+    entry->slot = slot;
+    entry->scope_start_ip = scope_start_ip;
+    entry->scope_end_ip = SIZE_MAX;  /* open until closed */
+    table->count += 1U;
+    return BASL_STATUS_OK;
+}
+
+void basl_debug_local_table_close_scope(
+    basl_debug_local_table_t *table,
+    size_t min_slot,
+    size_t scope_end_ip
+) {
+    size_t i;
+    if (table == NULL) return;
+    for (i = table->count; i > 0U; i -= 1U) {
+        basl_debug_local_t *entry = &table->locals[i - 1U];
+        if (entry->scope_end_ip != SIZE_MAX) continue;
+        if (entry->slot < min_slot) break;
+        entry->scope_end_ip = scope_end_ip;
+    }
+}
+
+const basl_debug_local_t *basl_debug_local_table_find(
+    const basl_debug_local_table_t *table,
+    size_t ip
+) {
+    /* Returns the first local whose scope contains the given IP.
+     * For a full list, callers should iterate with _get/_count. */
+    size_t i;
+    if (table == NULL) return NULL;
+    for (i = 0U; i < table->count; i += 1U) {
+        const basl_debug_local_t *entry = &table->locals[i];
+        if (ip >= entry->scope_start_ip && ip < entry->scope_end_ip) {
+            return entry;
+        }
+    }
+    return NULL;
+}
+
+size_t basl_debug_local_table_count(
+    const basl_debug_local_table_t *table
+) {
+    return table != NULL ? table->count : 0U;
+}
+
+const basl_debug_local_t *basl_debug_local_table_get(
+    const basl_debug_local_table_t *table,
+    size_t index
+) {
+    if (table == NULL || index >= table->count) return NULL;
+    return &table->locals[index];
+}
+
+/* ── Symbol table ────────────────────────────────────────────────── */
+
+void basl_debug_symbol_table_init(
+    basl_debug_symbol_table_t *table,
+    basl_runtime_t *runtime
+) {
+    if (table == NULL) return;
+    memset(table, 0, sizeof(*table));
+    table->runtime = runtime;
+}
+
+void basl_debug_symbol_table_free(
+    basl_debug_symbol_table_t *table
+) {
+    void *memory;
+    if (table == NULL) return;
+    if (table->symbols != NULL) {
+        memory = table->symbols;
+        basl_runtime_free(table->runtime, &memory);
+        table->symbols = NULL;
+    }
+    table->count = 0U;
+    table->capacity = 0U;
+}
+
+basl_status_t basl_debug_symbol_table_add(
+    basl_debug_symbol_table_t *table,
+    basl_debug_symbol_kind_t kind,
+    const char *name,
+    size_t name_length,
+    basl_source_span_t span,
+    int is_public,
+    size_t parent_index,
+    basl_error_t *error
+) {
+    basl_debug_symbol_t *entry;
+
+    if (table == NULL) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (table->count >= table->capacity) {
+        size_t new_cap = table->capacity == 0U ? 16U : table->capacity * 2U;
+        void *memory = NULL;
+        basl_status_t status = basl_runtime_alloc(
+            table->runtime,
+            new_cap * sizeof(basl_debug_symbol_t),
+            &memory,
+            error
+        );
+        if (status != BASL_STATUS_OK) return status;
+        if (table->symbols != NULL) {
+            memcpy(memory, table->symbols,
+                   table->count * sizeof(basl_debug_symbol_t));
+            void *old = table->symbols;
+            basl_runtime_free(table->runtime, &old);
+        }
+        table->symbols = (basl_debug_symbol_t *)memory;
+        table->capacity = new_cap;
+    }
+
+    entry = &table->symbols[table->count];
+    entry->kind = kind;
+    entry->name = name;
+    entry->name_length = name_length;
+    entry->span = span;
+    entry->is_public = is_public;
+    entry->parent_index = parent_index;
+    table->count += 1U;
+    return BASL_STATUS_OK;
+}
+
+size_t basl_debug_symbol_table_count(
+    const basl_debug_symbol_table_t *table
+) {
+    return table != NULL ? table->count : 0U;
+}
+
+const basl_debug_symbol_t *basl_debug_symbol_table_get(
+    const basl_debug_symbol_table_t *table,
+    size_t index
+) {
+    if (table == NULL || index >= table->count) return NULL;
+    return &table->symbols[index];
+}

--- a/tests/debug_info_test.cpp
+++ b/tests/debug_info_test.cpp
@@ -1,0 +1,299 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+extern "C" {
+#include "basl/debug_info.h"
+#include "basl/native_module.h"
+#include "basl/runtime.h"
+#include "basl/source.h"
+#include "basl/stdlib.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+}
+
+namespace {
+
+struct DebugInfoFixture {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_native_registry_t natives;
+    basl_diagnostic_list_t diagnostics;
+    basl_debug_symbol_table_t symbols;
+
+    DebugInfoFixture() {
+        EXPECT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+        basl_source_registry_init(&registry, runtime);
+        basl_diagnostic_list_init(&diagnostics, runtime);
+        basl_native_registry_init(&natives);
+        EXPECT_EQ(basl_stdlib_register_all(&natives, &error), BASL_STATUS_OK);
+        basl_debug_symbol_table_init(&symbols, runtime);
+    }
+
+    ~DebugInfoFixture() {
+        basl_debug_symbol_table_free(&symbols);
+        basl_diagnostic_list_free(&diagnostics);
+        basl_native_registry_free(&natives);
+        basl_source_registry_free(&registry);
+        basl_runtime_close(&runtime);
+    }
+
+    basl_object_t *compile(const char *source_text) {
+        basl_source_id_t source_id = 0U;
+        basl_object_t *function = nullptr;
+
+        EXPECT_EQ(
+            basl_source_registry_register_cstr(
+                &registry, "main.basl", source_text, &source_id, &error),
+            BASL_STATUS_OK
+        );
+        EXPECT_EQ(
+            basl_compile_source_with_debug_info(
+                &registry, source_id, &natives, &function,
+                &diagnostics, &symbols, &error),
+            BASL_STATUS_OK
+        );
+        EXPECT_EQ(basl_diagnostic_list_count(&diagnostics), 0U);
+        return function;
+    }
+};
+
+/* ── Symbol table tests ──────────────────────────────────────────── */
+
+TEST(BaslDebugInfoTest, SymbolTableContainsMainFunction) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    return 0;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+    EXPECT_GE(basl_debug_symbol_table_count(&f.symbols), 1U);
+
+    bool found_main = false;
+    for (size_t i = 0; i < basl_debug_symbol_table_count(&f.symbols); i++) {
+        const basl_debug_symbol_t *sym = basl_debug_symbol_table_get(&f.symbols, i);
+        if (sym->kind == BASL_DEBUG_SYMBOL_FUNCTION &&
+            sym->name_length == 4 && memcmp(sym->name, "main", 4) == 0) {
+            found_main = true;
+        }
+    }
+    EXPECT_TRUE(found_main);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebugInfoTest, SymbolTableContainsClassAndMembers) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+class Point {
+    pub i32 x;
+    pub i32 y;
+
+    pub fn distance() -> f64 {
+        return 0.0;
+    }
+}
+
+fn main() -> i32 {
+    return 0;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+
+    bool found_class = false;
+    bool found_field_x = false;
+    bool found_method = false;
+    size_t class_idx = SIZE_MAX;
+
+    for (size_t i = 0; i < basl_debug_symbol_table_count(&f.symbols); i++) {
+        const basl_debug_symbol_t *sym = basl_debug_symbol_table_get(&f.symbols, i);
+        if (sym->kind == BASL_DEBUG_SYMBOL_CLASS &&
+            sym->name_length == 5 && memcmp(sym->name, "Point", 5) == 0) {
+            found_class = true;
+            class_idx = i;
+        }
+        if (sym->kind == BASL_DEBUG_SYMBOL_FIELD &&
+            sym->name_length == 1 && sym->name[0] == 'x') {
+            found_field_x = true;
+            EXPECT_EQ(sym->parent_index, class_idx);
+        }
+        if (sym->kind == BASL_DEBUG_SYMBOL_METHOD &&
+            sym->name_length == 8 && memcmp(sym->name, "distance", 8) == 0) {
+            found_method = true;
+            EXPECT_EQ(sym->parent_index, class_idx);
+        }
+    }
+    EXPECT_TRUE(found_class);
+    EXPECT_TRUE(found_field_x);
+    EXPECT_TRUE(found_method);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebugInfoTest, SymbolTableContainsEnumAndMembers) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+enum Color {
+    Red,
+    Green,
+    Blue
+}
+
+fn main() -> i32 {
+    return 0;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+
+    bool found_enum = false;
+    bool found_red = false;
+    size_t enum_idx = SIZE_MAX;
+
+    for (size_t i = 0; i < basl_debug_symbol_table_count(&f.symbols); i++) {
+        const basl_debug_symbol_t *sym = basl_debug_symbol_table_get(&f.symbols, i);
+        if (sym->kind == BASL_DEBUG_SYMBOL_ENUM &&
+            sym->name_length == 5 && memcmp(sym->name, "Color", 5) == 0) {
+            found_enum = true;
+            enum_idx = i;
+        }
+        if (sym->kind == BASL_DEBUG_SYMBOL_ENUM_MEMBER &&
+            sym->name_length == 3 && memcmp(sym->name, "Red", 3) == 0) {
+            found_red = true;
+            EXPECT_EQ(sym->parent_index, enum_idx);
+        }
+    }
+    EXPECT_TRUE(found_enum);
+    EXPECT_TRUE(found_red);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebugInfoTest, SymbolTableContainsGlobals) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+const i32 MAX = 100;
+i32 counter = 0;
+
+fn main() -> i32 {
+    return MAX;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+
+    bool found_const = false;
+    bool found_var = false;
+
+    for (size_t i = 0; i < basl_debug_symbol_table_count(&f.symbols); i++) {
+        const basl_debug_symbol_t *sym = basl_debug_symbol_table_get(&f.symbols, i);
+        if (sym->kind == BASL_DEBUG_SYMBOL_GLOBAL_CONST &&
+            sym->name_length == 3 && memcmp(sym->name, "MAX", 3) == 0) {
+            found_const = true;
+        }
+        if (sym->kind == BASL_DEBUG_SYMBOL_GLOBAL_VAR &&
+            sym->name_length == 7 && memcmp(sym->name, "counter", 7) == 0) {
+            found_var = true;
+        }
+    }
+    EXPECT_TRUE(found_const);
+    EXPECT_TRUE(found_var);
+    basl_object_release(&fn);
+}
+
+/* ── Local variable debug info tests ─────────────────────────────── */
+
+TEST(BaslDebugInfoTest, LocalTableBasic) {
+    basl_runtime_t *runtime = nullptr;
+    basl_error_t error = {};
+    basl_debug_local_table_t table;
+
+    ASSERT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+    basl_debug_local_table_init(&table, runtime);
+
+    EXPECT_EQ(basl_debug_local_table_count(&table), 0U);
+
+    EXPECT_EQ(basl_debug_local_table_add(&table, "x", 1, 0, 0, &error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_debug_local_table_add(&table, "y", 1, 1, 5, &error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_debug_local_table_count(&table), 2U);
+
+    /* Close scope for slot >= 1 at IP 10. */
+    basl_debug_local_table_close_scope(&table, 1, 10);
+
+    const basl_debug_local_t *entry = basl_debug_local_table_get(&table, 1);
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->name_length, 1U);
+    EXPECT_EQ(entry->name[0], 'y');
+    EXPECT_EQ(entry->slot, 1U);
+    EXPECT_EQ(entry->scope_start_ip, 5U);
+    EXPECT_EQ(entry->scope_end_ip, 10U);
+
+    /* x should still be open. */
+    const basl_debug_local_t *x_entry = basl_debug_local_table_get(&table, 0);
+    ASSERT_NE(x_entry, nullptr);
+    EXPECT_EQ(x_entry->scope_end_ip, SIZE_MAX);
+
+    basl_debug_local_table_free(&table);
+    basl_runtime_close(&runtime);
+}
+
+TEST(BaslDebugInfoTest, ChunkContainsDebugLocals) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    i32 x = 10;
+    i32 y = 20;
+    return x + y;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+
+    /* The compiled function's chunk should have debug locals for x and y.
+     * We can't easily access the chunk from the function object in the
+     * public API, but we can verify the compilation succeeded and the
+     * program runs correctly. */
+    basl_vm_t *vm = nullptr;
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    ASSERT_EQ(basl_vm_open(&vm, f.runtime, nullptr, &f.error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_vm_execute_function(vm, fn, &result, &f.error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_value_as_int(&result), 30);
+    basl_value_release(&result);
+    basl_vm_close(&vm);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebugInfoTest, SymbolTableContainsInterface) {
+    DebugInfoFixture f;
+    basl_object_t *fn = f.compile(R"(
+interface Drawable {
+    fn draw() -> void;
+}
+
+class Circle implements Drawable {
+    pub i32 radius;
+
+    pub fn draw() -> void {}
+}
+
+fn main() -> i32 {
+    return 0;
+}
+    )");
+
+    ASSERT_NE(fn, nullptr);
+
+    bool found_interface = false;
+    for (size_t i = 0; i < basl_debug_symbol_table_count(&f.symbols); i++) {
+        const basl_debug_symbol_t *sym = basl_debug_symbol_table_get(&f.symbols, i);
+        if (sym->kind == BASL_DEBUG_SYMBOL_INTERFACE &&
+            sym->name_length == 8 && memcmp(sym->name, "Drawable", 8) == 0) {
+            found_interface = true;
+        }
+    }
+    EXPECT_TRUE(found_interface);
+    basl_object_release(&fn);
+}
+
+}  // namespace


### PR DESCRIPTION
Foundation PR that both the debugger and LSP will build on. Adds two data structures that capture symbol information during compilation.

## Per-chunk local variable debug info

Every `basl_chunk_t` now contains a `basl_debug_local_table_t` that records each local variable's:
- Name and name length
- Stack slot index
- Scope start IP (when the variable comes into scope)
- Scope end IP (when it goes out of scope)

This is populated automatically during compilation — `declare_local_symbol` records the start, `end_scope` closes the range. No opt-in needed.

**Debugger use:** Given a paused IP, iterate the table to find all locals in scope → map slot indices to names → inspect stack values by name.

**LSP use:** Not directly needed (LSP works at the source level), but validates the scope tracking design.

## Program-level symbol table

New `basl_compile_source_with_debug_info()` API that produces a `basl_debug_symbol_table_t` alongside the compiled function. Contains every program-level definition:

| Symbol kind | What it captures |
|---|---|
| `FUNCTION` | Top-level and class method functions |
| `CLASS` | Class declarations |
| `INTERFACE` | Interface declarations |
| `ENUM` | Enum declarations |
| `ENUM_MEMBER` | Individual enum values |
| `FIELD` | Class fields |
| `METHOD` | Class methods |
| `GLOBAL_CONST` | Top-level constants |
| `GLOBAL_VAR` | Top-level variables |

Each symbol has: name, source span, is_public flag, and parent_index (links fields→class, members→enum).

**LSP use:** Go-to-definition (look up symbol by name, return span), find-references (scan for matching names), hover (show symbol kind + name).

**Debugger use:** Stack trace enrichment (function names with source locations).

## What this does NOT include

- No VM step hooks or breakpoint table (that's the debugger PR)
- No LSP protocol code (that's the LSP PR)
- No changes to runtime behavior — debug info is purely additive metadata

## Testing
- 317/317 tests (7 new)
- ASAN+UBSAN clean
- Portability clean (56 core files)