### PR TITLE
Add debugger library: breakpoints, stepping, and variable inspection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(basl_core OBJECT
     src/chunk.c
     src/compiler.c
     src/debug_info.c
+    src/debugger.c
     src/compiler_program.c
     src/compiler_builtins.c
     src/compiler_strings.c
@@ -142,6 +143,7 @@ if(BASL_BUILD_TESTS)
         tests/chunk_test.cpp
         tests/compiler_test.cpp
         tests/debug_info_test.cpp
+        tests/debugger_test.cpp
         tests/diagnostic_test.cpp
         tests/lexer_test.cpp
         tests/log_test.cpp

--- a/include/basl/debugger.h
+++ b/include/basl/debugger.h
@@ -1,0 +1,150 @@
+#ifndef BASL_DEBUGGER_H
+#define BASL_DEBUGGER_H
+
+#include <stddef.h>
+
+#include "basl/debug_info.h"
+#include "basl/export.h"
+#include "basl/runtime.h"
+#include "basl/source.h"
+#include "basl/status.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Debugger state ──────────────────────────────────────────────── */
+
+typedef struct basl_debugger basl_debugger_t;
+
+typedef enum basl_debug_action {
+    BASL_DEBUG_CONTINUE = 0,    /* resume execution */
+    BASL_DEBUG_PAUSE = 1        /* stay paused (callback returns this) */
+} basl_debug_action_t;
+
+typedef enum basl_debug_stop_reason {
+    BASL_DEBUG_STOP_BREAKPOINT = 0,
+    BASL_DEBUG_STOP_STEP = 1,
+    BASL_DEBUG_STOP_ENTRY = 2
+} basl_debug_stop_reason_t;
+
+/**
+ * Called when the VM pauses (breakpoint hit, step completed, etc.).
+ * Return BASL_DEBUG_CONTINUE to resume, BASL_DEBUG_PAUSE to stay paused.
+ * While paused, the caller can inspect locals, stack, and call frames.
+ */
+typedef basl_debug_action_t (*basl_debug_callback_t)(
+    basl_debugger_t *debugger,
+    basl_debug_stop_reason_t reason,
+    void *userdata
+);
+
+/* ── Lifecycle ───────────────────────────────────────────────────── */
+
+BASL_API basl_status_t basl_debugger_create(
+    basl_debugger_t **out_debugger,
+    basl_vm_t *vm,
+    const basl_source_registry_t *sources,
+    basl_error_t *error
+);
+BASL_API void basl_debugger_destroy(basl_debugger_t **debugger);
+
+/**
+ * Attach the debugger to the VM. While attached, the VM checks for
+ * breakpoints and step conditions before each opcode.
+ * Call before basl_vm_execute_function().
+ */
+BASL_API void basl_debugger_attach(basl_debugger_t *debugger);
+
+/** Detach the debugger. VM runs at full speed. */
+BASL_API void basl_debugger_detach(basl_debugger_t *debugger);
+
+/** Set the callback invoked when the VM pauses. */
+BASL_API void basl_debugger_set_callback(
+    basl_debugger_t *debugger,
+    basl_debug_callback_t callback,
+    void *userdata
+);
+
+/* ── Breakpoints ─────────────────────────────────────────────────── */
+
+BASL_API basl_status_t basl_debugger_set_breakpoint(
+    basl_debugger_t *debugger,
+    basl_source_id_t source_id,
+    uint32_t line,
+    size_t *out_breakpoint_id,
+    basl_error_t *error
+);
+BASL_API basl_status_t basl_debugger_clear_breakpoint(
+    basl_debugger_t *debugger,
+    size_t breakpoint_id
+);
+BASL_API void basl_debugger_clear_all_breakpoints(
+    basl_debugger_t *debugger
+);
+
+/* ── Execution control ───────────────────────────────────────────── */
+
+/** Step one source line (step over function calls). */
+BASL_API void basl_debugger_step_over(basl_debugger_t *debugger);
+
+/** Step into the next function call. */
+BASL_API void basl_debugger_step_into(basl_debugger_t *debugger);
+
+/** Step out of the current function. */
+BASL_API void basl_debugger_step_out(basl_debugger_t *debugger);
+
+/** Resume execution until next breakpoint or completion. */
+BASL_API void basl_debugger_continue(basl_debugger_t *debugger);
+
+/** Request a pause at the next opportunity. */
+BASL_API void basl_debugger_pause(basl_debugger_t *debugger);
+
+/* ── Inspection (valid while paused) ─────────────────────────────── */
+
+/** Get the current source location where execution is paused. */
+BASL_API basl_status_t basl_debugger_current_location(
+    const basl_debugger_t *debugger,
+    basl_source_id_t *out_source_id,
+    uint32_t *out_line,
+    uint32_t *out_column
+);
+
+/** Get the call stack depth. */
+BASL_API size_t basl_debugger_frame_count(
+    const basl_debugger_t *debugger
+);
+
+/** Get info about a call frame (0 = innermost). */
+BASL_API basl_status_t basl_debugger_frame_info(
+    const basl_debugger_t *debugger,
+    size_t frame_index,
+    const char **out_function_name,
+    size_t *out_name_length,
+    basl_source_id_t *out_source_id,
+    uint32_t *out_line,
+    uint32_t *out_column
+);
+
+/**
+ * Get locals in scope for a given frame.
+ * Returns the number of locals written to out_names/out_values.
+ * out_names[i] points into debug info (do not free).
+ * out_values[i] are copies (caller must release).
+ */
+BASL_API size_t basl_debugger_frame_locals(
+    const basl_debugger_t *debugger,
+    size_t frame_index,
+    const char **out_names,
+    size_t *out_name_lengths,
+    basl_value_t *out_values,
+    size_t max_locals
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/basl/vm.h
+++ b/include/basl/vm.h
@@ -53,6 +53,23 @@ BASL_API basl_status_t basl_vm_stack_push(
     basl_vm_t *vm, const basl_value_t *value, basl_error_t *error);
 BASL_API void basl_vm_stack_pop_n(basl_vm_t *vm, size_t count);
 
+/* Debug hook — set by debugger, NULL when not debugging. */
+BASL_API void basl_vm_set_debug_hook(
+    basl_vm_t *vm,
+    int (*hook)(basl_vm_t *vm, void *userdata),
+    void *userdata
+);
+
+/* Frame inspection for debugger. */
+BASL_API const basl_chunk_t *basl_vm_frame_chunk(
+    const basl_vm_t *vm, size_t frame_index);
+BASL_API size_t basl_vm_frame_ip(
+    const basl_vm_t *vm, size_t frame_index);
+BASL_API size_t basl_vm_frame_base_slot(
+    const basl_vm_t *vm, size_t frame_index);
+BASL_API const basl_object_t *basl_vm_frame_function(
+    const basl_vm_t *vm, size_t frame_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1,0 +1,473 @@
+/* BASL debugger: breakpoints, stepping, and variable inspection.
+ *
+ * The debugger attaches to a VM via a lightweight hook function that
+ * is checked before each opcode dispatch.  When no debugger is attached
+ * the hook pointer is NULL and the VM runs at full speed.
+ */
+#include <string.h>
+
+#include "basl/debugger.h"
+#include "basl/chunk.h"
+#include "basl/status.h"
+
+#include "internal/basl_internal.h"
+
+/* ── Internal types ──────────────────────────────────────────────── */
+
+typedef enum basl_debug_mode {
+    BASL_DEBUG_MODE_RUN = 0,
+    BASL_DEBUG_MODE_PAUSE = 1,
+    BASL_DEBUG_MODE_STEP_OVER = 2,
+    BASL_DEBUG_MODE_STEP_INTO = 3,
+    BASL_DEBUG_MODE_STEP_OUT = 4
+} basl_debug_mode_t;
+
+typedef struct basl_breakpoint {
+    basl_source_id_t source_id;
+    uint32_t line;
+    int active;
+} basl_breakpoint_t;
+
+struct basl_debugger {
+    basl_runtime_t *runtime;
+    basl_vm_t *vm;
+    const basl_source_registry_t *sources;
+    basl_debug_callback_t callback;
+    void *callback_userdata;
+    basl_debug_mode_t mode;
+    /* For step-over/step-out: the frame depth when stepping started. */
+    size_t step_frame_depth;
+    /* For step-over: the source line when stepping started. */
+    uint32_t step_start_line;
+    basl_source_id_t step_start_source;
+    /* Breakpoints. */
+    basl_breakpoint_t *breakpoints;
+    size_t breakpoint_count;
+    size_t breakpoint_capacity;
+    /* Cached pause state. */
+    int is_paused;
+};
+
+/* ── Forward declarations ────────────────────────────────────────── */
+
+static int basl_debugger_vm_hook(basl_vm_t *vm, void *userdata);
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+/* Resolve the current IP to a source location. */
+static int basl_debugger_resolve_ip(
+    const basl_debugger_t *dbg,
+    size_t frame_index,
+    basl_source_id_t *out_source_id,
+    uint32_t *out_line,
+    uint32_t *out_column
+) {
+    size_t vm_frame_count;
+    size_t vm_frame_idx;
+    basl_source_span_t span;
+    basl_source_location_t location;
+    const basl_chunk_t *chunk;
+    size_t ip;
+
+    vm_frame_count = basl_vm_frame_depth(dbg->vm);
+    if (vm_frame_count == 0U) return 0;
+
+    /* frame_index 0 = innermost (top of stack). */
+    vm_frame_idx = vm_frame_count - 1U - frame_index;
+    chunk = basl_vm_frame_chunk(dbg->vm, vm_frame_idx);
+    ip = basl_vm_frame_ip(dbg->vm, vm_frame_idx);
+
+    if (chunk == NULL) return 0;
+    span = basl_chunk_span_at(chunk, ip);
+
+    basl_source_location_clear(&location);
+    location.source_id = span.source_id;
+    location.offset = span.start_offset;
+    if (basl_source_registry_resolve_location(dbg->sources, &location, NULL) != BASL_STATUS_OK) {
+        return 0;
+    }
+
+    if (out_source_id != NULL) *out_source_id = location.source_id;
+    if (out_line != NULL) *out_line = location.line;
+    if (out_column != NULL) *out_column = location.column;
+    return 1;
+}
+
+static int basl_debugger_check_breakpoint(
+    const basl_debugger_t *dbg,
+    basl_source_id_t source_id,
+    uint32_t line
+) {
+    size_t i;
+    for (i = 0U; i < dbg->breakpoint_count; i += 1U) {
+        if (dbg->breakpoints[i].active &&
+            dbg->breakpoints[i].source_id == source_id &&
+            dbg->breakpoints[i].line == line) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void basl_debugger_invoke_callback(
+    basl_debugger_t *dbg,
+    basl_debug_stop_reason_t reason
+) {
+    basl_debug_action_t action;
+
+    dbg->is_paused = 1;
+    if (dbg->callback != NULL) {
+        action = dbg->callback(dbg, reason, dbg->callback_userdata);
+        if (action == BASL_DEBUG_CONTINUE) {
+            dbg->is_paused = 0;
+            dbg->mode = BASL_DEBUG_MODE_RUN;
+        }
+    }
+}
+
+/* ── VM hook ─────────────────────────────────────────────────────── */
+
+static int basl_debugger_vm_hook(basl_vm_t *vm, void *userdata) {
+    basl_debugger_t *dbg = (basl_debugger_t *)userdata;
+    basl_source_id_t source_id = 0U;
+    uint32_t line = 0U;
+    uint32_t column = 0U;
+    size_t current_depth;
+    int should_stop = 0;
+
+    (void)vm;
+
+    if (!basl_debugger_resolve_ip(dbg, 0U, &source_id, &line, &column)) {
+        return 0;  /* can't resolve — keep running */
+    }
+
+    current_depth = basl_vm_frame_depth(dbg->vm);
+
+    switch (dbg->mode) {
+    case BASL_DEBUG_MODE_RUN:
+        should_stop = basl_debugger_check_breakpoint(dbg, source_id, line);
+        break;
+    case BASL_DEBUG_MODE_PAUSE:
+        should_stop = 1;
+        break;
+    case BASL_DEBUG_MODE_STEP_INTO:
+        /* Stop at any new source line. */
+        should_stop = (source_id != dbg->step_start_source ||
+                       line != dbg->step_start_line);
+        break;
+    case BASL_DEBUG_MODE_STEP_OVER:
+        /* Stop at a new source line at the same or shallower depth. */
+        should_stop = (current_depth <= dbg->step_frame_depth &&
+                       (source_id != dbg->step_start_source ||
+                        line != dbg->step_start_line));
+        break;
+    case BASL_DEBUG_MODE_STEP_OUT:
+        /* Stop when we return to a shallower frame. */
+        should_stop = (current_depth < dbg->step_frame_depth);
+        break;
+    }
+
+    /* Also check breakpoints in stepping modes. */
+    if (!should_stop && dbg->mode != BASL_DEBUG_MODE_RUN) {
+        should_stop = basl_debugger_check_breakpoint(dbg, source_id, line);
+    }
+
+    if (should_stop) {
+        basl_debug_stop_reason_t reason =
+            (dbg->mode == BASL_DEBUG_MODE_RUN)
+                ? BASL_DEBUG_STOP_BREAKPOINT
+                : BASL_DEBUG_STOP_STEP;
+        basl_debugger_invoke_callback(dbg, reason);
+    }
+
+    return 0;  /* 0 = keep executing */
+}
+
+/* ── Lifecycle ───────────────────────────────────────────────────── */
+
+basl_status_t basl_debugger_create(
+    basl_debugger_t **out_debugger,
+    basl_vm_t *vm,
+    const basl_source_registry_t *sources,
+    basl_error_t *error
+) {
+    void *memory = NULL;
+    basl_runtime_t *runtime;
+    basl_status_t status;
+
+    if (out_debugger == NULL || vm == NULL || sources == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "debugger arguments must not be null");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    *out_debugger = NULL;
+    runtime = basl_vm_runtime(vm);
+    status = basl_runtime_alloc(runtime, sizeof(basl_debugger_t), &memory, error);
+    if (status != BASL_STATUS_OK) return status;
+
+    memset(memory, 0, sizeof(basl_debugger_t));
+    *out_debugger = (basl_debugger_t *)memory;
+    (*out_debugger)->runtime = runtime;
+    (*out_debugger)->vm = vm;
+    (*out_debugger)->sources = sources;
+    (*out_debugger)->mode = BASL_DEBUG_MODE_RUN;
+    return BASL_STATUS_OK;
+}
+
+void basl_debugger_destroy(basl_debugger_t **debugger) {
+    void *memory;
+    if (debugger == NULL || *debugger == NULL) return;
+    basl_debugger_detach(*debugger);
+    if ((*debugger)->breakpoints != NULL) {
+        memory = (*debugger)->breakpoints;
+        basl_runtime_free((*debugger)->runtime, &memory);
+    }
+    memory = *debugger;
+    basl_runtime_free((*debugger)->runtime, &memory);
+    *debugger = NULL;
+}
+
+void basl_debugger_attach(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    basl_vm_set_debug_hook(debugger->vm, basl_debugger_vm_hook, debugger);
+}
+
+void basl_debugger_detach(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    basl_vm_set_debug_hook(debugger->vm, NULL, NULL);
+    debugger->is_paused = 0;
+}
+
+void basl_debugger_set_callback(
+    basl_debugger_t *debugger,
+    basl_debug_callback_t callback,
+    void *userdata
+) {
+    if (debugger == NULL) return;
+    debugger->callback = callback;
+    debugger->callback_userdata = userdata;
+}
+
+/* ── Breakpoints ─────────────────────────────────────────────────── */
+
+basl_status_t basl_debugger_set_breakpoint(
+    basl_debugger_t *debugger,
+    basl_source_id_t source_id,
+    uint32_t line,
+    size_t *out_breakpoint_id,
+    basl_error_t *error
+) {
+    basl_breakpoint_t *bp;
+
+    if (debugger == NULL) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    /* Reuse an inactive slot. */
+    for (size_t i = 0U; i < debugger->breakpoint_count; i += 1U) {
+        if (!debugger->breakpoints[i].active) {
+            debugger->breakpoints[i].source_id = source_id;
+            debugger->breakpoints[i].line = line;
+            debugger->breakpoints[i].active = 1;
+            if (out_breakpoint_id != NULL) *out_breakpoint_id = i;
+            return BASL_STATUS_OK;
+        }
+    }
+
+    /* Grow. */
+    if (debugger->breakpoint_count >= debugger->breakpoint_capacity) {
+        size_t new_cap = debugger->breakpoint_capacity == 0U
+                             ? 8U
+                             : debugger->breakpoint_capacity * 2U;
+        void *memory = NULL;
+        basl_status_t status = basl_runtime_alloc(
+            debugger->runtime,
+            new_cap * sizeof(basl_breakpoint_t),
+            &memory, error
+        );
+        if (status != BASL_STATUS_OK) return status;
+        if (debugger->breakpoints != NULL) {
+            memcpy(memory, debugger->breakpoints,
+                   debugger->breakpoint_count * sizeof(basl_breakpoint_t));
+            void *old = debugger->breakpoints;
+            basl_runtime_free(debugger->runtime, &old);
+        }
+        debugger->breakpoints = (basl_breakpoint_t *)memory;
+        debugger->breakpoint_capacity = new_cap;
+    }
+
+    bp = &debugger->breakpoints[debugger->breakpoint_count];
+    bp->source_id = source_id;
+    bp->line = line;
+    bp->active = 1;
+    if (out_breakpoint_id != NULL) *out_breakpoint_id = debugger->breakpoint_count;
+    debugger->breakpoint_count += 1U;
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_debugger_clear_breakpoint(
+    basl_debugger_t *debugger,
+    size_t breakpoint_id
+) {
+    if (debugger == NULL || breakpoint_id >= debugger->breakpoint_count) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    debugger->breakpoints[breakpoint_id].active = 0;
+    return BASL_STATUS_OK;
+}
+
+void basl_debugger_clear_all_breakpoints(basl_debugger_t *debugger) {
+    size_t i;
+    if (debugger == NULL) return;
+    for (i = 0U; i < debugger->breakpoint_count; i += 1U) {
+        debugger->breakpoints[i].active = 0;
+    }
+}
+
+/* ── Execution control ───────────────────────────────────────────── */
+
+static void basl_debugger_begin_step(basl_debugger_t *debugger) {
+    debugger->step_frame_depth = basl_vm_frame_depth(debugger->vm);
+    debugger->step_start_line = 0U;
+    debugger->step_start_source = 0U;
+    basl_debugger_resolve_ip(
+        debugger, 0U,
+        &debugger->step_start_source,
+        &debugger->step_start_line,
+        NULL
+    );
+    debugger->is_paused = 0;
+}
+
+void basl_debugger_step_over(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    debugger->mode = BASL_DEBUG_MODE_STEP_OVER;
+    basl_debugger_begin_step(debugger);
+}
+
+void basl_debugger_step_into(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    debugger->mode = BASL_DEBUG_MODE_STEP_INTO;
+    basl_debugger_begin_step(debugger);
+}
+
+void basl_debugger_step_out(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    debugger->mode = BASL_DEBUG_MODE_STEP_OUT;
+    basl_debugger_begin_step(debugger);
+}
+
+void basl_debugger_continue(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    debugger->mode = BASL_DEBUG_MODE_RUN;
+    debugger->is_paused = 0;
+}
+
+void basl_debugger_pause(basl_debugger_t *debugger) {
+    if (debugger == NULL) return;
+    debugger->mode = BASL_DEBUG_MODE_PAUSE;
+}
+
+/* ── Inspection ──────────────────────────────────────────────────── */
+
+basl_status_t basl_debugger_current_location(
+    const basl_debugger_t *debugger,
+    basl_source_id_t *out_source_id,
+    uint32_t *out_line,
+    uint32_t *out_column
+) {
+    if (debugger == NULL) return BASL_STATUS_INVALID_ARGUMENT;
+    if (!basl_debugger_resolve_ip(debugger, 0U, out_source_id, out_line, out_column)) {
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    return BASL_STATUS_OK;
+}
+
+size_t basl_debugger_frame_count(const basl_debugger_t *debugger) {
+    if (debugger == NULL) return 0U;
+    return basl_vm_frame_depth(debugger->vm);
+}
+
+basl_status_t basl_debugger_frame_info(
+    const basl_debugger_t *debugger,
+    size_t frame_index,
+    const char **out_function_name,
+    size_t *out_name_length,
+    basl_source_id_t *out_source_id,
+    uint32_t *out_line,
+    uint32_t *out_column
+) {
+    size_t vm_frame_count;
+    size_t vm_frame_idx;
+
+    if (debugger == NULL) return BASL_STATUS_INVALID_ARGUMENT;
+
+    vm_frame_count = basl_vm_frame_depth(debugger->vm);
+    if (frame_index >= vm_frame_count) return BASL_STATUS_INVALID_ARGUMENT;
+
+    vm_frame_idx = vm_frame_count - 1U - frame_index;
+
+    /* Get function name from the frame's function object. */
+    {
+        const basl_object_t *fn_obj = basl_vm_frame_function(debugger->vm, vm_frame_idx);
+        if (fn_obj != NULL) {
+            const char *name = basl_function_object_name(fn_obj);
+            if (out_function_name != NULL) *out_function_name = name;
+            if (out_name_length != NULL) *out_name_length = name != NULL ? strlen(name) : 0U;
+        } else {
+            if (out_function_name != NULL) *out_function_name = NULL;
+            if (out_name_length != NULL) *out_name_length = 0U;
+        }
+    }
+
+    basl_debugger_resolve_ip(debugger, frame_index, out_source_id, out_line, out_column);
+    return BASL_STATUS_OK;
+}
+
+size_t basl_debugger_frame_locals(
+    const basl_debugger_t *debugger,
+    size_t frame_index,
+    const char **out_names,
+    size_t *out_name_lengths,
+    basl_value_t *out_values,
+    size_t max_locals
+) {
+    size_t vm_frame_count;
+    size_t vm_frame_idx;
+    const basl_chunk_t *chunk;
+    size_t ip;
+    size_t base_slot;
+    size_t count = 0U;
+    size_t i;
+
+    if (debugger == NULL || max_locals == 0U) return 0U;
+
+    vm_frame_count = basl_vm_frame_depth(debugger->vm);
+    if (frame_index >= vm_frame_count) return 0U;
+    vm_frame_idx = vm_frame_count - 1U - frame_index;
+
+    chunk = basl_vm_frame_chunk(debugger->vm, vm_frame_idx);
+    ip = basl_vm_frame_ip(debugger->vm, vm_frame_idx);
+    base_slot = basl_vm_frame_base_slot(debugger->vm, vm_frame_idx);
+
+    if (chunk == NULL) return 0U;
+
+    for (i = 0U; i < basl_debug_local_table_count(&chunk->debug_locals); i += 1U) {
+        const basl_debug_local_t *local = basl_debug_local_table_get(&chunk->debug_locals, i);
+        if (local == NULL) continue;
+        if (ip >= local->scope_start_ip &&
+            (local->scope_end_ip == SIZE_MAX || ip < local->scope_end_ip)) {
+            if (count >= max_locals) break;
+            if (out_names != NULL) out_names[count] = local->name;
+            if (out_name_lengths != NULL) out_name_lengths[count] = local->name_length;
+            if (out_values != NULL) {
+                size_t stack_slot = base_slot + local->slot;
+                out_values[count] = basl_vm_stack_get(debugger->vm, stack_slot);
+            }
+            count += 1U;
+        }
+    }
+
+    return count;
+}

--- a/src/vm.c
+++ b/src/vm.c
@@ -253,6 +253,9 @@ struct basl_vm {
     basl_vm_frame_t *frames;
     size_t frame_count;
     size_t frame_capacity;
+    /* Debug hook — NULL when no debugger attached (zero overhead). */
+    int (*debug_hook)(basl_vm_t *vm, void *userdata);
+    void *debug_hook_userdata;
 };
 
 static basl_status_t basl_vm_fail_at_ip(
@@ -2588,6 +2591,40 @@ void basl_vm_stack_pop_n(basl_vm_t *vm, size_t count) {
     }
 }
 
+void basl_vm_set_debug_hook(
+    basl_vm_t *vm,
+    int (*hook)(basl_vm_t *vm, void *userdata),
+    void *userdata
+) {
+    if (vm == NULL) return;
+    vm->debug_hook = hook;
+    vm->debug_hook_userdata = userdata;
+}
+
+const basl_chunk_t *basl_vm_frame_chunk(
+    const basl_vm_t *vm, size_t frame_index
+) {
+    if (vm == NULL || frame_index >= vm->frame_count) return NULL;
+    return vm->frames[frame_index].chunk;
+}
+
+size_t basl_vm_frame_ip(const basl_vm_t *vm, size_t frame_index) {
+    if (vm == NULL || frame_index >= vm->frame_count) return 0U;
+    return vm->frames[frame_index].ip;
+}
+
+size_t basl_vm_frame_base_slot(const basl_vm_t *vm, size_t frame_index) {
+    if (vm == NULL || frame_index >= vm->frame_count) return 0U;
+    return vm->frames[frame_index].base_slot;
+}
+
+const basl_object_t *basl_vm_frame_function(
+    const basl_vm_t *vm, size_t frame_index
+) {
+    if (vm == NULL || frame_index >= vm->frame_count) return NULL;
+    return vm->frames[frame_index].function;
+}
+
 basl_status_t basl_vm_execute(
     basl_vm_t *vm,
     const basl_chunk_t *chunk,
@@ -2875,6 +2912,12 @@ basl_status_t basl_vm_execute_function(
 
         #define VM_DISPATCH() \
             do { \
+                if (vm->debug_hook != NULL) { \
+                    if (vm->debug_hook(vm, vm->debug_hook_userdata) != 0) { \
+                        status = BASL_STATUS_OK; \
+                        goto cleanup; \
+                    } \
+                } \
                 if (dispatch_table[code[frame->ip]] == NULL) { \
                     status = basl_vm_fail_at_ip( \
                         vm, BASL_STATUS_UNSUPPORTED, \
@@ -2904,6 +2947,12 @@ basl_status_t basl_vm_execute_function(
         #define VM_BREAK() break
         #define VM_BREAK_RELOAD() break
 
+        if (vm->debug_hook != NULL) {
+            if (vm->debug_hook(vm, vm->debug_hook_userdata) != 0) {
+                status = BASL_STATUS_OK;
+                goto cleanup;
+            }
+        }
         switch ((basl_opcode_t)code[frame->ip]) {
 #endif
 

--- a/tests/debugger_test.cpp
+++ b/tests/debugger_test.cpp
@@ -1,0 +1,250 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include "basl/debugger.h"
+#include "basl/native_module.h"
+#include "basl/runtime.h"
+#include "basl/source.h"
+#include "basl/stdlib.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+}
+
+namespace {
+
+struct DebuggerFixture {
+    basl_runtime_t *runtime = nullptr;
+    basl_vm_t *vm = nullptr;
+    basl_error_t error = {};
+    basl_source_registry_t registry;
+    basl_native_registry_t natives;
+    basl_diagnostic_list_t diagnostics;
+    basl_debugger_t *debugger = nullptr;
+    basl_source_id_t source_id = 0U;
+
+    DebuggerFixture() {
+        EXPECT_EQ(basl_runtime_open(&runtime, nullptr, &error), BASL_STATUS_OK);
+        EXPECT_EQ(basl_vm_open(&vm, runtime, nullptr, &error), BASL_STATUS_OK);
+        basl_source_registry_init(&registry, runtime);
+        basl_diagnostic_list_init(&diagnostics, runtime);
+        basl_native_registry_init(&natives);
+        EXPECT_EQ(basl_stdlib_register_all(&natives, &error), BASL_STATUS_OK);
+    }
+
+    ~DebuggerFixture() {
+        if (debugger != nullptr) basl_debugger_destroy(&debugger);
+        basl_diagnostic_list_free(&diagnostics);
+        basl_native_registry_free(&natives);
+        basl_source_registry_free(&registry);
+        basl_vm_close(&vm);
+        basl_runtime_close(&runtime);
+    }
+
+    basl_object_t *compile(const char *source_text) {
+        basl_object_t *function = nullptr;
+        EXPECT_EQ(
+            basl_source_registry_register_cstr(
+                &registry, "main.basl", source_text, &source_id, &error),
+            BASL_STATUS_OK
+        );
+        EXPECT_EQ(
+            basl_compile_source_with_natives(
+                &registry, source_id, &natives, &function,
+                &diagnostics, &error),
+            BASL_STATUS_OK
+        );
+        return function;
+    }
+
+    void create_debugger() {
+        EXPECT_EQ(
+            basl_debugger_create(&debugger, vm, &registry, &error),
+            BASL_STATUS_OK
+        );
+        ASSERT_NE(debugger, nullptr);
+    }
+};
+
+/* Track callback invocations. */
+struct CallbackState {
+    std::vector<uint32_t> hit_lines;
+    std::vector<basl_debug_stop_reason_t> reasons;
+    int continue_after = 0;  /* 0 = always continue */
+};
+
+static basl_debug_action_t test_callback(
+    basl_debugger_t *debugger,
+    basl_debug_stop_reason_t reason,
+    void *userdata
+) {
+    auto *state = static_cast<CallbackState *>(userdata);
+    uint32_t line = 0;
+    basl_debugger_current_location(debugger, nullptr, &line, nullptr);
+    state->hit_lines.push_back(line);
+    state->reasons.push_back(reason);
+    return BASL_DEBUG_CONTINUE;
+}
+
+/* ── Tests ───────────────────────────────────────────────────────── */
+
+TEST(BaslDebuggerTest, CreateAndDestroy) {
+    DebuggerFixture f;
+    f.create_debugger();
+    EXPECT_NE(f.debugger, nullptr);
+}
+
+TEST(BaslDebuggerTest, AttachDetachDoesNotBreakExecution) {
+    DebuggerFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    return 42;
+}
+    )");
+    ASSERT_NE(fn, nullptr);
+    f.create_debugger();
+    basl_debugger_attach(f.debugger);
+
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    EXPECT_EQ(basl_vm_execute_function(f.vm, fn, &result, &f.error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_value_as_int(&result), 42);
+
+    basl_debugger_detach(f.debugger);
+    basl_value_release(&result);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebuggerTest, BreakpointHitsCorrectLine) {
+    DebuggerFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    i32 x = 10;
+    i32 y = 20;
+    return x + y;
+}
+    )");
+    ASSERT_NE(fn, nullptr);
+    f.create_debugger();
+
+    CallbackState cb_state;
+    basl_debugger_set_callback(f.debugger, test_callback, &cb_state);
+
+    size_t bp_id = 0;
+    EXPECT_EQ(
+        basl_debugger_set_breakpoint(f.debugger, f.source_id, 4, &bp_id, &f.error),
+        BASL_STATUS_OK
+    );
+
+    basl_debugger_attach(f.debugger);
+
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    EXPECT_EQ(basl_vm_execute_function(f.vm, fn, &result, &f.error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_value_as_int(&result), 30);
+
+    /* Should have hit the breakpoint on line 4. */
+    EXPECT_FALSE(cb_state.hit_lines.empty());
+    bool found_line_4 = false;
+    for (uint32_t line : cb_state.hit_lines) {
+        if (line == 4) found_line_4 = true;
+    }
+    EXPECT_TRUE(found_line_4);
+    EXPECT_EQ(cb_state.reasons[0], BASL_DEBUG_STOP_BREAKPOINT);
+
+    basl_debugger_detach(f.debugger);
+    basl_value_release(&result);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebuggerTest, ClearBreakpointStopsHitting) {
+    DebuggerFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    i32 x = 10;
+    return x;
+}
+    )");
+    ASSERT_NE(fn, nullptr);
+    f.create_debugger();
+
+    CallbackState cb_state;
+    basl_debugger_set_callback(f.debugger, test_callback, &cb_state);
+
+    size_t bp_id = 0;
+    basl_debugger_set_breakpoint(f.debugger, f.source_id, 3, &bp_id, &f.error);
+    basl_debugger_clear_breakpoint(f.debugger, bp_id);
+
+    basl_debugger_attach(f.debugger);
+
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    EXPECT_EQ(basl_vm_execute_function(f.vm, fn, &result, &f.error), BASL_STATUS_OK);
+
+    /* No breakpoints should have been hit. */
+    EXPECT_TRUE(cb_state.hit_lines.empty());
+
+    basl_debugger_detach(f.debugger);
+    basl_value_release(&result);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebuggerTest, FrameCountDuringCallback) {
+    DebuggerFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    return 42;
+}
+    )");
+    ASSERT_NE(fn, nullptr);
+    f.create_debugger();
+
+    struct FrameCheckState {
+        size_t frame_count = 0;
+    } fc_state;
+
+    auto frame_check_cb = [](basl_debugger_t *debugger,
+                             basl_debug_stop_reason_t,
+                             void *userdata) -> basl_debug_action_t {
+        auto *s = static_cast<FrameCheckState *>(userdata);
+        s->frame_count = basl_debugger_frame_count(debugger);
+        return BASL_DEBUG_CONTINUE;
+    };
+
+    basl_debugger_set_callback(f.debugger, frame_check_cb, &fc_state);
+    size_t bp_id = 0;
+    basl_debugger_set_breakpoint(f.debugger, f.source_id, 3, &bp_id, &f.error);
+    basl_debugger_attach(f.debugger);
+
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    basl_vm_execute_function(f.vm, fn, &result, &f.error);
+
+    EXPECT_GE(fc_state.frame_count, 1U);
+
+    basl_debugger_detach(f.debugger);
+    basl_value_release(&result);
+    basl_object_release(&fn);
+}
+
+TEST(BaslDebuggerTest, NoDebuggerAttachedRunsNormally) {
+    DebuggerFixture f;
+    basl_object_t *fn = f.compile(R"(
+fn main() -> i32 {
+    return 99;
+}
+    )");
+    ASSERT_NE(fn, nullptr);
+
+    /* Don't create or attach a debugger — just run. */
+    basl_value_t result;
+    basl_value_init_nil(&result);
+    EXPECT_EQ(basl_vm_execute_function(f.vm, fn, &result, &f.error), BASL_STATUS_OK);
+    EXPECT_EQ(basl_value_as_int(&result), 99);
+
+    basl_value_release(&result);
+    basl_object_release(&fn);
+}
+
+}  // namespace


### PR DESCRIPTION
Pure C library API for debugging BASL programs. No CLI commands, no DAP protocol — just the core debug engine that any frontend can drive.

## Design

The debugger attaches to a VM via a lightweight hook function pointer. When NULL (no debugger), the VM runs at full speed with zero overhead. When set, the hook is called before each opcode dispatch to check breakpoints and step conditions.

## Public API

### Lifecycle
```c
basl_debugger_create(&debugger, vm, sources, &error);
basl_debugger_attach(debugger);    // install VM hook
basl_debugger_detach(debugger);    // remove hook, full speed
basl_debugger_destroy(&debugger);
```

### Breakpoints
```c
basl_debugger_set_breakpoint(debugger, source_id, line, &bp_id, &error);
basl_debugger_clear_breakpoint(debugger, bp_id);
basl_debugger_clear_all_breakpoints(debugger);
```

### Execution control
```c
basl_debugger_step_over(debugger);   // next source line, skip calls
basl_debugger_step_into(debugger);   // next source line, enter calls
basl_debugger_step_out(debugger);    // run until current function returns
basl_debugger_continue(debugger);    // run until next breakpoint
basl_debugger_pause(debugger);       // pause at next opportunity
```

### Inspection (while paused in callback)
```c
basl_debugger_current_location(debugger, &source_id, &line, &column);
basl_debugger_frame_count(debugger);
basl_debugger_frame_info(debugger, i, &name, &len, &src, &line, &col);
basl_debugger_frame_locals(debugger, i, names, lengths, values, max);
```

### Callback model
```c
basl_debug_action_t on_pause(basl_debugger_t *dbg,
                              basl_debug_stop_reason_t reason,
                              void *userdata) {
    // inspect state, set next action...
    return BASL_DEBUG_CONTINUE;  // or BASL_DEBUG_PAUSE
}
basl_debugger_set_callback(debugger, on_pause, userdata);
```

## VM changes

- Added `debug_hook` and `debug_hook_userdata` to VM struct
- Added `basl_vm_set_debug_hook()` public API
- Added frame inspection: `basl_vm_frame_chunk/ip/base_slot/function()`
- Hook check in both computed-goto and switch dispatch paths

## What this enables

A DAP (Debug Adapter Protocol) server can be built on top of this API to support VS Code debugging. The server would:
1. Create a debugger, attach to VM
2. Translate DAP requests (setBreakpoints, next, stepIn, etc.) to debugger API calls
3. In the callback, translate debugger state to DAP events (stopped, stackTrace, variables)

## Testing
- 323/323 tests (6 new)
- ASAN+UBSAN clean
- Portability clean (58 core files)