### PR TITLE
Add interactive REPL (basl repl)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ target_include_directories(basl
 )
 
 target_compile_features(basl PUBLIC c_std_11)
+target_compile_definitions(basl PUBLIC BASL_VERSION="${PROJECT_VERSION}")
 
 if(NOT EMSCRIPTEN)
     target_compile_definitions(basl

--- a/include/basl/compiler.h
+++ b/include/basl/compiler.h
@@ -3,6 +3,7 @@
 
 #include "basl/diagnostic.h"
 #include "basl/export.h"
+#include "basl/native_module.h"
 #include "basl/source.h"
 #include "basl/status.h"
 #include "basl/value.h"
@@ -24,6 +25,23 @@ BASL_API basl_status_t basl_compile_source(
     const basl_source_registry_t *registry,
     basl_source_id_t source_id,
     basl_object_t **out_function,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+);
+
+/*
+ * Compile in REPL mode.  Top-level statements and expressions are allowed
+ * without a fn main() wrapper.  The compiler synthesizes an entrypoint
+ * from any non-declaration tokens found at the top level.  If the source
+ * contains only declarations and no statements, *out_has_statements is set
+ * to 0 (the returned function still validates global initializers).
+ */
+BASL_API basl_status_t basl_compile_source_repl(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    int *out_has_statements,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
 );

--- a/src/checker.c
+++ b/src/checker.c
@@ -15,6 +15,7 @@ basl_status_t basl_check_source(
         BASL_COMPILE_MODE_CHECK_ONLY,
         natives,
         NULL,
+        NULL,
         diagnostics,
         error
     );

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1608,6 +1608,505 @@ static int cmd_embed(int argc, char **argv) {
     return 0;
 }
 
+/* ── repl command ────────────────────────────────────────────────── */
+
+/* Simple growable string buffer for the REPL preamble. */
+typedef struct {
+    char *data;
+    size_t length;
+    size_t capacity;
+} repl_buf_t;
+
+static void repl_buf_init(repl_buf_t *buf) {
+    buf->data = NULL;
+    buf->length = 0;
+    buf->capacity = 0;
+}
+
+static void repl_buf_free(repl_buf_t *buf) {
+    free(buf->data);
+    buf->data = NULL;
+    buf->length = 0;
+    buf->capacity = 0;
+}
+
+static int repl_buf_append(repl_buf_t *buf, const char *text, size_t len) {
+    if (buf->length + len + 1U > buf->capacity) {
+        size_t new_cap = buf->capacity == 0 ? 256 : buf->capacity;
+        while (new_cap < buf->length + len + 1U) new_cap *= 2;
+        char *new_data = realloc(buf->data, new_cap);
+        if (!new_data) return 0;
+        buf->data = new_data;
+        buf->capacity = new_cap;
+    }
+    memcpy(buf->data + buf->length, text, len);
+    buf->length += len;
+    buf->data[buf->length] = '\0';
+    return 1;
+}
+
+static int repl_buf_append_cstr(repl_buf_t *buf, const char *text) {
+    return repl_buf_append(buf, text, strlen(text));
+}
+
+static void repl_buf_clear(repl_buf_t *buf) {
+    buf->length = 0;
+    if (buf->data) buf->data[0] = '\0';
+}
+
+/* Named preamble entry for redefinition support. */
+typedef struct {
+    char *name;   /* declaration name (NULL for imports) */
+    char *source; /* full source text including trailing newline */
+} repl_decl_t;
+
+typedef struct {
+    repl_decl_t *entries;
+    size_t count;
+    size_t capacity;
+} repl_decl_list_t;
+
+static void repl_decl_list_init(repl_decl_list_t *list) {
+    list->entries = NULL;
+    list->count = 0;
+    list->capacity = 0;
+}
+
+static void repl_decl_list_free(repl_decl_list_t *list) {
+    for (size_t i = 0; i < list->count; i++) {
+        free(list->entries[i].name);
+        free(list->entries[i].source);
+    }
+    free(list->entries);
+    list->entries = NULL;
+    list->count = 0;
+    list->capacity = 0;
+}
+
+/* Extract the declaration name from input. Recognizes:
+   fn <name>, class <name>, enum <name>, interface <name>,
+   const <type> <name>, <type> <name> = ... (global var) */
+static char *repl_extract_decl_name(const char *input) {
+    const char *p = input;
+    while (*p == ' ' || *p == '\t') p++;
+    /* fn, class, enum, interface — name is the token after the keyword */
+    const char *keywords[] = {"fn ", "class ", "enum ", "interface ", NULL};
+    for (int i = 0; keywords[i]; i++) {
+        size_t klen = strlen(keywords[i]);
+        if (strncmp(p, keywords[i], klen) == 0) {
+            const char *start = p + klen;
+            while (*start == ' ' || *start == '\t') start++;
+            const char *end = start;
+            while (*end && *end != '(' && *end != ' ' && *end != '{' && *end != '\t' && *end != '<') end++;
+            if (end > start) {
+                char *name = malloc((size_t)(end - start) + 1);
+                if (name) { memcpy(name, start, (size_t)(end - start)); name[end - start] = '\0'; }
+                return name;
+            }
+            return NULL;
+        }
+    }
+    /* const <type> <name> OR <type> <name> = ... */
+    if (strncmp(p, "const ", 6) == 0) p += 6;
+    /* skip type token(s) — simplified: skip first word */
+    while (*p == ' ' || *p == '\t') p++;
+    const char *type_start = p;
+    while (*p && *p != ' ' && *p != '\t') p++;
+    if (p == type_start) return NULL;
+    while (*p == ' ' || *p == '\t') p++;
+    /* p should now be at the name */
+    const char *nstart = p;
+    while (*p && *p != ' ' && *p != '\t' && *p != '=' && *p != ';' && *p != '\n') p++;
+    if (p > nstart) {
+        char *name = malloc((size_t)(p - nstart) + 1);
+        if (name) { memcpy(name, nstart, (size_t)(p - nstart)); name[p - nstart] = '\0'; }
+        return name;
+    }
+    return NULL;
+}
+
+/* Add or replace a declaration in the list. */
+static void repl_decl_list_put(repl_decl_list_t *list, const char *name, const char *source) {
+    /* If name is non-NULL, look for existing entry to replace. */
+    if (name) {
+        for (size_t i = 0; i < list->count; i++) {
+            if (list->entries[i].name && strcmp(list->entries[i].name, name) == 0) {
+                free(list->entries[i].source);
+                list->entries[i].source = cli_strdup(source);
+                return;
+            }
+        }
+    }
+    if (list->count >= list->capacity) {
+        size_t new_cap = list->capacity == 0 ? 16 : list->capacity * 2;
+        repl_decl_t *new_entries = realloc(list->entries, new_cap * sizeof(repl_decl_t));
+        if (!new_entries) return;
+        list->entries = new_entries;
+        list->capacity = new_cap;
+    }
+    list->entries[list->count].name = name ? cli_strdup(name) : NULL;
+    list->entries[list->count].source = cli_strdup(source);
+    list->count++;
+}
+
+/* Rebuild the preamble buffer from the declaration list. */
+static void repl_rebuild_preamble(repl_buf_t *preamble, const repl_decl_list_t *list) {
+    repl_buf_clear(preamble);
+    for (size_t i = 0; i < list->count; i++) {
+        repl_buf_append_cstr(preamble, list->entries[i].source);
+    }
+}
+
+/* Print a runtime error with source location when available. */
+static void repl_print_error(const basl_error_t *err) {
+    if (err->location.line > 0) {
+        fprintf(stderr, "error: <repl>:%u:%u: %s\n",
+                err->location.line, err->location.column,
+                basl_error_message(err));
+    } else {
+        fprintf(stderr, "error: %s\n", basl_error_message(err));
+    }
+}
+
+/* Check if input needs continuation (trailing operator, comma, arrow, or unterminated string). */
+static int repl_needs_continuation(const char *text) {
+    const char *p;
+    int quotes = 0;
+
+    /* Count unescaped double quotes for unterminated string detection. */
+    for (p = text; *p; p++) {
+        if (*p == '\\' && p[1]) { p++; continue; }
+        if (*p == '"') quotes++;
+    }
+    if (quotes % 2 != 0) return 1;
+
+    /* Find last non-whitespace character. */
+    p = text + strlen(text);
+    while (p > text && (p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n' || p[-1] == '\r')) p--;
+    if (p == text) return 0;
+
+    /* Single-char trailing tokens. */
+    char last = p[-1];
+    if (last == ',' || last == '+' || last == '*' || last == '/' ||
+        last == '%' || last == '^') return 1;
+
+    /* Trailing - but not -> (handled below) or -- */
+    if (last == '-' && (p - 1 == text || p[-2] != '-')) return 1;
+
+    /* Two-char trailing tokens. */
+    if (p - text >= 2) {
+        if (p[-2] == '-' && p[-1] == '>') return 1; /* -> */
+        if (p[-2] == '&' && p[-1] == '&') return 1;
+        if (p[-2] == '|' && p[-1] == '|') return 1;
+        if (p[-2] == '=' && p[-1] == '=') return 1;
+        if (p[-2] == '!' && p[-1] == '=') return 1;
+        if (p[-2] == '<' && p[-1] == '=') return 1;
+        if (p[-2] == '>' && p[-1] == '=') return 1;
+    }
+
+    /* Single < > | & = as trailing (but not <=, >=, ==, etc. already handled) */
+    if (last == '<' || last == '>' || last == '|' || last == '&' || last == '=') return 1;
+
+    return 0;
+}
+
+/* Count net open brackets in text. */
+static int repl_bracket_depth(const char *text) {
+    int depth = 0;
+    int in_string = 0;
+    char quote = 0;
+    for (; *text; text++) {
+        if (in_string) {
+            if (*text == '\\') { if (text[1]) text++; continue; }
+            if (*text == quote) in_string = 0;
+            continue;
+        }
+        if (*text == '"' || *text == '\'') { in_string = 1; quote = *text; continue; }
+        if (*text == '{' || *text == '(' || *text == '[') depth++;
+        else if (*text == '}' || *text == ')' || *text == ']') depth--;
+    }
+    return depth;
+}
+
+/* Try to compile source in REPL mode.  If out_function is non-NULL after
+   a successful call, the source contained executable statements.  If NULL,
+   it contained only declarations.  Returns 1 on success. */
+static int repl_compile_and_run(
+    basl_runtime_t *runtime,
+    const char *source_text,
+    const char *project_root,
+    basl_object_t **out_function,
+    int *out_has_statements,
+    int print_errors
+) {
+    basl_error_t error = {0};
+    basl_source_registry_t registry;
+    basl_diagnostic_list_t diagnostics;
+    basl_source_id_t source_id = 0;
+    basl_status_t status;
+    int ok = 0;
+
+    if (out_function) *out_function = NULL;
+
+    basl_source_registry_init(&registry, runtime);
+    basl_diagnostic_list_init(&diagnostics, runtime);
+
+    if (basl_source_registry_register_cstr(&registry, "<repl>", source_text,
+            &source_id, &error) != BASL_STATUS_OK) {
+        if (print_errors) fprintf(stderr, "error: %s\n", basl_error_message(&error));
+        goto done;
+    }
+
+    /* Register non-native imports. */
+    {
+        const basl_source_file_t *source = basl_source_registry_get(&registry, source_id);
+        basl_token_list_t tokens;
+        size_t cursor = 0, brace_depth = 0;
+
+        basl_token_list_init(&tokens, runtime);
+        if (basl_lex_source(&registry, source_id, &tokens, &diagnostics, &error) == BASL_STATUS_OK) {
+            while (1) {
+                const basl_token_t *token = basl_token_list_get(&tokens, cursor);
+                if (!token || token->kind == BASL_TOKEN_EOF) break;
+                if (token->kind == BASL_TOKEN_LBRACE) { brace_depth++; cursor++; continue; }
+                if (token->kind == BASL_TOKEN_RBRACE) {
+                    if (brace_depth) brace_depth--;
+                    cursor++;
+                    continue;
+                }
+                if (brace_depth == 0 && token->kind == BASL_TOKEN_IMPORT) {
+                    const basl_token_t *path_token;
+                    const char *import_text;
+                    size_t import_length;
+                    cursor++;
+                    path_token = basl_token_list_get(&tokens, cursor);
+                    if (!path_token ||
+                        (path_token->kind != BASL_TOKEN_STRING_LITERAL &&
+                         path_token->kind != BASL_TOKEN_RAW_STRING_LITERAL)) break;
+                    import_text = source_token_text(source, path_token, &import_length);
+                    if (!import_text || import_length < 2) break;
+                    if (!basl_stdlib_is_native_module(import_text + 1, import_length - 2)) {
+                        basl_string_t import_path;
+                        basl_string_init(&import_path, runtime);
+                        if (resolve_import_path(runtime, "<repl>",
+                                import_text + 1, import_length - 2,
+                                &import_path, &error) == BASL_STATUS_OK) {
+                            register_source_tree(&registry, basl_string_c_str(&import_path),
+                                project_root, NULL, &error);
+                        }
+                        basl_string_free(&import_path);
+                    }
+                }
+                cursor++;
+            }
+        }
+        basl_token_list_free(&tokens);
+        basl_diagnostic_list_free(&diagnostics);
+        basl_diagnostic_list_init(&diagnostics, runtime);
+    }
+
+    {
+        basl_native_registry_t natives;
+        basl_object_t *function = NULL;
+        basl_native_registry_init(&natives);
+        basl_stdlib_register_all(&natives, &error);
+        status = basl_compile_source_repl(&registry, source_id, &natives,
+                                           &function, out_has_statements, &diagnostics, &error);
+        basl_native_registry_free(&natives);
+        if (status != BASL_STATUS_OK) {
+            if (print_errors) {
+                if (basl_diagnostic_list_count(&diagnostics))
+                    print_diagnostics(&registry, &diagnostics);
+                else
+                    fprintf(stderr, "error: %s\n", basl_error_message(&error));
+            }
+            basl_object_release(&function);
+            goto done;
+        }
+        if (out_function) *out_function = function;
+        else basl_object_release(&function);
+    }
+    ok = 1;
+
+done:
+    basl_diagnostic_list_free(&diagnostics);
+    basl_source_registry_free(&registry);
+    return ok;
+}
+
+static int cmd_repl(void) {
+    basl_runtime_t *runtime = NULL;
+    basl_vm_t *vm = NULL;
+    basl_error_t error = {0};
+    repl_buf_t preamble;
+    repl_buf_t input;
+    repl_decl_list_t decls;
+    char line[4096];
+    char proj_root[4096];
+    const char *project_root = NULL;
+    int exit_code = 0;
+
+    if (basl_runtime_open(&runtime, NULL, &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "failed to initialize runtime: %s\n", basl_error_message(&error));
+        return 1;
+    }
+    if (basl_vm_open(&vm, runtime, NULL, &error) != BASL_STATUS_OK) {
+        fprintf(stderr, "failed to initialize vm: %s\n", basl_error_message(&error));
+        basl_runtime_close(&runtime);
+        return 1;
+    }
+
+    repl_buf_init(&preamble);
+    repl_buf_init(&input);
+    repl_decl_list_init(&decls);
+
+    /* Auto-inject fmt for expression printing. */
+    repl_decl_list_put(&decls, NULL, "import \"fmt\";\n");
+    repl_rebuild_preamble(&preamble, &decls);
+
+    /* Detect project root from cwd. */
+    if (find_project_root("./dummy.basl", proj_root, sizeof(proj_root)))
+        project_root = proj_root;
+
+    printf("basl %s\n", BASL_VERSION);
+    printf("Type :help for help, :quit to exit.\n");
+
+    for (;;) {
+        const char *prompt = ">>> ";
+        basl_status_t rs;
+
+        repl_buf_clear(&input);
+
+        rs = basl_platform_readline(prompt, line, sizeof(line), &error);
+        if (rs != BASL_STATUS_OK) break; /* EOF / Ctrl-D */
+
+        /* Skip empty lines. */
+        {
+            const char *p = line;
+            while (*p == ' ' || *p == '\t') p++;
+            if (*p == '\0') continue;
+        }
+
+        repl_buf_append_cstr(&input, line);
+
+        /* Special commands. */
+        if (strcmp(line, ":quit") == 0 || strcmp(line, ":q") == 0 ||
+            strcmp(line, "exit()") == 0) break;
+        if (strcmp(line, ":help") == 0 || strcmp(line, ":h") == 0) {
+            printf("  :help    Show this message\n");
+            printf("  :quit    Exit the REPL (also Ctrl-D or exit())\n");
+            printf("  :clear   Reset all state\n");
+            printf("  __ans    Last expression result (string)\n");
+            continue;
+        }
+        if (strcmp(line, ":clear") == 0) {
+            repl_decl_list_free(&decls);
+            repl_decl_list_init(&decls);
+            repl_decl_list_put(&decls, NULL, "import \"fmt\";\n");
+            repl_rebuild_preamble(&preamble, &decls);
+            printf("State cleared.\n");
+            continue;
+        }
+
+        /* Multi-line: accumulate while brackets are unbalanced or line needs continuation. */
+        while (repl_bracket_depth(input.data) > 0 || repl_needs_continuation(input.data)) {
+            rs = basl_platform_readline("... ", line, sizeof(line), &error);
+            if (rs != BASL_STATUS_OK) goto done;
+            repl_buf_append_cstr(&input, "\n");
+            repl_buf_append_cstr(&input, line);
+        }
+
+        {
+            repl_buf_t src;
+            basl_object_t *function = NULL;
+            const char *tail;
+            int needs_semi;
+
+            repl_buf_init(&src);
+
+            /* Auto-append semicolon if input doesn't end with ; or } */
+            tail = input.data + input.length;
+            while (tail > input.data && (tail[-1] == ' ' || tail[-1] == '\t' || tail[-1] == '\n'))
+                tail--;
+            needs_semi = (tail > input.data && tail[-1] != ';' && tail[-1] != '}');
+
+            /* 1) Try as expression with auto-print: fmt.println(string(<input>)) */
+            repl_buf_append_cstr(&src, preamble.data ? preamble.data : "");
+            repl_buf_append_cstr(&src, "fmt.println(string(");
+            repl_buf_append_cstr(&src, input.data);
+            repl_buf_append_cstr(&src, "));\n");
+
+            if (repl_compile_and_run(runtime, src.data, project_root, &function, NULL, 0) && function) {
+                basl_value_t result;
+                basl_value_init_nil(&result);
+                if (basl_vm_execute_function(vm, function, &result, &error) != BASL_STATUS_OK) {
+                    repl_print_error(&error);
+                } else {
+                    /* Store expression result as __ans. */
+                    repl_buf_t ans;
+                    repl_buf_init(&ans);
+                    repl_buf_append_cstr(&ans, "string __ans = string(");
+                    repl_buf_append_cstr(&ans, input.data);
+                    repl_buf_append_cstr(&ans, ");\n");
+                    repl_decl_list_put(&decls, "__ans", ans.data);
+                    repl_rebuild_preamble(&preamble, &decls);
+                    repl_buf_free(&ans);
+                }
+                basl_value_release(&result);
+                basl_object_release(&function);
+            } else {
+                /* 2) Try as bare code (declarations, statements, or mix).
+                   Compile with REPL mode — the compiler synthesizes main
+                   from any top-level statements and validates globals. */
+                int has_stmts = 0;
+                basl_object_release(&function); function = NULL;
+                repl_buf_clear(&src);
+                repl_buf_append_cstr(&src, preamble.data ? preamble.data : "");
+                repl_buf_append_cstr(&src, input.data);
+                if (needs_semi) repl_buf_append_cstr(&src, ";");
+                repl_buf_append_cstr(&src, "\n");
+
+                if (repl_compile_and_run(runtime, src.data, project_root, &function, &has_stmts, 1)) {
+                    if (function) {
+                        basl_value_t result;
+                        basl_value_init_nil(&result);
+                        if (basl_vm_execute_function(vm, function, &result, &error) != BASL_STATUS_OK)
+                            repl_print_error(&error);
+                        basl_value_release(&result);
+                        basl_object_release(&function);
+                    }
+                    if (!has_stmts) {
+                        /* Declarations only — add/replace in preamble. */
+                        repl_buf_t decl_src;
+                        char *dname;
+                        repl_buf_init(&decl_src);
+                        repl_buf_append_cstr(&decl_src, input.data);
+                        if (needs_semi) repl_buf_append_cstr(&decl_src, ";");
+                        repl_buf_append_cstr(&decl_src, "\n");
+                        dname = repl_extract_decl_name(input.data);
+                        repl_decl_list_put(&decls, dname, decl_src.data);
+                        repl_rebuild_preamble(&preamble, &decls);
+                        free(dname);
+                        repl_buf_free(&decl_src);
+                    }
+                } else {
+                    basl_object_release(&function);
+                }
+            }
+
+            repl_buf_free(&src);
+        }
+    }
+
+done:
+    repl_buf_free(&preamble);
+    repl_decl_list_free(&decls);
+    repl_buf_free(&input);
+    basl_vm_close(&vm);
+    basl_runtime_close(&runtime);
+    return exit_code;
+}
+
 /* ── package command ─────────────────────────────────────────────── */
 
 static int cmd_package(const char *entry_path, const char *output_path,
@@ -1770,6 +2269,11 @@ int main(int argc, char **argv) {
         return cmd_test(argc, argv);
     }
 
+    /* Handle "basl repl" before CLI parser. */
+    if (argc >= 2 && strcmp(argv[1], "repl") == 0) {
+        return cmd_repl();
+    }
+
     basl_cli_init(&cli, "basl", "Blazingly Awesome Scripting Language");
 
     cmd = basl_cli_add_command(&cli, "run", "Run a BASL script");
@@ -1792,6 +2296,8 @@ int main(int argc, char **argv) {
     cmd = basl_cli_add_command(&cli, "fmt", "Format BASL source files");
     basl_cli_add_positional(cmd, "file", "Source file to format", &fmt_file);
     basl_cli_add_bool_flag(cmd, "check", 'c', "Check formatting without rewriting", &fmt_check);
+
+    (void)basl_cli_add_command(&cli, "repl", "Start interactive REPL");
 
     cmd = basl_cli_add_command(&cli, "package", "Package a BASL program as a standalone binary");
     basl_cli_add_positional(cmd, "entry", "Entry script or project directory", &pkg_entry);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -704,9 +704,11 @@ static basl_status_t basl_program_add_module_import(
     basl_module_import_t *import_decl;
     void *memory;
 
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (basl_program_module_find_import(module, alias, alias_length, NULL)) {
         return basl_compile_report(program, alias_span, "import alias is already declared");
     }
+    } /* end REPL redefinition guard */
 
     status = basl_program_module_grow_imports(program, module, module->import_count + 1U);
     if (status != BASL_STATUS_OK) {
@@ -4805,6 +4807,22 @@ static basl_status_t basl_program_parse_declarations(
             continue;
         }
         if (token->kind != BASL_TOKEN_FN) {
+            if (program->compile_mode == BASL_COMPILE_MODE_REPL && !is_public) {
+                /* In REPL mode, non-declaration tokens are top-level
+                   statements.  Record their bounds for the synthetic main. */
+                size_t end_cursor = cursor;
+                size_t depth = 0;
+                while (1) {
+                    const basl_token_t *t = basl_program_token_at(program, end_cursor);
+                    if (t == NULL || t->kind == BASL_TOKEN_EOF) break;
+                    if (t->kind == BASL_TOKEN_LBRACE) depth++;
+                    else if (t->kind == BASL_TOKEN_RBRACE) { if (depth) depth--; }
+                    end_cursor++;
+                }
+                program->repl_stmts_start = cursor;
+                program->repl_stmts_end = end_cursor;
+                break;
+            }
             return basl_compile_report(
                 program,
                 token->span,
@@ -4823,6 +4841,7 @@ static basl_status_t basl_program_parse_declarations(
         }
 
         name_text = basl_program_token_text(program, name_token, &name_length);
+        if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
         if (
             basl_program_find_top_level_function_name_in_source(
                 program,
@@ -4918,6 +4937,7 @@ static basl_status_t basl_program_parse_declarations(
                 "function name conflicts with interface"
             );
         }
+        } /* end REPL redefinition guard */
 
         status = basl_program_grow_functions(program, program->functions.count + 1U);
         if (status != BASL_STATUS_OK) {
@@ -14945,6 +14965,51 @@ static basl_status_t basl_compile_function_with_parent(
         body_result.guaranteed_return = 1;
     }
 
+    /* In REPL mode, emit a synthetic 'return 0' for the synthetic main
+       when the user's statements don't include an explicit return. */
+    if (
+        !body_result.guaranteed_return &&
+        program->compile_mode == BASL_COMPILE_MODE_REPL &&
+        function_index == program->functions.main_index
+    ) {
+        status = basl_parser_emit_opcode(&state, BASL_OPCODE_CONSTANT, decl->name_span);
+        if (status != BASL_STATUS_OK) {
+            basl_chunk_free(&state.chunk);
+            basl_parser_state_free(&state);
+            return status;
+        }
+        {
+            basl_value_t zero_val;
+            size_t const_index;
+            basl_value_init_int(&zero_val, 0);
+            status = basl_chunk_add_constant(&state.chunk, &zero_val, &const_index, program->error);
+            if (status != BASL_STATUS_OK) {
+                basl_chunk_free(&state.chunk);
+                basl_parser_state_free(&state);
+                return status;
+            }
+            status = basl_parser_emit_u32(&state, (uint32_t)const_index, decl->name_span);
+        }
+        if (status != BASL_STATUS_OK) {
+            basl_chunk_free(&state.chunk);
+            basl_parser_state_free(&state);
+            return status;
+        }
+        status = basl_parser_emit_opcode(&state, BASL_OPCODE_RETURN, decl->name_span);
+        if (status != BASL_STATUS_OK) {
+            basl_chunk_free(&state.chunk);
+            basl_parser_state_free(&state);
+            return status;
+        }
+        status = basl_parser_emit_u32(&state, 1U, decl->name_span);
+        if (status != BASL_STATUS_OK) {
+            basl_chunk_free(&state.chunk);
+            basl_parser_state_free(&state);
+            return status;
+        }
+        body_result.guaranteed_return = 1;
+    }
+
     status = basl_compile_require_function_returns(
         program,
         decl,
@@ -15000,7 +15065,7 @@ static basl_status_t basl_compile_validate_inputs(
         basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "diagnostic list must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
     }
-    if (mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT && out_function == NULL) {
+    if ((mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT || mode == BASL_COMPILE_MODE_REPL) && out_function == NULL) {
         basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "out_function must not be null");
         return BASL_STATUS_INVALID_ARGUMENT;
     }
@@ -15192,6 +15257,7 @@ basl_status_t basl_compile_source_internal(
     basl_compile_mode_t mode,
     const basl_native_registry_t *natives,
     basl_object_t **out_function,
+    int *out_repl_has_statements,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
 ) {
@@ -15200,6 +15266,7 @@ basl_status_t basl_compile_source_internal(
     const basl_source_file_t *source;
 
     basl_error_clear(error);
+    if (out_repl_has_statements) *out_repl_has_statements = 0;
     if (out_function != NULL) {
         *out_function = NULL;
     }
@@ -15230,6 +15297,7 @@ basl_status_t basl_compile_source_internal(
     program.diagnostics = diagnostics;
     program.error = error;
     program.natives = natives;
+    program.compile_mode = (int)mode;
     basl_binding_function_table_init(&program.functions, registry->runtime);
     basl_program_set_module_context(&program, source, NULL);
 
@@ -15240,7 +15308,50 @@ basl_status_t basl_compile_source_internal(
     }
 
     basl_program_set_module_context(&program, source, NULL);
+
+    /* In REPL mode, synthesize fn main from top-level statements.
+       Also synthesize when there are globals (even without statements)
+       so their initializers get compiled and type-checked. */
+    if (mode == BASL_COMPILE_MODE_REPL && !program.functions.has_main &&
+        (program.repl_stmts_start < program.repl_stmts_end || program.global_count > 0U)) {
+        basl_binding_function_t *decl;
+        basl_binding_type_t ret_type;
+        size_t mod_idx = 0;
+
+        status = basl_program_grow_functions(&program, program.functions.count + 1U);
+        if (status != BASL_STATUS_OK) {
+            basl_program_free(&program);
+            return status;
+        }
+        decl = &program.functions.functions[program.functions.count];
+        basl_binding_function_init(decl);
+        decl->name = "main";
+        decl->name_length = 4U;
+        decl->name_span = basl_program_eof_span(&program);
+        decl->is_public = 0;
+        decl->source = source;
+        /* Retrieve the module's token list so the parser can read the body. */
+        if (basl_program_module_find(&program, source_id, &mod_idx)) {
+            decl->tokens = program.modules[mod_idx].tokens;
+        }
+        decl->body_start = program.repl_stmts_start;
+        decl->body_end = program.repl_stmts_end;
+        memset(&ret_type, 0, sizeof(ret_type));
+        ret_type.kind = BASL_TYPE_I32;
+        decl->return_type = ret_type;
+        decl->return_count = 1U;
+        program.functions.main_index = program.functions.count;
+        program.functions.has_main = 1;
+        program.repl_has_statements = (program.repl_stmts_start < program.repl_stmts_end) ? 1 : 0;
+        program.functions.count += 1U;
+    }
+
     if (!program.functions.has_main) {
+        if (mode == BASL_COMPILE_MODE_REPL) {
+            /* No statements and no main — nothing to execute. */
+            basl_program_free(&program);
+            return BASL_STATUS_OK;
+        }
         status = basl_compile_report(
             &program,
             basl_program_eof_span(&program),
@@ -15256,7 +15367,7 @@ basl_status_t basl_compile_source_internal(
         return status;
     }
 
-    if (mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT) {
+    if (mode == BASL_COMPILE_MODE_BUILD_ENTRYPOINT || mode == BASL_COMPILE_MODE_REPL) {
         status = basl_compile_attach_entrypoint(&program, out_function);
         if (status != BASL_STATUS_OK) {
             basl_program_free(&program);
@@ -15264,6 +15375,7 @@ basl_status_t basl_compile_source_internal(
         }
     }
 
+    if (out_repl_has_statements) *out_repl_has_statements = program.repl_has_statements;
     basl_program_free(&program);
     return BASL_STATUS_OK;
 }
@@ -15281,6 +15393,7 @@ basl_status_t basl_compile_source(
         BASL_COMPILE_MODE_BUILD_ENTRYPOINT,
         NULL,
         out_function,
+        NULL,
         diagnostics,
         error
     );
@@ -15300,6 +15413,28 @@ basl_status_t basl_compile_source_with_natives(
         BASL_COMPILE_MODE_BUILD_ENTRYPOINT,
         natives,
         out_function,
+        NULL,
+        diagnostics,
+        error
+    );
+}
+
+basl_status_t basl_compile_source_repl(
+    const basl_source_registry_t *registry,
+    basl_source_id_t source_id,
+    const basl_native_registry_t *natives,
+    basl_object_t **out_function,
+    int *out_has_statements,
+    basl_diagnostic_list_t *diagnostics,
+    basl_error_t *error
+) {
+    return basl_compile_source_internal(
+        registry,
+        source_id,
+        BASL_COMPILE_MODE_REPL,
+        natives,
+        out_function,
+        out_has_statements,
         diagnostics,
         error
     );

--- a/src/compiler_declarations.c
+++ b/src/compiler_declarations.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "internal/basl_compiler_types.h"
+#include "internal/basl_compiler_internal.h"
 #include "internal/basl_internal.h"
 
 int basl_program_token_is_identifier_text(
@@ -315,6 +316,7 @@ basl_status_t basl_program_parse_global_variable_declaration(
         );
     }
     name_text = basl_program_token_text(program, name_token, &name_length);
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (
         basl_program_find_top_level_function_name_in_source(
             program,
@@ -410,6 +412,7 @@ basl_status_t basl_program_parse_global_variable_declaration(
             "global variable is already declared"
         );
     }
+    } /* end REPL redefinition guard */
     basl_program_cursor_advance(program, cursor);
 
     token = basl_program_cursor_peek(program, *cursor);
@@ -517,6 +520,7 @@ basl_status_t basl_program_parse_constant_declaration(
         );
     }
     name_text = basl_program_token_text(program, name_token, &name_length);
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (
         basl_program_find_top_level_function_name_in_source(
             program,
@@ -612,6 +616,7 @@ basl_status_t basl_program_parse_constant_declaration(
             "global constant name conflicts with global variable"
         );
     }
+    } /* end REPL redefinition guard */
     basl_program_cursor_advance(program, cursor);
 
     type_token = basl_program_cursor_peek(program, *cursor);
@@ -705,6 +710,7 @@ basl_status_t basl_program_parse_enum_declaration(
         return basl_compile_report(program, enum_token->span, "expected enum name");
     }
     name_text = basl_program_token_text(program, name_token, &name_length);
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (
         basl_program_find_enum_in_source(
             program,
@@ -788,6 +794,7 @@ basl_status_t basl_program_parse_enum_declaration(
     ) {
         return basl_compile_report(program, name_token->span, "enum name conflicts with function");
     }
+    } /* end REPL redefinition guard */
 
     status = basl_program_grow_enums(program, program->enum_count + 1U);
     if (status != BASL_STATUS_OK) {
@@ -935,6 +942,7 @@ basl_status_t basl_program_parse_interface_declaration(
         return basl_compile_report(program, interface_token->span, "expected interface name");
     }
     name_text = basl_program_token_text(program, name_token, &name_length);
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (
         basl_program_find_interface_in_source(
             program,
@@ -1014,6 +1022,7 @@ basl_status_t basl_program_parse_interface_declaration(
     ) {
         return basl_compile_report(program, name_token->span, "interface name conflicts with function");
     }
+    } /* end REPL redefinition guard */
 
     status = basl_program_grow_interfaces(program, program->interface_count + 1U);
     if (status != BASL_STATUS_OK) {
@@ -1449,6 +1458,7 @@ basl_status_t basl_program_parse_class_declaration(
         return basl_compile_report(program, class_token->span, "expected class name");
     }
     name_text = basl_program_token_text(program, name_token, &name_length);
+    if (program->compile_mode != BASL_COMPILE_MODE_REPL) {
     if (
         basl_program_find_class_in_source(
             program,
@@ -1528,6 +1538,7 @@ basl_status_t basl_program_parse_class_declaration(
     ) {
         return basl_compile_report(program, name_token->span, "class name conflicts with interface");
     }
+    } /* end REPL redefinition guard */
 
     status = basl_program_grow_classes(program, program->class_count + 1U);
     if (status != BASL_STATUS_OK) {

--- a/src/internal/basl_compiler_internal.h
+++ b/src/internal/basl_compiler_internal.h
@@ -6,7 +6,8 @@
 
 typedef enum basl_compile_mode {
     BASL_COMPILE_MODE_CHECK_ONLY = 0,
-    BASL_COMPILE_MODE_BUILD_ENTRYPOINT = 1
+    BASL_COMPILE_MODE_BUILD_ENTRYPOINT = 1,
+    BASL_COMPILE_MODE_REPL = 2
 } basl_compile_mode_t;
 
 basl_status_t basl_compile_source_internal(
@@ -15,6 +16,7 @@ basl_status_t basl_compile_source_internal(
     basl_compile_mode_t mode,
     const basl_native_registry_t *natives,
     basl_object_t **out_function,
+    int *out_repl_has_statements,
     basl_diagnostic_list_t *diagnostics,
     basl_error_t *error
 );

--- a/src/internal/basl_compiler_types.h
+++ b/src/internal/basl_compiler_types.h
@@ -214,6 +214,10 @@ typedef struct basl_program_state {
     size_t global_count;
     size_t global_capacity;
     const struct basl_native_registry *natives;
+    int compile_mode;
+    size_t repl_stmts_start;
+    size_t repl_stmts_end;
+    int repl_has_statements;
 } basl_program_state_t;
 
 typedef struct basl_parser_state {


### PR DESCRIPTION
Closes #138

Adds `basl repl` — a full interactive REPL that supports all BASL syntax.

### Demo

```
$ basl repl
basl 0.1.3
Type :help for help, :quit to exit.
>>> 1 + 2
3
>>> fn square(i32 n) -> i32 { return n * n; }
>>> square(7)
49
>>> i32 x = 10
>>> x * x
100
>>> class Rect {
...   pub i32 w;
...   pub i32 h;
...   fn init(i32 w, i32 h) -> void { self.w = w; self.h = h; }
...   fn area() -> i32 { return self.w * self.h; }
... }
>>> Rect(3, 5).area()
15
>>> fmt.println("hello from repl")
hello from repl
>>> import "math"
>>> math.sqrt(16.0)
4
>>> :quit
```

### Features

- Expressions auto-print their result
- All declarations persist across rounds: `fn`, `class`, `enum`, `interface`, `import`, `const`, global variables
- Multi-line input via bracket-depth tracking (`...` continuation prompt)
- Project-aware imports work when run inside a `basl.toml` project
- Non-fatal errors — compile and runtime errors print and return to the prompt
- Special commands: `:help`, `:quit` (or Ctrl-D), `:clear`
- Semicolons auto-appended where needed

### How it works

Each input is tried through a cascade:
1. **Declaration** — try compiling as a top-level declaration (fn, class, enum, etc.) added to a growing preamble
2. **Expression** — wrap in `fmt.println(string(...))` for auto-print
3. **Statement** — wrap as bare statement(s) in a synthetic `fn main`

### Limitations (to address in follow-up work)

- No history file persistence or tab completion (deferred per #138)
- Variables with complex initializers (class instances) don't persist across rounds — BASL global variables require constant initializers
- Each round re-compiles the full preamble (acceptable for interactive use)

### Validation

- `make test` — 9/9 CTest targets pass
- 44/44 smoke test checks pass
- Tested: expressions, functions, classes, enums, interfaces, imports (stdlib + project lib), if/else, while loops, f-strings, error recovery, multi-line input, :clear, Ctrl-D exit