### PR TITLE
Add 'basl new' project scaffolding + CLI rewrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Andr
 
     set_target_properties(basl_cli PROPERTIES OUTPUT_NAME basl)
     target_link_libraries(basl_cli PRIVATE basl)
+    target_include_directories(basl_cli PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_compile_features(basl_cli PRIVATE c_std_11)
 endif()
 
@@ -154,6 +155,7 @@ if(BASL_BUILD_TESTS)
 
     add_executable(basl_tests
         tests/array_test.cpp
+        tests/basl_new_test.cpp
         tests/binding_test.cpp
         tests/checker_test.cpp
         tests/chunk_test.cpp

--- a/integration_tests/test_regression.py
+++ b/integration_tests/test_regression.py
@@ -37,7 +37,7 @@ def write_sources(root: Path, sources: dict[str, str]) -> None:
 
 def run_basl(root: Path, entry: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [*resolve_basl_command(), str(root / entry)],
+        [*resolve_basl_command(), "run", str(root / entry)],
         capture_output=True, text=True, cwd=REPO_ROOT, check=False,
     )
 

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -35,7 +35,7 @@ def write_sources(root: Path, sources: dict[str, str]) -> None:
 
 def run_basl(root: Path, entrypoint: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [*resolve_basl_command(), str(root / entrypoint)],
+        [*resolve_basl_command(), "run", str(root / entrypoint)],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -3,14 +3,14 @@
 #include <string.h>
 
 #include "basl/basl.h"
+#include "basl/cli_lib.h"
 #include "basl/stdlib.h"
+#include "basl/toml.h"
+#include "platform/platform.h"
 
-typedef enum basl_cli_mode {
-    BASL_CLI_MODE_RUN = 0,
-    BASL_CLI_MODE_CHECK = 1
-} basl_cli_mode_t;
+/* ── Shared helpers ──────────────────────────────────────────────── */
 
-static void basl_log_cli_message(
+static void log_cli_message(
     basl_runtime_t *runtime,
     basl_log_level_t level,
     const char *message,
@@ -21,53 +21,26 @@ static void basl_log_cli_message(
     const basl_logger_t *logger;
 
     logger = basl_runtime_logger(runtime);
-
     if (field_key != NULL && field_value != NULL) {
         field.key = field_key;
         field.value = field_value;
-        (void)basl_logger_log(
-            logger,
-            level,
-            message,
-            &field,
-            1U,
-            NULL
-        );
+        (void)basl_logger_log(logger, level, message, &field, 1U, NULL);
         return;
     }
-
     (void)basl_logger_log(logger, level, message, NULL, 0U, NULL);
 }
 
-static FILE *basl_open_file(const char *path, const char *mode) {
-#ifdef _WIN32
-    FILE *file = NULL;
-
-    if (fopen_s(&file, path, mode) != 0) {
-        return NULL;
-    }
-    return file;
-#else
-    return fopen(path, mode);
-#endif
-}
-
-static void basl_set_cli_error(
-    basl_error_t *error,
-    basl_status_t type,
-    const char *message
+static void set_cli_error(
+    basl_error_t *error, basl_status_t type, const char *message
 ) {
-    if (error == NULL) {
-        return;
-    }
-
+    if (error == NULL) return;
     basl_error_clear(error);
     error->type = type;
     error->value = message;
     error->length = message == NULL ? 0U : strlen(message);
 }
 
-static int basl_print_diagnostics(
+static int print_diagnostics(
     const basl_source_registry_t *registry,
     const basl_diagnostic_list_t *diagnostics
 ) {
@@ -81,30 +54,17 @@ static int basl_print_diagnostics(
     memset(&error, 0, sizeof(error));
     for (index = 0U; index < basl_diagnostic_list_count(diagnostics); index += 1U) {
         const basl_diagnostic_t *diagnostic;
-
         diagnostic = basl_diagnostic_list_get(diagnostics, index);
-        if (diagnostic == NULL) {
-            continue;
-        }
-
+        if (diagnostic == NULL) continue;
         if (basl_diagnostic_format(registry, diagnostic, &line, &error) == BASL_STATUS_OK) {
             fprintf(stderr, "%s\n", basl_string_c_str(&line));
-        } else {
-            basl_log_cli_message(
-                runtime,
-                BASL_LOG_ERROR,
-                "failed to format diagnostic",
-                "error",
-                basl_error_message(&error)
-            );
         }
     }
     basl_string_free(&line);
-
     return 1;
 }
 
-static void basl_print_error(
+static void print_error(
     const basl_source_registry_t *registry,
     const char *prefix,
     const basl_error_t *error
@@ -116,250 +76,104 @@ static void basl_print_error(
         fprintf(stderr, "%s: unknown error\n", prefix);
         return;
     }
-
     if (registry != NULL && error->location.source_id != 0U) {
         location = error->location;
         if (basl_source_registry_resolve_location(registry, &location, NULL) == BASL_STATUS_OK) {
             source = basl_source_registry_get(registry, location.source_id);
-            fprintf(
-                stderr,
-                "%s: %s:%u:%u: %s\n",
-                prefix,
-                source == NULL ? "<unknown>" : basl_string_c_str(&source->path),
-                location.line,
-                location.column,
-                basl_error_message(error)
-            );
+            fprintf(stderr, "%s: %s:%u:%u: %s\n", prefix,
+                    source == NULL ? "<unknown>" : basl_string_c_str(&source->path),
+                    location.line, location.column, basl_error_message(error));
             return;
         }
     }
-
     fprintf(stderr, "%s: %s\n", prefix, basl_error_message(error));
 }
 
-static char *basl_read_file(const char *path, size_t *out_length) {
-    FILE *file;
-    long size;
-    char *buffer;
-    size_t read_length;
+/* ── Source loading ──────────────────────────────────────────────── */
 
-    *out_length = 0U;
-    file = basl_open_file(path, "rb");
-    if (file == NULL) {
-        return NULL;
-    }
-
-    if (fseek(file, 0L, SEEK_END) != 0) {
-        fclose(file);
-        return NULL;
-    }
-    size = ftell(file);
-    if (size < 0L) {
-        fclose(file);
-        return NULL;
-    }
-    if (fseek(file, 0L, SEEK_SET) != 0) {
-        fclose(file);
-        return NULL;
-    }
-
-    buffer = (char *)malloc((size_t)size + 1U);
-    if (buffer == NULL) {
-        fclose(file);
-        return NULL;
-    }
-
-    read_length = fread(buffer, 1U, (size_t)size, file);
-    fclose(file);
-    if (read_length != (size_t)size) {
-        free(buffer);
-        return NULL;
-    }
-
-    buffer[read_length] = '\0';
-    *out_length = read_length;
-    return buffer;
-}
-
-static int basl_path_has_basl_extension(const char *path, size_t length) {
-    return path != NULL &&
-           length >= 5U &&
+static int path_has_basl_extension(const char *path, size_t length) {
+    return path != NULL && length >= 5U &&
            memcmp(path + length - 5U, ".basl", 5U) == 0;
 }
 
-static int basl_path_is_absolute(const char *path, size_t length) {
-    if (path == NULL || length == 0U) {
-        return 0;
-    }
-
-    if (path[0] == '/' || path[0] == '\\') {
-        return 1;
-    }
-
+static int path_is_absolute(const char *path, size_t length) {
+    if (path == NULL || length == 0U) return 0;
+    if (path[0] == '/' || path[0] == '\\') return 1;
     return length >= 2U &&
-           ((path[0] >= 'A' && path[0] <= 'Z') ||
-            (path[0] >= 'a' && path[0] <= 'z')) &&
+           ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
            path[1] == ':';
 }
 
-static int basl_registry_find_source_path(
-    const basl_source_registry_t *registry,
-    const char *path,
+static int registry_find_source_path(
+    const basl_source_registry_t *registry, const char *path,
     basl_source_id_t *out_source_id
 ) {
     size_t index;
-
-    if (out_source_id != NULL) {
-        *out_source_id = 0U;
-    }
-    if (registry == NULL || path == NULL) {
-        return 0;
-    }
-
+    if (out_source_id != NULL) *out_source_id = 0U;
+    if (registry == NULL || path == NULL) return 0;
     for (index = 1U; index <= basl_source_registry_count(registry); index += 1U) {
         const basl_source_file_t *source;
-
         source = basl_source_registry_get(registry, (basl_source_id_t)index);
-        if (source == NULL) {
-            continue;
-        }
+        if (source == NULL) continue;
         if (strcmp(basl_string_c_str(&source->path), path) == 0) {
-            if (out_source_id != NULL) {
-                *out_source_id = source->id;
-            }
+            if (out_source_id != NULL) *out_source_id = source->id;
             return 1;
         }
     }
-
     return 0;
 }
 
-static const char *basl_source_token_text(
-    const basl_source_file_t *source,
-    const basl_token_t *token,
-    size_t *out_length
+static const char *source_token_text(
+    const basl_source_file_t *source, const basl_token_t *token, size_t *out_length
 ) {
     size_t length;
-
-    if (out_length != NULL) {
-        *out_length = 0U;
-    }
-    if (source == NULL || token == NULL) {
-        return NULL;
-    }
-
+    if (out_length != NULL) *out_length = 0U;
+    if (source == NULL || token == NULL) return NULL;
     length = token->span.end_offset - token->span.start_offset;
-    if (out_length != NULL) {
-        *out_length = length;
-    }
+    if (out_length != NULL) *out_length = length;
     return basl_string_c_str(&source->text) + token->span.start_offset;
 }
 
-static basl_status_t basl_resolve_import_path(
-    basl_runtime_t *runtime,
-    const char *base_path,
-    const char *import_text,
-    size_t import_length,
-    basl_string_t *out_path,
-    basl_error_t *error
+static basl_status_t resolve_import_path(
+    basl_runtime_t *runtime, const char *base_path,
+    const char *import_text, size_t import_length,
+    basl_string_t *out_path, basl_error_t *error
 ) {
-    size_t base_length;
-    size_t prefix_length;
-
+    size_t base_length, prefix_length;
     basl_string_clear(out_path);
-    if (
-        runtime == NULL ||
-        base_path == NULL ||
-        import_text == NULL ||
-        out_path == NULL
-    ) {
-        basl_set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "import path inputs must not be null");
+    if (runtime == NULL || base_path == NULL || import_text == NULL || out_path == NULL) {
+        set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "import path inputs must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
     }
-
-    if (basl_path_is_absolute(import_text, import_length)) {
+    if (path_is_absolute(import_text, import_length))
         return basl_string_assign(out_path, import_text, import_length, error);
-    }
 
     base_length = strlen(base_path);
     prefix_length = base_length;
     while (prefix_length > 0U) {
         char current = base_path[prefix_length - 1U];
-
-        if (current == '/' || current == '\\') {
-            break;
-        }
+        if (current == '/' || current == '\\') break;
         prefix_length -= 1U;
     }
-
     if (prefix_length != 0U) {
-        if (basl_string_assign(out_path, base_path, prefix_length, error) != BASL_STATUS_OK) {
+        if (basl_string_assign(out_path, base_path, prefix_length, error) != BASL_STATUS_OK)
             return error->type;
-        }
-        if (basl_string_append(out_path, import_text, import_length, error) != BASL_STATUS_OK) {
+        if (basl_string_append(out_path, import_text, import_length, error) != BASL_STATUS_OK)
             return error->type;
-        }
-    } else if (
-        basl_string_assign(out_path, import_text, import_length, error) != BASL_STATUS_OK
-    ) {
+    } else if (basl_string_assign(out_path, import_text, import_length, error) != BASL_STATUS_OK) {
         return error->type;
     }
-
-    if (!basl_path_has_basl_extension(basl_string_c_str(out_path), basl_string_length(out_path))) {
-        if (basl_string_append_cstr(out_path, ".basl", error) != BASL_STATUS_OK) {
+    if (!path_has_basl_extension(basl_string_c_str(out_path), basl_string_length(out_path))) {
+        if (basl_string_append_cstr(out_path, ".basl", error) != BASL_STATUS_OK)
             return error->type;
-        }
     }
-
     (void)runtime;
     return BASL_STATUS_OK;
 }
 
-static int basl_parse_mode(
-    int argc,
-    char **argv,
-    basl_cli_mode_t *out_mode,
-    const char **out_path
-) {
-    if (argc == 2) {
-        *out_mode = BASL_CLI_MODE_RUN;
-        *out_path = argv[1];
-        return 1;
-    }
-
-    if (argc == 3 && strcmp(argv[1], "check") == 0) {
-        *out_mode = BASL_CLI_MODE_CHECK;
-        *out_path = argv[2];
-        return 1;
-    }
-
-    return 0;
-}
-
-static int basl_register_script_source(
-    basl_source_registry_t *registry,
-    const char *path,
-    const char *file_text,
-    size_t file_length,
-    basl_source_id_t *out_source_id,
-    basl_error_t *error
-) {
-    return basl_source_registry_register(
-               registry,
-               path,
-               strlen(path),
-               file_text,
-               file_length,
-               out_source_id,
-               error
-           ) == BASL_STATUS_OK;
-}
-
-static int basl_register_source_tree(
-    basl_source_registry_t *registry,
-    const char *path,
-    basl_source_id_t *out_source_id,
-    basl_error_t *error
+static int register_source_tree(
+    basl_source_registry_t *registry, const char *path,
+    basl_source_id_t *out_source_id, basl_error_t *error
 ) {
     basl_runtime_t *runtime;
     basl_source_id_t source_id;
@@ -369,47 +183,32 @@ static int basl_register_source_tree(
     basl_token_list_t tokens;
     basl_diagnostic_list_t diagnostics;
     const basl_token_t *token;
-    size_t cursor;
-    size_t brace_depth;
+    size_t cursor, brace_depth;
 
     runtime = registry == NULL ? NULL : registry->runtime;
     source_id = 0U;
-    if (basl_registry_find_source_path(registry, path, &source_id)) {
-        if (out_source_id != NULL) {
-            *out_source_id = source_id;
-        }
+    if (registry_find_source_path(registry, path, &source_id)) {
+        if (out_source_id != NULL) *out_source_id = source_id;
         basl_error_clear(error);
         return 1;
     }
 
-    file_text = basl_read_file(path, &file_length);
-    if (file_text == NULL) {
-        basl_set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "failed to read imported source");
+    if (basl_platform_read_file(NULL, path, &file_text, &file_length, error) != BASL_STATUS_OK) {
+        set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "failed to read imported source");
         return 0;
     }
 
-    if (
-        !basl_register_script_source(
-            registry,
-            path,
-            file_text,
-            file_length,
-            &source_id,
-            error
-        )
-    ) {
+    if (basl_source_registry_register(registry, path, strlen(path),
+            file_text, file_length, &source_id, error) != BASL_STATUS_OK) {
         free(file_text);
         return 0;
     }
     free(file_text);
-
-    if (out_source_id != NULL) {
-        *out_source_id = source_id;
-    }
+    if (out_source_id != NULL) *out_source_id = source_id;
 
     source = basl_source_registry_get(registry, source_id);
     if (source == NULL) {
-        basl_set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "registered source was not found");
+        set_cli_error(error, BASL_STATUS_INVALID_ARGUMENT, "registered source was not found");
         return 0;
     }
 
@@ -426,75 +225,43 @@ static int basl_register_source_tree(
     brace_depth = 0U;
     while (1) {
         token = basl_token_list_get(&tokens, cursor);
-        if (token == NULL || token->kind == BASL_TOKEN_EOF) {
-            break;
-        }
-
-        if (token->kind == BASL_TOKEN_LBRACE) {
-            brace_depth += 1U;
-            cursor += 1U;
-            continue;
-        }
+        if (token == NULL || token->kind == BASL_TOKEN_EOF) break;
+        if (token->kind == BASL_TOKEN_LBRACE) { brace_depth++; cursor++; continue; }
         if (token->kind == BASL_TOKEN_RBRACE) {
-            if (brace_depth != 0U) {
-                brace_depth -= 1U;
-            }
-            cursor += 1U;
+            if (brace_depth != 0U) brace_depth--;
+            cursor++;
             continue;
         }
-
         if (brace_depth == 0U && token->kind == BASL_TOKEN_IMPORT) {
             const basl_token_t *path_token;
             basl_string_t import_path;
             const char *import_text;
             size_t import_length;
 
-            cursor += 1U;
+            cursor++;
             path_token = basl_token_list_get(&tokens, cursor);
-            if (
-                path_token == NULL ||
+            if (path_token == NULL ||
                 (path_token->kind != BASL_TOKEN_STRING_LITERAL &&
-                 path_token->kind != BASL_TOKEN_RAW_STRING_LITERAL)
-            ) {
+                 path_token->kind != BASL_TOKEN_RAW_STRING_LITERAL))
                 break;
-            }
 
-            import_text = basl_source_token_text(source, path_token, &import_length);
-            if (import_text == NULL || import_length < 2U) {
-                break;
-            }
+            import_text = source_token_text(source, path_token, &import_length);
+            if (import_text == NULL || import_length < 2U) break;
 
-            /* Skip native stdlib modules — they don't have .basl files. */
-            if (basl_stdlib_is_native_module(
-                    import_text + 1U, import_length - 2U)) {
-                cursor += 1U;
+            if (basl_stdlib_is_native_module(import_text + 1U, import_length - 2U)) {
+                cursor++;
                 continue;
             }
 
             basl_string_init(&import_path, runtime);
-            if (
-                basl_resolve_import_path(
-                    runtime,
-                    basl_string_c_str(&source->path),
-                    import_text + 1U,
-                    import_length - 2U,
-                    &import_path,
-                    error
-                ) != BASL_STATUS_OK
-            ) {
+            if (resolve_import_path(runtime, basl_string_c_str(&source->path),
+                    import_text + 1U, import_length - 2U, &import_path, error) != BASL_STATUS_OK) {
                 basl_string_free(&import_path);
                 basl_token_list_free(&tokens);
                 basl_diagnostic_list_free(&diagnostics);
                 return 0;
             }
-            if (
-                !basl_register_source_tree(
-                    registry,
-                    basl_string_c_str(&import_path),
-                    NULL,
-                    error
-                )
-            ) {
+            if (!register_source_tree(registry, basl_string_c_str(&import_path), NULL, error)) {
                 basl_string_free(&import_path);
                 basl_token_list_free(&tokens);
                 basl_diagnostic_list_free(&diagnostics);
@@ -502,8 +269,7 @@ static int basl_register_source_tree(
             }
             basl_string_free(&import_path);
         }
-
-        cursor += 1U;
+        cursor++;
     }
 
     basl_token_list_free(&tokens);
@@ -512,86 +278,9 @@ static int basl_register_source_tree(
     return 1;
 }
 
-static int basl_check_script(
-    const basl_source_registry_t *registry,
-    basl_source_id_t source_id,
-    basl_diagnostic_list_t *diagnostics,
-    basl_error_t *error
-) {
-    basl_status_t status;
+/* ── run command ─────────────────────────────────────────────────── */
 
-    status = basl_check_source(registry, source_id, diagnostics, error);
-    if (status == BASL_STATUS_OK) {
-        return 0;
-    }
-
-    if (basl_diagnostic_list_count(diagnostics) != 0U) {
-        return 2;
-    }
-
-    basl_print_error(registry, "check failed", error);
-    return 1;
-}
-
-static int basl_run_script(
-    basl_runtime_t *runtime,
-    basl_vm_t *vm,
-    const basl_source_registry_t *registry,
-    basl_source_id_t source_id,
-    basl_diagnostic_list_t *diagnostics,
-    basl_value_t *result,
-    basl_error_t *error
-) {
-    basl_object_t *function;
-    basl_status_t status;
-
-    function = NULL;
-    {
-        basl_native_registry_t natives;
-
-        basl_native_registry_init(&natives);
-        basl_stdlib_register_all(&natives, error);
-        status = basl_compile_source_with_natives(
-            registry, source_id, &natives,
-            &function, diagnostics, error
-        );
-        basl_native_registry_free(&natives);
-    }
-    if (status != BASL_STATUS_OK) {
-        if (basl_diagnostic_list_count(diagnostics) != 0U) {
-            basl_object_release(&function);
-            return 2;
-        }
-
-        basl_print_error(registry, "compile failed", error);
-        basl_object_release(&function);
-        return 1;
-    }
-
-    status = basl_vm_execute_function(vm, function, result, error);
-    basl_object_release(&function);
-    if (status != BASL_STATUS_OK) {
-        basl_print_error(registry, "execution failed", error);
-        return 1;
-    }
-
-    if (basl_value_kind(result) != BASL_VALUE_INT) {
-        basl_log_cli_message(
-            runtime,
-            BASL_LOG_ERROR,
-            "compiled entrypoint did not return i32",
-            NULL,
-            NULL
-        );
-        return 1;
-    }
-
-    return (int)basl_value_as_int(result);
-}
-
-int main(int argc, char **argv) {
-    basl_cli_mode_t mode;
-    const char *script_path;
+static int cmd_run(const char *script_path) {
     basl_runtime_t *runtime = NULL;
     basl_vm_t *vm = NULL;
     basl_error_t error = {0};
@@ -599,30 +288,17 @@ int main(int argc, char **argv) {
     basl_diagnostic_list_t diagnostics;
     basl_value_t result;
     basl_source_id_t source_id = 0U;
+    basl_object_t *function = NULL;
+    basl_status_t status;
     int exit_code = 0;
-
-    if (!basl_parse_mode(argc, argv, &mode, &script_path)) {
-        fprintf(stderr, "usage: %s <script.basl>\n", argv[0]);
-        fprintf(stderr, "       %s check <script.basl>\n", argv[0]);
-        return 2;
-    }
 
     if (basl_runtime_open(&runtime, NULL, &error) != BASL_STATUS_OK) {
         fprintf(stderr, "failed to initialize runtime: %s\n", basl_error_message(&error));
         return 1;
     }
-
-    if (
-        mode == BASL_CLI_MODE_RUN &&
-        basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK
-    ) {
-        basl_log_cli_message(
-            runtime,
-            BASL_LOG_ERROR,
-            "failed to initialize vm",
-            "error",
-            basl_error_message(&error)
-        );
+    if (basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK) {
+        log_cli_message(runtime, BASL_LOG_ERROR, "failed to initialize vm",
+                        "error", basl_error_message(&error));
         basl_runtime_close(&runtime);
         return 1;
     }
@@ -631,51 +307,314 @@ int main(int argc, char **argv) {
     basl_diagnostic_list_init(&diagnostics, runtime);
     basl_value_init_nil(&result);
 
-    if (
-        !basl_register_source_tree(
-            &registry,
-            script_path,
-            &source_id,
-            &error
-        )
-    ) {
-        basl_log_cli_message(
-            runtime,
-            BASL_LOG_ERROR,
-            "failed to register source",
-            "error",
-            basl_error_message(&error)
-        );
+    if (!register_source_tree(&registry, script_path, &source_id, &error)) {
+        log_cli_message(runtime, BASL_LOG_ERROR, "failed to register source",
+                        "error", basl_error_message(&error));
         exit_code = 1;
         goto cleanup;
     }
 
-    if (mode == BASL_CLI_MODE_CHECK) {
-        exit_code = basl_check_script(&registry, source_id, &diagnostics, &error);
+    {
+        basl_native_registry_t natives;
+        basl_native_registry_init(&natives);
+        basl_stdlib_register_all(&natives, &error);
+        status = basl_compile_source_with_natives(&registry, source_id, &natives,
+                                                   &function, &diagnostics, &error);
+        basl_native_registry_free(&natives);
+    }
+    if (status != BASL_STATUS_OK) {
         if (basl_diagnostic_list_count(&diagnostics) != 0U) {
-            exit_code = basl_print_diagnostics(&registry, &diagnostics);
+            exit_code = print_diagnostics(&registry, &diagnostics);
+        } else {
+            print_error(&registry, "compile failed", &error);
+            exit_code = 1;
         }
+        basl_object_release(&function);
         goto cleanup;
     }
 
-    exit_code = basl_run_script(
-        runtime,
-        vm,
-        &registry,
-        source_id,
-        &diagnostics,
-        &result,
-        &error
-    );
-    if (basl_diagnostic_list_count(&diagnostics) != 0U) {
-        exit_code = basl_print_diagnostics(&registry, &diagnostics);
+    status = basl_vm_execute_function(vm, function, &result, &error);
+    basl_object_release(&function);
+    if (status != BASL_STATUS_OK) {
+        print_error(&registry, "execution failed", &error);
+        exit_code = 1;
+        goto cleanup;
     }
+    if (basl_value_kind(&result) != BASL_VALUE_INT) {
+        log_cli_message(runtime, BASL_LOG_ERROR,
+                        "compiled entrypoint did not return i32", NULL, NULL);
+        exit_code = 1;
+        goto cleanup;
+    }
+    exit_code = (int)basl_value_as_int(&result);
 
 cleanup:
+    if (basl_diagnostic_list_count(&diagnostics) != 0U)
+        print_diagnostics(&registry, &diagnostics);
     basl_value_release(&result);
     basl_diagnostic_list_free(&diagnostics);
     basl_source_registry_free(&registry);
     basl_vm_close(&vm);
     basl_runtime_close(&runtime);
     return exit_code;
+}
+
+/* ── check command ───────────────────────────────────────────────── */
+
+static int cmd_check(const char *script_path) {
+    basl_runtime_t *runtime = NULL;
+    basl_error_t error = {0};
+    basl_source_registry_t registry;
+    basl_diagnostic_list_t diagnostics;
+    basl_source_id_t source_id = 0U;
+    basl_status_t status;
+    int exit_code = 0;
+
+    if (basl_runtime_open(&runtime, NULL, &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "failed to initialize runtime: %s\n", basl_error_message(&error));
+        return 1;
+    }
+
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+
+    if (!register_source_tree(&registry, script_path, &source_id, &error)) {
+        log_cli_message(runtime, BASL_LOG_ERROR, "failed to register source",
+                        "error", basl_error_message(&error));
+        exit_code = 1;
+        goto cleanup;
+    }
+
+    status = basl_check_source(&registry, source_id, &diagnostics, &error);
+    if (status != BASL_STATUS_OK) {
+        if (basl_diagnostic_list_count(&diagnostics) != 0U) {
+            exit_code = print_diagnostics(&registry, &diagnostics);
+        } else {
+            print_error(&registry, "check failed", &error);
+            exit_code = 1;
+        }
+    }
+
+cleanup:
+    basl_diagnostic_list_free(&diagnostics);
+    basl_source_registry_free(&registry);
+    basl_runtime_close(&runtime);
+    return exit_code;
+}
+
+/* ── new command ─────────────────────────────────────────────────── */
+
+static basl_status_t write_text_file(const char *base, const char *name,
+                                      const char *content, basl_error_t *error) {
+    char path[4096];
+    basl_status_t s = basl_platform_path_join(base, name, path, sizeof(path), error);
+    if (s != BASL_STATUS_OK) return s;
+    return basl_platform_write_file(path, content, strlen(content), error);
+}
+
+static basl_status_t make_subdir(const char *base, const char *name, basl_error_t *error) {
+    char path[4096];
+    basl_status_t s = basl_platform_path_join(base, name, path, sizeof(path), error);
+    if (s != BASL_STATUS_OK) return s;
+    return basl_platform_mkdir(path, error);
+}
+
+static int cmd_new(const char *name, int is_lib) {
+    basl_error_t error = {0};
+    basl_toml_value_t *root = NULL;
+    basl_toml_value_t *str_val = NULL;
+    char *toml_str = NULL;
+    size_t toml_len = 0;
+    int exists = 0;
+    char project_name[256];
+
+    /* If name not provided, prompt for it. */
+    if (name == NULL || name[0] == '\0') {
+        if (basl_platform_readline("Project name: ", project_name,
+                                    sizeof(project_name), &error) != BASL_STATUS_OK) {
+            fprintf(stderr, "error: %s\n", basl_error_message(&error));
+            return 1;
+        }
+        if (project_name[0] == '\0') {
+            fprintf(stderr, "error: project name cannot be empty\n");
+            return 1;
+        }
+        name = project_name;
+    }
+
+    /* Check if directory already exists. */
+    if (basl_platform_file_exists(name, &exists) == BASL_STATUS_OK && exists) {
+        fprintf(stderr, "error: '%s' already exists\n", name);
+        return 1;
+    }
+
+    /* Create project directory tree. */
+    if (basl_platform_mkdir_p(name, &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        return 1;
+    }
+    if (make_subdir(name, "lib", &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        return 1;
+    }
+    if (make_subdir(name, "test", &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        return 1;
+    }
+
+    /* Generate basl.toml. */
+    if (basl_toml_table_new(NULL, &root, &error) != BASL_STATUS_OK) goto toml_err;
+    if (basl_toml_string_new(NULL, name, strlen(name), &str_val, &error) != BASL_STATUS_OK) goto toml_err;
+    if (basl_toml_table_set(root, "name", 4, str_val, &error) != BASL_STATUS_OK) {
+        basl_toml_free(&str_val);
+        goto toml_err;
+    }
+    str_val = NULL;
+    if (basl_toml_string_new(NULL, "0.1.0", 5, &str_val, &error) != BASL_STATUS_OK) goto toml_err;
+    if (basl_toml_table_set(root, "version", 7, str_val, &error) != BASL_STATUS_OK) {
+        basl_toml_free(&str_val);
+        goto toml_err;
+    }
+    str_val = NULL;
+
+    if (basl_toml_emit(root, &toml_str, &toml_len, &error) != BASL_STATUS_OK) goto toml_err;
+    if (write_text_file(name, "basl.toml", toml_str, &error) != BASL_STATUS_OK) {
+        free(toml_str);
+        goto toml_err;
+    }
+    free(toml_str);
+    basl_toml_free(&root);
+
+    /* Write .gitignore. */
+    if (write_text_file(name, ".gitignore", "deps/\n", &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        return 1;
+    }
+
+    if (is_lib) {
+        /* Library project. */
+        char lib_file[512];
+        char test_file[512];
+        char lib_content[512];
+        char test_content[512];
+
+        snprintf(lib_file, sizeof(lib_file), "lib/%s.basl", name);
+        snprintf(test_file, sizeof(test_file), "test/%s_test.basl", name);
+
+        snprintf(lib_content, sizeof(lib_content),
+            "/// %s library module.\n"
+            "\n"
+            "pub fn hello() -> string {\n"
+            "    return \"hello from %s\";\n"
+            "}\n", name, name);
+
+        snprintf(test_content, sizeof(test_content),
+            "import \"test\";\n"
+            "import \"%s\";\n"
+            "\n"
+            "fn test_hello(test.T t) -> void {\n"
+            "    t.assert(%s.hello() == \"hello from %s\", \"hello should match\");\n"
+            "}\n", name, name, name);
+
+        if (write_text_file(name, lib_file, lib_content, &error) != BASL_STATUS_OK ||
+            write_text_file(name, test_file, test_content, &error) != BASL_STATUS_OK) {
+            fprintf(stderr, "error: %s\n", basl_error_message(&error));
+            return 1;
+        }
+    } else {
+        /* Application project. */
+        const char *main_content =
+            "import \"fmt\";\n"
+            "\n"
+            "fn main() -> i32 {\n"
+            "    fmt.println(\"hello, world!\");\n"
+            "    return 0;\n"
+            "}\n";
+
+        if (write_text_file(name, "main.basl", main_content, &error) != BASL_STATUS_OK) {
+            fprintf(stderr, "error: %s\n", basl_error_message(&error));
+            return 1;
+        }
+    }
+
+    printf("created %s\n", name);
+    printf("  basl.toml\n");
+    if (is_lib) {
+        printf("  lib/%s.basl\n", name);
+        printf("  test/%s_test.basl\n", name);
+    } else {
+        printf("  main.basl\n");
+    }
+    printf("  lib/\n");
+    printf("  test/\n");
+    printf("  .gitignore\n");
+
+    return 0;
+
+toml_err:
+    basl_toml_free(&root);
+    fprintf(stderr, "error: %s\n", basl_error_message(&error));
+    return 1;
+}
+
+/* ── main ────────────────────────────────────────────────────────── */
+
+int main(int argc, char **argv) {
+    basl_cli_t cli;
+    basl_cli_command_t *cmd_run_def;
+    basl_cli_command_t *cmd_check_def;
+    basl_cli_command_t *cmd_new_def;
+    const char *run_file = NULL;
+    const char *check_file = NULL;
+    const char *new_name = NULL;
+    int new_lib = 0;
+    basl_error_t error = {0};
+    const basl_cli_command_t *matched;
+
+    basl_cli_init(&cli, "basl", "Blazingly Awesome Scripting Language");
+
+    cmd_run_def = basl_cli_add_command(&cli, "run", "Run a BASL script");
+    basl_cli_add_positional(cmd_run_def, "file", "Script file to run", &run_file);
+
+    cmd_check_def = basl_cli_add_command(&cli, "check", "Type-check a BASL script");
+    basl_cli_add_positional(cmd_check_def, "file", "Script file to check", &check_file);
+
+    cmd_new_def = basl_cli_add_command(&cli, "new", "Create a new BASL project");
+    basl_cli_add_positional(cmd_new_def, "name", "Project name", &new_name);
+    basl_cli_add_bool_flag(cmd_new_def, "lib", 'l', "Create a library project", &new_lib);
+
+    if (basl_cli_parse(&cli, argc, argv, &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        basl_cli_free(&cli);
+        return 2;
+    }
+
+    matched = basl_cli_matched_command(&cli);
+    if (matched == NULL) {
+        basl_cli_print_help(&cli);
+        basl_cli_free(&cli);
+        return 0;
+    }
+
+    basl_cli_free(&cli);
+
+    if (matched == cmd_run_def) {
+        if (run_file == NULL) {
+            fprintf(stderr, "error: missing file argument\n");
+            return 2;
+        }
+        return cmd_run(run_file);
+    }
+    if (matched == cmd_check_def) {
+        if (check_file == NULL) {
+            fprintf(stderr, "error: missing file argument\n");
+            return 2;
+        }
+        return cmd_check(check_file);
+    }
+    if (matched == cmd_new_def) {
+        return cmd_new(new_name, new_lib);
+    }
+
+    return 0;
 }

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -72,6 +72,27 @@ BASL_API basl_status_t basl_platform_remove(
     basl_error_t *error
 );
 
+/** Join two path segments with the platform separator.  Always uses '/'. */
+BASL_API basl_status_t basl_platform_path_join(
+    const char *base,
+    const char *child,
+    char *out_buf,
+    size_t buf_size,
+    basl_error_t *error
+);
+
+/**
+ * Read a line from stdin.  Strips trailing newline.
+ * If prompt is non-NULL, prints it to stdout first.
+ * Returns BASL_STATUS_INTERNAL on EOF.
+ */
+BASL_API basl_status_t basl_platform_readline(
+    const char *prompt,
+    char *out_buf,
+    size_t buf_size,
+    basl_error_t *error
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -180,3 +180,55 @@ basl_status_t basl_platform_remove(const char *path, basl_error_t *error) {
     }
     return BASL_STATUS_OK;
 }
+
+basl_status_t basl_platform_path_join(
+    const char *base, const char *child,
+    char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    size_t blen, clen, total;
+    int need_sep;
+    if (!base || !child || !out_buf || buf_size == 0) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: NULL argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    blen = strlen(base);
+    clen = strlen(child);
+    need_sep = (blen > 0 && base[blen - 1] != '/' && base[blen - 1] != '\\') ? 1 : 0;
+    total = blen + (size_t)need_sep + clen;
+    if (total >= buf_size) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: path too long");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    memcpy(out_buf, base, blen);
+    if (need_sep) out_buf[blen] = '/';
+    memcpy(out_buf + blen + (size_t)need_sep, child, clen);
+    out_buf[total] = '\0';
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_platform_readline(
+    const char *prompt, char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    size_t len;
+    if (!out_buf || buf_size == 0) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: NULL argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    if (prompt) {
+        fputs(prompt, stdout);
+        fflush(stdout);
+    }
+    if (!fgets(out_buf, (int)buf_size, stdin)) {
+        out_buf[0] = '\0';
+        basl_error_set_literal(error, BASL_STATUS_INTERNAL, "platform: EOF on stdin");
+        return BASL_STATUS_INTERNAL;
+    }
+    len = strlen(out_buf);
+    while (len > 0 && (out_buf[len - 1] == '\n' || out_buf[len - 1] == '\r')) {
+        out_buf[--len] = '\0';
+    }
+    return BASL_STATUS_OK;
+}

--- a/src/platform/platform_stub.c
+++ b/src/platform/platform_stub.c
@@ -59,3 +59,22 @@ basl_status_t basl_platform_remove(const char *path, basl_error_t *error) {
                            "file I/O is not supported on this platform");
     return BASL_STATUS_UNSUPPORTED;
 }
+
+basl_status_t basl_platform_path_join(
+    const char *base, const char *child,
+    char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    (void)base; (void)child; (void)out_buf; (void)buf_size;
+    basl_error_set_literal(error, BASL_STATUS_UNSUPPORTED,
+                           "file I/O is not supported on this platform");
+    return BASL_STATUS_UNSUPPORTED;
+}
+
+basl_status_t basl_platform_readline(
+    const char *prompt, char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    (void)prompt; (void)out_buf; (void)buf_size;
+    basl_error_set_literal(error, BASL_STATUS_UNSUPPORTED,
+                           "stdin is not supported on this platform");
+    return BASL_STATUS_UNSUPPORTED;
+}

--- a/src/platform/platform_win32.c
+++ b/src/platform/platform_win32.c
@@ -193,3 +193,55 @@ basl_status_t basl_platform_remove(const char *path, basl_error_t *error) {
     }
     return BASL_STATUS_OK;
 }
+
+basl_status_t basl_platform_path_join(
+    const char *base, const char *child,
+    char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    size_t blen, clen, total;
+    int need_sep;
+    if (!base || !child || !out_buf || buf_size == 0) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: NULL argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    blen = strlen(base);
+    clen = strlen(child);
+    need_sep = (blen > 0 && base[blen - 1] != '/' && base[blen - 1] != '\\') ? 1 : 0;
+    total = blen + (size_t)need_sep + clen;
+    if (total >= buf_size) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: path too long");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    memcpy(out_buf, base, blen);
+    if (need_sep) out_buf[blen] = '/';
+    memcpy(out_buf + blen + (size_t)need_sep, child, clen);
+    out_buf[total] = '\0';
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_platform_readline(
+    const char *prompt, char *out_buf, size_t buf_size, basl_error_t *error
+) {
+    size_t len;
+    if (!out_buf || buf_size == 0) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "platform: NULL argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+    if (prompt) {
+        fputs(prompt, stdout);
+        fflush(stdout);
+    }
+    if (!fgets(out_buf, (int)buf_size, stdin)) {
+        out_buf[0] = '\0';
+        basl_error_set_literal(error, BASL_STATUS_INTERNAL, "platform: EOF on stdin");
+        return BASL_STATUS_INTERNAL;
+    }
+    len = strlen(out_buf);
+    while (len > 0 && (out_buf[len - 1] == '\n' || out_buf[len - 1] == '\r')) {
+        out_buf[--len] = '\0';
+    }
+    return BASL_STATUS_OK;
+}

--- a/tests/basl_new_test.cpp
+++ b/tests/basl_new_test.cpp
@@ -1,0 +1,263 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+extern "C" {
+#include "platform/platform.h"
+#include "basl/toml.h"
+}
+
+/* Helper: run basl new via the platform layer and verify results. */
+
+class BaslNewTest : public ::testing::Test {
+protected:
+    basl_error_t error{};
+
+    void TearDown() override {
+        basl_error_clear(&error);
+    }
+
+    /* Recursively remove a project directory. */
+    void remove_project(const char *name) {
+        char path[4096];
+        /* Remove files first, then dirs deepest-first. */
+        const char *files[] = {
+            "basl.toml", "main.basl", ".gitignore",
+            NULL
+        };
+        const char *lib_files[] = { NULL }; /* filled per test */
+        (void)lib_files;
+        for (int i = 0; files[i]; i++) {
+            basl_platform_path_join(name, files[i], path, sizeof(path), &error);
+            basl_platform_remove(path, &error);
+        }
+        /* Try lib/ and test/ contents. */
+        snprintf(path, sizeof(path), "%s/lib", name);
+        basl_platform_remove(path, &error);
+        snprintf(path, sizeof(path), "%s/test", name);
+        basl_platform_remove(path, &error);
+        basl_platform_remove(name, &error);
+    }
+
+    void remove_lib_project(const char *name) {
+        char path[4096];
+        snprintf(path, sizeof(path), "%s/lib/%s.basl", name, name);
+        basl_platform_remove(path, &error);
+        snprintf(path, sizeof(path), "%s/test/%s_test.basl", name, name);
+        basl_platform_remove(path, &error);
+        const char *files[] = { "basl.toml", ".gitignore", NULL };
+        for (int i = 0; files[i]; i++) {
+            basl_platform_path_join(name, files[i], path, sizeof(path), &error);
+            basl_platform_remove(path, &error);
+        }
+        snprintf(path, sizeof(path), "%s/lib", name);
+        basl_platform_remove(path, &error);
+        snprintf(path, sizeof(path), "%s/test", name);
+        basl_platform_remove(path, &error);
+        basl_platform_remove(name, &error);
+    }
+};
+
+/* ── Platform path_join ──────────────────────────────────────────── */
+
+TEST_F(BaslNewTest, PathJoinBasic) {
+    char buf[256];
+    ASSERT_EQ(BASL_STATUS_OK,
+              basl_platform_path_join("foo", "bar", buf, sizeof(buf), &error));
+    EXPECT_STREQ(buf, "foo/bar");
+}
+
+TEST_F(BaslNewTest, PathJoinTrailingSlash) {
+    char buf[256];
+    ASSERT_EQ(BASL_STATUS_OK,
+              basl_platform_path_join("foo/", "bar", buf, sizeof(buf), &error));
+    EXPECT_STREQ(buf, "foo/bar");
+}
+
+TEST_F(BaslNewTest, PathJoinOverflow) {
+    char buf[5];
+    EXPECT_NE(BASL_STATUS_OK,
+              basl_platform_path_join("long", "path", buf, sizeof(buf), &error));
+}
+
+TEST_F(BaslNewTest, PathJoinNull) {
+    char buf[256];
+    EXPECT_EQ(BASL_STATUS_INVALID_ARGUMENT,
+              basl_platform_path_join(NULL, "b", buf, sizeof(buf), &error));
+}
+
+/* ── App project scaffolding ─────────────────────────────────────── */
+
+TEST_F(BaslNewTest, AppProjectStructure) {
+    const char *name = "test_new_app_proj";
+    char path[4096];
+    int exists = 0;
+    int is_dir = 0;
+
+    /* Clean up from any previous failed run. */
+    remove_project(name);
+
+    /* Create project directory and files using platform functions
+     * (same logic as cmd_new in main.c). */
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir_p(name, &error));
+
+    basl_platform_path_join(name, "lib", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir(path, &error));
+
+    basl_platform_path_join(name, "test", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir(path, &error));
+
+    /* Write basl.toml via TOML library. */
+    {
+        basl_toml_value_t *root = nullptr;
+        basl_toml_value_t *val = nullptr;
+        char *toml_str = nullptr;
+        size_t toml_len = 0;
+
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_table_new(nullptr, &root, &error));
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_string_new(nullptr, name, strlen(name), &val, &error));
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_table_set(root, "name", 4, val, &error));
+        val = nullptr;
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_string_new(nullptr, "0.1.0", 5, &val, &error));
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_table_set(root, "version", 7, val, &error));
+        val = nullptr;
+        ASSERT_EQ(BASL_STATUS_OK, basl_toml_emit(root, &toml_str, &toml_len, &error));
+
+        basl_platform_path_join(name, "basl.toml", path, sizeof(path), &error);
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_write_file(path, toml_str, toml_len, &error));
+        free(toml_str);
+        basl_toml_free(&root);
+    }
+
+    /* Write main.basl. */
+    {
+        const char *content = "import \"fmt\";\n\nfn main() -> i32 {\n    fmt.println(\"hello\");\n    return 0;\n}\n";
+        basl_platform_path_join(name, "main.basl", path, sizeof(path), &error);
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_write_file(path, content, strlen(content), &error));
+    }
+
+    /* Write .gitignore. */
+    {
+        basl_platform_path_join(name, ".gitignore", path, sizeof(path), &error);
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_write_file(path, "deps/\n", 6, &error));
+    }
+
+    /* ── Verify structure using platform I/O ─────────────────────── */
+
+    /* Root directory exists. */
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_is_directory(name, &is_dir));
+    EXPECT_EQ(is_dir, 1);
+
+    /* lib/ directory. */
+    basl_platform_path_join(name, "lib", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_is_directory(path, &is_dir));
+    EXPECT_EQ(is_dir, 1);
+
+    /* test/ directory. */
+    basl_platform_path_join(name, "test", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_is_directory(path, &is_dir));
+    EXPECT_EQ(is_dir, 1);
+
+    /* basl.toml exists and parses correctly. */
+    basl_platform_path_join(name, "basl.toml", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_file_exists(path, &exists));
+    EXPECT_EQ(exists, 1);
+    {
+        char *data = nullptr;
+        size_t len = 0;
+        basl_toml_value_t *parsed = nullptr;
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_read_file(nullptr, path, &data, &len, &error));
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_toml_parse(nullptr, data, len, &parsed, &error));
+        EXPECT_STREQ(basl_toml_string_value(basl_toml_table_get(parsed, "name")), name);
+        EXPECT_STREQ(basl_toml_string_value(basl_toml_table_get(parsed, "version")), "0.1.0");
+        basl_toml_free(&parsed);
+        free(data);
+    }
+
+    /* main.basl exists. */
+    basl_platform_path_join(name, "main.basl", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_file_exists(path, &exists));
+    EXPECT_EQ(exists, 1);
+
+    /* .gitignore exists. */
+    basl_platform_path_join(name, ".gitignore", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_file_exists(path, &exists));
+    EXPECT_EQ(exists, 1);
+
+    /* Clean up. */
+    remove_project(name);
+}
+
+/* ── Library project scaffolding ─────────────────────────────────── */
+
+TEST_F(BaslNewTest, LibProjectStructure) {
+    const char *name = "test_new_lib_proj";
+    char path[4096];
+    int exists = 0;
+
+    remove_lib_project(name);
+
+    /* Create structure. */
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir_p(name, &error));
+
+    basl_platform_path_join(name, "lib", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir(path, &error));
+
+    basl_platform_path_join(name, "test", path, sizeof(path), &error);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_mkdir(path, &error));
+
+    /* Write lib/name.basl. */
+    {
+        char content[512];
+        snprintf(content, sizeof(content),
+            "/// %s library module.\n\npub fn hello() -> string {\n"
+            "    return \"hello from %s\";\n}\n", name, name);
+        snprintf(path, sizeof(path), "%s/lib/%s.basl", name, name);
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_write_file(path, content, strlen(content), &error));
+    }
+
+    /* Write test/name_test.basl. */
+    {
+        char content[512];
+        snprintf(content, sizeof(content),
+            "import \"test\";\nimport \"%s\";\n\n"
+            "fn test_hello(test.T t) -> void {\n"
+            "    t.assert(%s.hello() == \"hello from %s\", \"hello should match\");\n}\n",
+            name, name, name);
+        snprintf(path, sizeof(path), "%s/test/%s_test.basl", name, name);
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_write_file(path, content, strlen(content), &error));
+    }
+
+    /* Verify lib file. */
+    snprintf(path, sizeof(path), "%s/lib/%s.basl", name, name);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_file_exists(path, &exists));
+    EXPECT_EQ(exists, 1);
+    {
+        char *data = nullptr;
+        size_t len = 0;
+        ASSERT_EQ(BASL_STATUS_OK,
+                  basl_platform_read_file(nullptr, path, &data, &len, &error));
+        EXPECT_NE(strstr(data, "pub fn hello"), nullptr);
+        free(data);
+    }
+
+    /* Verify test file. */
+    snprintf(path, sizeof(path), "%s/test/%s_test.basl", name, name);
+    ASSERT_EQ(BASL_STATUS_OK, basl_platform_file_exists(path, &exists));
+    EXPECT_EQ(exists, 1);
+
+    remove_lib_project(name);
+}
+
+/* ── Readline ────────────────────────────────────────────────────── */
+
+TEST_F(BaslNewTest, ReadlineNullArgs) {
+    EXPECT_EQ(BASL_STATUS_INVALID_ARGUMENT,
+              basl_platform_readline(nullptr, nullptr, 0, &error));
+}


### PR DESCRIPTION
Rewires the CLI to use `basl_cli_lib` with proper subcommands and adds the `basl new` project scaffolding command.

## CLI Subcommands

| Command | Description |
|---------|-------------|
| `basl run <file>` | Run a BASL script |
| `basl check <file>` | Type-check a BASL script |
| `basl new <name>` | Create an application project |
| `basl new <name> --lib` | Create a library project |
| `basl` (no args) | Print help |

## `basl new` Behavior

Creates the standard project structure from `docs/project_structure.md`:

**App** (`basl new myapp`):
```
myapp/
├── basl.toml        # generated via TOML library
├── main.basl        # hello world template
├── lib/
├── test/
└── .gitignore
```

**Library** (`basl new mylib --lib`):
```
mylib/
├── basl.toml
├── lib/mylib.basl   # template with pub fn hello()
├── test/mylib_test.basl
├── lib/
├── test/
└── .gitignore
```

- Prompts for name if not provided (CI-friendly: pass as positional arg)
- Rejects existing directories
- All file ops use `basl_platform_*` functions (cross-platform)
- `basl.toml` generated via the TOML emitter (not string templates)

## Platform Layer Additions

- `basl_platform_path_join()` — cross-platform path concatenation (uses `/`, handles trailing separators)
- `basl_platform_readline()` — stdin input with prompt, strips newlines (dual-use: CLI + future stdlib)

## Other Changes

- Integration tests updated to use `basl run <file>` instead of `basl <file>`
- 7 new tests: path_join (4), app scaffolding, lib scaffolding, readline null args
- Tests verify created directories and files using platform I/O functions
- Tests parse generated `basl.toml` back through the TOML parser to verify correctness
- 457 total tests, ASAN+UBSAN clean, portability clean