### PR TITLE
Enable POSIX file I/O for Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,7 @@ add_library(basl ${BASL_LIBRARY_TYPE}
 # ── Platform abstraction layer ──────────────────────────────────────
 if(WIN32)
     target_sources(basl PRIVATE src/platform/platform_win32.c)
-elseif(EMSCRIPTEN)
-    target_sources(basl PRIVATE src/platform/platform_stub.c)
-elseif(UNIX)
+elseif(UNIX OR EMSCRIPTEN)
     target_sources(basl PRIVATE src/platform/platform_posix.c)
 else()
     target_sources(basl PRIVATE src/platform/platform_stub.c)

--- a/tests/platform_test.cpp
+++ b/tests/platform_test.cpp
@@ -24,8 +24,6 @@ protected:
 
 /* ── File read/write round-trip ──────────────────────────────────── */
 
-#ifndef __EMSCRIPTEN__
-
 TEST_F(PlatformTest, WriteAndReadFile) {
     const char *path = "test_platform_rw.tmp";
     const char *content = "hello platform";
@@ -185,8 +183,6 @@ TEST_F(PlatformTest, WriteEmptyFile) {
     basl_platform_remove(path, &error);
 }
 
-#endif /* !__EMSCRIPTEN__ */
-
 /* ── Stub contract tests (always compiled) ───────────────────────── */
 
 /* These verify the stub returns UNSUPPORTED.  On native builds we
@@ -196,10 +192,6 @@ TEST_F(PlatformTest, WriteEmptyFile) {
 TEST_F(PlatformTest, FileExistsReturnsValidStatus) {
     int exists = 0;
     basl_status_t s = basl_platform_file_exists(".", &exists);
-#ifdef __EMSCRIPTEN__
-    EXPECT_EQ(s, BASL_STATUS_UNSUPPORTED);
-#else
     EXPECT_EQ(s, BASL_STATUS_OK);
-    EXPECT_EQ(exists, 1);  /* "." always exists on native */
-#endif
+    EXPECT_EQ(exists, 1);  /* "." always exists */
 }


### PR DESCRIPTION
Emscripten supports POSIX file APIs via MEMFS (in-browser) and NODEFS (Node.js). Switch from the stub to `platform_posix.c` for Emscripten builds.

Changes:
- CMake: Emscripten now uses `platform_posix.c` (was `platform_stub.c`)
- Tests: removed `#ifndef __EMSCRIPTEN__` guard — all 10 platform tests now run on Emscripten too
- Stub is retained for truly unknown/unsupported platforms