### PR TITLE
Fix nanbox i32 sign loss, check native imports, and scaffolded lib imports

### DIFF
--- a/examples/test_programs/module_type_bug/main.basl
+++ b/examples/test_programs/module_type_bug/main.basl
@@ -1,4 +1,4 @@
-import "mymodule";
+import "lib/mymodule";
 import "fmt";
 
 fn main() -> i32 {

--- a/examples/test_programs/module_type_bug/test/module_type_test.basl
+++ b/examples/test_programs/module_type_bug/test/module_type_test.basl
@@ -1,5 +1,5 @@
 import "test";
-import "mymodule";
+import "../lib/mymodule";
 
 fn test_module_class_type_annotation(test.T t) -> void {
     // This should work: module-qualified type annotation

--- a/include/basl/checker.h
+++ b/include/basl/checker.h
@@ -3,6 +3,7 @@
 
 #include "basl/diagnostic.h"
 #include "basl/export.h"
+#include "basl/native_module.h"
 #include "basl/source.h"
 #include "basl/status.h"
 
@@ -14,10 +15,13 @@ extern "C" {
  * Validates a BASL source file without returning an executable entrypoint.
  * Diagnostics describe syntax and semantic errors discovered during lexing,
  * declaration parsing, and function-body compilation.
+ * If |natives| is non-NULL, native stdlib modules are recognized during
+ * type checking; otherwise imports of native modules will be rejected.
  */
 BASL_API basl_status_t basl_check_source(
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
 );

--- a/src/checker.c
+++ b/src/checker.c
@@ -5,6 +5,7 @@
 basl_status_t basl_check_source(
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
 ) {
@@ -12,7 +13,7 @@ basl_status_t basl_check_source(
         registry,
         source_id,
         BASL_COMPILE_MODE_CHECK_ONLY,
-        NULL,
+        natives,
         NULL,
         diagnostics,
         error

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -398,7 +398,13 @@ static int cmd_check(const char *script_path) {
         goto cleanup;
     }
 
-    status = basl_check_source(&registry, source_id, &diagnostics, &error);
+    {
+        basl_native_registry_t natives;
+        basl_native_registry_init(&natives);
+        basl_stdlib_register_all(&natives, &error);
+        status = basl_check_source(&registry, source_id, &natives, &diagnostics, &error);
+        basl_native_registry_free(&natives);
+    }
     if (status != BASL_STATUS_OK) {
         if (basl_diagnostic_list_count(&diagnostics) != 0U) {
             exit_code = print_diagnostics(&registry, &diagnostics);
@@ -523,7 +529,7 @@ static int cmd_new(const char *name, int is_lib) {
 
         snprintf(test_content, sizeof(test_content),
             "import \"test\";\n"
-            "import \"%s\";\n"
+            "import \"../lib/%s\";\n"
             "\n"
             "fn test_hello(test.T t) -> void {\n"
             "    t.assert(%s.hello() == \"hello from %s\", \"hello should match\");\n"

--- a/src/internal/basl_nanbox.h
+++ b/src/internal/basl_nanbox.h
@@ -190,10 +190,11 @@ static inline int basl_nanbox_uint_fits_inline(uint64_t v) {
     return v <= BASL_NANBOX_UINT_MAX;
 }
 
-/* Fast i32 encode/decode — no sign-extension branch needed because
-   i32 values always fit in the 48-bit payload. */
+/* Fast i32 encode/decode — i32 values always fit in the 48-bit
+   inline payload.  Encode sign-extends to 64 bits before masking
+   so that the 48-bit payload preserves the sign bit at position 47. */
 static inline uint64_t basl_nanbox_encode_i32(int32_t v) {
-    return BASL_NANBOX_TAG_INT | ((uint64_t)(uint32_t)v & BASL_NANBOX_PAYLOAD_MASK);
+    return BASL_NANBOX_TAG_INT | ((uint64_t)(int64_t)v & BASL_NANBOX_PAYLOAD_MASK);
 }
 
 static inline int32_t basl_nanbox_decode_i32(uint64_t v) {

--- a/tests/checker_test.c
+++ b/tests/checker_test.c
@@ -50,7 +50,7 @@ TEST(BaslCheckerTest, ValidatesWellTypedProgramWithoutDiagnostics) {
     );
 
     EXPECT_EQ(
-        basl_check_source(&registry, source_id, &diagnostics, &error),
+        basl_check_source(&registry, source_id, NULL, &diagnostics, &error),
         BASL_STATUS_OK
     );
     EXPECT_EQ(basl_diagnostic_list_count(&diagnostics), 0U);
@@ -87,7 +87,7 @@ TEST(BaslCheckerTest, ReportsSemanticErrorsWithoutProducingEntrypoint) {
     );
 
     EXPECT_EQ(
-        basl_check_source(&registry, source_id, &diagnostics, &error),
+        basl_check_source(&registry, source_id, NULL, &diagnostics, &error),
         BASL_STATUS_SYNTAX_ERROR
     );
     ASSERT_EQ(basl_diagnostic_list_count(&diagnostics), 1U);
@@ -130,7 +130,7 @@ TEST(BaslCheckerTest, ReportsMissingReturnOnSomePaths) {
     );
 
     EXPECT_EQ(
-        basl_check_source(&registry, source_id, &diagnostics, &error),
+        basl_check_source(&registry, source_id, NULL, &diagnostics, &error),
         BASL_STATUS_SYNTAX_ERROR
     );
     ASSERT_EQ(basl_diagnostic_list_count(&diagnostics), 1U);
@@ -154,7 +154,7 @@ TEST(BaslCheckerTest, ValidatesArguments) {
     basl_source_id_t source_id = 0U;
 
     ASSERT_EQ(
-        basl_check_source(NULL, source_id, &diagnostics, &error),
+        basl_check_source(NULL, source_id, NULL, &diagnostics, &error),
         BASL_STATUS_INVALID_ARGUMENT
     );
     EXPECT_STREQ(basl_error_message(&error), "source registry must not be null");
@@ -170,7 +170,7 @@ TEST(BaslCheckerTest, ValidatesArguments) {
     );
 
     EXPECT_EQ(
-        basl_check_source(&registry, source_id, NULL, &error),
+        basl_check_source(&registry, source_id, NULL, NULL, &error),
         BASL_STATUS_INVALID_ARGUMENT
     );
     EXPECT_STREQ(basl_error_message(&error), "diagnostic list must not be null");

--- a/tests/value_test.c
+++ b/tests/value_test.c
@@ -5,6 +5,7 @@
 
 
 #include "basl/basl.h"
+#include "internal/basl_nanbox.h"
 
 struct AllocatorStats {
     int allocate_calls;
@@ -400,6 +401,24 @@ TEST(BaslValueTest, ArrayAndMapObjectsStoreAndExposeIndexedValues) {
     basl_runtime_close(&runtime);
 }
 
+TEST(BaslValueTest, NanboxI32RoundTripPreservesSign) {
+    /* Negative i32 values must survive encode → decode and
+       encode → value_as_int round-trips with correct sign. */
+    static const int32_t cases[] = { 0, 1, -1, -2, INT32_MIN, INT32_MAX, -42, 42 };
+    size_t i;
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        int32_t input = cases[i];
+        uint64_t encoded = basl_nanbox_encode_i32(input);
+        int32_t decoded_i32 = basl_nanbox_decode_i32(encoded);
+        EXPECT_EQ(decoded_i32, input);
+
+        /* Also verify the 48-bit decode path used by stringify. */
+        basl_value_t v = encoded;
+        EXPECT_EQ(basl_value_kind(&v), BASL_VALUE_INT);
+        EXPECT_EQ((int32_t)basl_value_as_int(&v), input);
+    }
+}
+
 void register_value_tests(void) {
     REGISTER_TEST(BaslValueTest, ImmediateValuesRoundTrip);
     REGISTER_TEST(BaslValueTest, StringObjectStartsWithOneReferenceAndExposesText);
@@ -412,4 +431,5 @@ void register_value_tests(void) {
     REGISTER_TEST(BaslValueTest, FunctionObjectValidatesArguments);
     REGISTER_TEST(BaslValueTest, InstanceObjectStoresAndUpdatesFields);
     REGISTER_TEST(BaslValueTest, ArrayAndMapObjectsStoreAndExposeIndexedValues);
+    REGISTER_TEST(BaslValueTest, NanboxI32RoundTripPreservesSign);
 }


### PR DESCRIPTION
Three bugs found via CLI smoke testing all 9 subcommands against a non-trivial multi-module project:

## 1. NaN-box i32 sign loss (runtime correctness)

`basl_nanbox_encode_i32` zero-extended negative i32 values (`(uint64_t)(uint32_t)v`) instead of sign-extending, so the 48-bit payload lost the sign bit. Any i32 arithmetic producing a negative result (e.g. `1 - 3`) displayed as unsigned (`4294967294` instead of `-2`). Comparisons like `if (x < 0)` also failed.

**Fix:** Cast through `int64_t` before masking: `(uint64_t)(int64_t)v & PAYLOAD_MASK`.

Added table-style unit test covering 0, ±1, ±2, INT32_MIN, INT32_MAX, ±42 through both the i32 and 48-bit decode paths.

## 2. `basl check` rejects native module imports

`basl_check_source` passed `NULL` for the native registry, so any file importing `fmt`, `math`, `args`, etc. failed with `imported source is not registered`. This made `basl check` unusable on real programs.

**Fix:** Add `natives` parameter to `basl_check_source` API; wire up `basl_stdlib_register_all` in `cmd_check`.

## 3. `basl new --lib` generates broken test imports

The scaffolded test file used `import "name"` but the import resolver only looks relative to the importing file. From `test/`, the correct path is `import "../lib/name"`.

**Fix:** Update the template in `cmd_new`. Also fix the existing `module_type_bug` example which had the same issue.

## Validation

- `make build` clean
- `make test` — all 9 CTest targets pass (478 individual test cases)
- 44/44 smoke test checks pass across all CLI subcommands