### PR TITLE
Add unified documentation system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(basl_core OBJECT
     src/compiler.c
     src/dap.c
     src/doc.c
+    src/doc_registry.c
     src/embed.c
     src/ffi_callback.c
     src/fmt.c
@@ -197,6 +198,7 @@ if(BASL_BUILD_TESTS)
         tests/runtime_test.c
         tests/semantic_test.c
         tests/lsp_test.c
+        tests/doc_registry_test.c
         tests/source_test.c
         tests/stdlib_test.c
         tests/string_test.c

--- a/include/basl/doc_registry.h
+++ b/include/basl/doc_registry.h
@@ -1,0 +1,64 @@
+#ifndef BASL_DOC_REGISTRY_H
+#define BASL_DOC_REGISTRY_H
+
+#include <stddef.h>
+
+#include "basl/doc.h"
+#include "basl/export.h"
+#include "basl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Doc Entry ────────────────────────────────────────────── */
+
+typedef struct basl_doc_entry {
+    const char *name;           /* "print" or "math.sqrt" */
+    const char *signature;      /* "print(value: any) -> void" */
+    const char *summary;        /* One-line description */
+    const char *description;    /* Full description (may be NULL) */
+    const char *example;        /* Example code (may be NULL) */
+} basl_doc_entry_t;
+
+/* ── Doc Registry ─────────────────────────────────────────── */
+
+/*
+ * Lookup documentation by name.
+ * Supports: "print", "math", "math.sqrt", "MyClass.method"
+ * Returns NULL if not found.
+ */
+BASL_API const basl_doc_entry_t *basl_doc_lookup(const char *name);
+
+/*
+ * List all documented modules.
+ * Returns array of module names, sets *count.
+ */
+BASL_API const char **basl_doc_list_modules(size_t *count);
+
+/*
+ * List all entries in a module.
+ * Returns array of entries, sets *count.
+ * Returns NULL if module not found.
+ */
+BASL_API const basl_doc_entry_t *basl_doc_list_module(
+    const char *module_name,
+    size_t *count
+);
+
+/*
+ * Render a doc entry to formatted text.
+ * Caller must free *out_text.
+ */
+BASL_API basl_status_t basl_doc_entry_render(
+    const basl_doc_entry_t *entry,
+    char **out_text,
+    size_t *out_length,
+    basl_error_t *error
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -14,6 +14,7 @@
 #include "basl/dap.h"
 #include "basl/lsp.h"
 #include "basl/doc.h"
+#include "basl/doc_registry.h"
 #include "basl/embed.h"
 #include "basl/fmt.h"
 #include "basl/package.h"
@@ -1229,6 +1230,57 @@ cleanup:
 
 /* ── doc command ──────────────────────────────────────────────────── */
 
+/* Show list of all documented modules */
+static int cmd_doc_list_modules(void) {
+    size_t count, i;
+    const char **modules = basl_doc_list_modules(&count);
+
+    printf("Available modules:\n\n");
+    for (i = 0; i < count; i++) {
+        const basl_doc_entry_t *entry = basl_doc_lookup(modules[i]);
+        if (entry != NULL && entry->summary != NULL) {
+            printf("  %-12s %s\n", modules[i], entry->summary);
+        } else {
+            printf("  %s\n", modules[i]);
+        }
+    }
+    printf("\nUse 'basl doc <module>' for module details.\n");
+    printf("Use 'basl doc <file.basl>' for user code documentation.\n");
+    return 0;
+}
+
+/* Show documentation for a builtin/stdlib symbol or module */
+static int cmd_doc_builtin(const char *name) {
+    const basl_doc_entry_t *entry;
+    char *output = NULL;
+    size_t output_len = 0;
+    basl_error_t error = {0};
+
+    /* Try direct lookup first */
+    entry = basl_doc_lookup(name);
+    if (entry != NULL) {
+        if (basl_doc_entry_render(entry, &output, &output_len, &error) == BASL_STATUS_OK) {
+            fwrite(output, 1, output_len, stdout);
+            free(output);
+        }
+
+        /* If it's a module, also list its contents */
+        if (entry->signature == NULL) {
+            size_t count, i;
+            const basl_doc_entry_t *entries = basl_doc_list_module(name, &count);
+            if (entries != NULL && count > 1) {
+                printf("\nFunctions:\n");
+                for (i = 1; i < count; i++) {  /* Skip module entry itself */
+                    printf("  %-20s %s\n", entries[i].name, entries[i].summary);
+                }
+            }
+        }
+        return 0;
+    }
+
+    return -1;  /* Not found in registry */
+}
+
 static int cmd_doc(const char *file_path, const char *symbol) {
     basl_runtime_t *runtime = NULL;
     basl_error_t error = {0};
@@ -1242,6 +1294,24 @@ static int cmd_doc(const char *file_path, const char *symbol) {
     size_t output_len = 0;
     int exit_code = 0;
 
+    /* No arguments: list all modules */
+    if (file_path == NULL) {
+        return cmd_doc_list_modules();
+    }
+
+    /* Check if it's a builtin/stdlib name first */
+    if (cmd_doc_builtin(file_path) == 0) {
+        return 0;
+    }
+
+    /* If no file extension and not found in registry, error */
+    if (strchr(file_path, '/') == NULL && 
+        (strlen(file_path) < 5 || strcmp(file_path + strlen(file_path) - 5, ".basl") != 0)) {
+        fprintf(stderr, "error: '%s' not found. Use 'basl doc' to list available modules.\n", file_path);
+        return 1;
+    }
+
+    /* File-based documentation */
     if (basl_runtime_open(&runtime, NULL, &error) != BASL_STATUS_OK) {
         fprintf(stderr, "failed to initialize runtime: %s\n", basl_error_message(&error));
         return 1;
@@ -2474,7 +2544,34 @@ static int cmd_repl(void) {
             printf("  :help    Show this message\n");
             printf("  :quit    Exit the REPL (also Ctrl-D or exit())\n");
             printf("  :clear   Reset all state\n");
+            printf("  :doc     Show documentation (e.g. :doc len, :doc math)\n");
             printf("  __ans    Last expression result (string)\n");
+            continue;
+        }
+        if (strncmp(line, ":doc", 4) == 0) {
+            const char *arg = line + 4;
+            while (*arg == ' ') arg++;
+            if (*arg == '\0') {
+                /* List modules */
+                size_t count, i;
+                const char **modules = basl_doc_list_modules(&count);
+                printf("Available: ");
+                for (i = 0; i < count; i++) {
+                    printf("%s%s", modules[i], i < count - 1 ? ", " : "\n");
+                }
+            } else {
+                const basl_doc_entry_t *entry = basl_doc_lookup(arg);
+                if (entry != NULL) {
+                    char *text = NULL;
+                    size_t len = 0;
+                    if (basl_doc_entry_render(entry, &text, &len, &error) == BASL_STATUS_OK) {
+                        printf("%s", text);
+                        free(text);
+                    }
+                } else {
+                    printf("Not found: %s\n", arg);
+                }
+            }
             continue;
         }
         if (strcmp(line, ":clear") == 0) {
@@ -2775,9 +2872,9 @@ int main(int argc, char **argv) {
     basl_cli_add_positional(cmd, "file", "Script file to debug", &debug_file);
     basl_cli_add_bool_flag(cmd, "interactive", 'i', "Use interactive CLI debugger (default: DAP server)", &debug_interactive);
 
-    cmd = basl_cli_add_command(&cli, "doc", "Show public API documentation for a BASL source file");
-    basl_cli_add_positional(cmd, "file", "Source file to document", &doc_file);
-    basl_cli_add_positional(cmd, "symbol", "Symbol to look up (e.g. Point or Point.x)", &doc_symbol);
+    cmd = basl_cli_add_command(&cli, "doc", "Show documentation for modules, builtins, or source files");
+    basl_cli_add_positional(cmd, "target", "Module name (e.g. math) or source file path", &doc_file);
+    basl_cli_add_positional(cmd, "symbol", "Symbol to look up (e.g. sqrt or Point.x)", &doc_symbol);
 
     cmd = basl_cli_add_command(&cli, "fmt", "Format BASL source files");
     basl_cli_add_positional(cmd, "file", "Source file to format", &fmt_file);
@@ -2840,10 +2937,6 @@ int main(int argc, char **argv) {
             return cmd_debug(debug_file);
         }
         if (strcmp(matched_name, "doc") == 0) {
-            if (doc_file == NULL) {
-                fprintf(stderr, "error: missing file argument\n");
-                return 2;
-            }
             return cmd_doc(doc_file, doc_symbol);
         }
         if (strcmp(matched_name, "fmt") == 0) {

--- a/src/doc_registry.c
+++ b/src/doc_registry.c
@@ -1,0 +1,377 @@
+#include "basl/doc_registry.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "internal/basl_internal.h"
+
+/* ── Builtin Function Docs ────────────────────────────────── */
+
+static const basl_doc_entry_t builtin_docs[] = {
+    {
+        "builtins",
+        NULL,
+        "Built-in functions available without import.",
+        "These functions are always available in BASL programs.",
+        NULL
+    },
+    {
+        "len",
+        "len(value: string | array | map) -> int",
+        "Return the length of a string, array, or map.",
+        NULL,
+        "len(\"hello\")  // 5\nlen([1, 2, 3])  // 3"
+    },
+    {
+        "type",
+        "type(value: any) -> string",
+        "Return the type name of a value.",
+        NULL,
+        "type(42)       // \"int\"\ntype(\"hello\")  // \"string\""
+    },
+    {
+        "str",
+        "str(value: any) -> string",
+        "Convert a value to its string representation.",
+        NULL,
+        "str(42)    // \"42\"\nstr(true)  // \"true\""
+    },
+    {
+        "int",
+        "int(value: string | float) -> int",
+        "Convert a string or float to an integer.",
+        NULL,
+        "int(\"42\")   // 42\nint(3.14)   // 3"
+    },
+    {
+        "float",
+        "float(value: string | int) -> float",
+        "Convert a string or integer to a float.",
+        NULL,
+        "float(\"3.14\")  // 3.14\nfloat(42)      // 42.0"
+    },
+    {
+        "exit",
+        "exit(code: int) -> void",
+        "Exit the program with the given status code.",
+        NULL,
+        "exit(0)  // success\nexit(1)  // failure"
+    },
+};
+
+#define BUILTIN_COUNT (sizeof(builtin_docs) / sizeof(builtin_docs[0]))
+
+/* ── fmt Module Docs ──────────────────────────────────────── */
+
+static const basl_doc_entry_t fmt_docs[] = {
+    {
+        "fmt",
+        NULL,
+        "Formatted output functions.",
+        "The fmt module provides functions for printing to stdout and stderr.",
+        NULL
+    },
+    {
+        "fmt.print",
+        "fmt.print(value: string) -> void",
+        "Print a string to stdout without a newline.",
+        NULL,
+        "fmt.print(\"hello \")\nfmt.print(\"world\")"
+    },
+    {
+        "fmt.println",
+        "fmt.println(value: string) -> void",
+        "Print a string to stdout with a newline.",
+        NULL,
+        "fmt.println(\"Hello, world!\")"
+    },
+    {
+        "fmt.eprintln",
+        "fmt.eprintln(value: string) -> void",
+        "Print a string to stderr with a newline.",
+        NULL,
+        "fmt.eprintln(\"Error: something went wrong\")"
+    },
+};
+
+#define FMT_COUNT (sizeof(fmt_docs) / sizeof(fmt_docs[0]))
+
+/* ── math Module Docs ─────────────────────────────────────── */
+
+static const basl_doc_entry_t math_docs[] = {
+    {
+        "math",
+        NULL,
+        "Mathematical functions and constants.",
+        "The math module provides common mathematical operations.",
+        NULL
+    },
+    {
+        "math.sqrt",
+        "math.sqrt(x: float) -> float",
+        "Return the square root of x.",
+        NULL,
+        "math.sqrt(16.0)  // 4.0"
+    },
+    {
+        "math.abs",
+        "math.abs(x: int | float) -> int | float",
+        "Return the absolute value of x.",
+        NULL,
+        "math.abs(-5)    // 5\nmath.abs(-3.14) // 3.14"
+    },
+    {
+        "math.floor",
+        "math.floor(x: float) -> int",
+        "Return the largest integer less than or equal to x.",
+        NULL,
+        "math.floor(3.7)   // 3\nmath.floor(-3.2)  // -4"
+    },
+    {
+        "math.ceil",
+        "math.ceil(x: float) -> int",
+        "Return the smallest integer greater than or equal to x.",
+        NULL,
+        "math.ceil(3.2)   // 4\nmath.ceil(-3.7)  // -3"
+    },
+    {
+        "math.pow",
+        "math.pow(base: float, exp: float) -> float",
+        "Return base raised to the power exp.",
+        NULL,
+        "math.pow(2.0, 10.0)  // 1024.0"
+    },
+    {
+        "math.sin",
+        "math.sin(x: float) -> float",
+        "Return the sine of x (in radians).",
+        NULL,
+        "math.sin(0.0)  // 0.0"
+    },
+    {
+        "math.cos",
+        "math.cos(x: float) -> float",
+        "Return the cosine of x (in radians).",
+        NULL,
+        "math.cos(0.0)  // 1.0"
+    },
+    {
+        "math.tan",
+        "math.tan(x: float) -> float",
+        "Return the tangent of x (in radians).",
+        NULL,
+        "math.tan(0.0)  // 0.0"
+    },
+    {
+        "math.log",
+        "math.log(x: float) -> float",
+        "Return the natural logarithm of x.",
+        NULL,
+        "math.log(2.718281828)  // ~1.0"
+    },
+    {
+        "math.exp",
+        "math.exp(x: float) -> float",
+        "Return e raised to the power x.",
+        NULL,
+        "math.exp(1.0)  // ~2.718"
+    },
+};
+
+#define MATH_COUNT (sizeof(math_docs) / sizeof(math_docs[0]))
+
+/* ── args Module Docs ─────────────────────────────────────── */
+
+static const basl_doc_entry_t args_docs[] = {
+    {
+        "args",
+        NULL,
+        "Command-line argument access.",
+        "The args module provides access to command-line arguments.",
+        NULL
+    },
+    {
+        "args.get",
+        "args.get() -> [string]",
+        "Return the command-line arguments as an array of strings.",
+        NULL,
+        "let argv = args.get()\nfor arg in argv { println(arg) }"
+    },
+};
+
+#define ARGS_COUNT (sizeof(args_docs) / sizeof(args_docs[0]))
+
+/* ── test Module Docs ─────────────────────────────────────── */
+
+static const basl_doc_entry_t test_docs[] = {
+    {
+        "test",
+        NULL,
+        "Testing utilities.",
+        "The test module provides assertion functions for testing.",
+        NULL
+    },
+    {
+        "test.assert",
+        "test.assert(condition: bool) -> void",
+        "Assert that condition is true, panic otherwise.",
+        NULL,
+        "test.assert(1 + 1 == 2)"
+    },
+    {
+        "test.assert_eq",
+        "test.assert_eq(left: any, right: any) -> void",
+        "Assert that left equals right, panic otherwise.",
+        NULL,
+        "test.assert_eq(add(1, 2), 3)"
+    },
+};
+
+#define TEST_COUNT (sizeof(test_docs) / sizeof(test_docs[0]))
+
+/* ── Module List ──────────────────────────────────────────── */
+
+static const char *module_names[] = {
+    "builtins",
+    "fmt",
+    "math",
+    "args",
+    "test",
+};
+
+#define MODULE_COUNT (sizeof(module_names) / sizeof(module_names[0]))
+
+/* ── Lookup Implementation ────────────────────────────────── */
+
+const basl_doc_entry_t *basl_doc_lookup(const char *name) {
+    size_t i, len;
+
+    if (name == NULL) return NULL;
+    len = strlen(name);
+
+    /* Check builtins */
+    for (i = 0; i < BUILTIN_COUNT; i++) {
+        if (strcmp(builtin_docs[i].name, name) == 0) {
+            return &builtin_docs[i];
+        }
+    }
+
+    /* Check fmt */
+    for (i = 0; i < FMT_COUNT; i++) {
+        if (strcmp(fmt_docs[i].name, name) == 0) {
+            return &fmt_docs[i];
+        }
+    }
+
+    /* Check math */
+    for (i = 0; i < MATH_COUNT; i++) {
+        if (strcmp(math_docs[i].name, name) == 0) {
+            return &math_docs[i];
+        }
+    }
+
+    /* Check args */
+    for (i = 0; i < ARGS_COUNT; i++) {
+        if (strcmp(args_docs[i].name, name) == 0) {
+            return &args_docs[i];
+        }
+    }
+
+    /* Check test */
+    for (i = 0; i < TEST_COUNT; i++) {
+        if (strcmp(test_docs[i].name, name) == 0) {
+            return &test_docs[i];
+        }
+    }
+
+    (void)len;
+    return NULL;
+}
+
+const char **basl_doc_list_modules(size_t *count) {
+    if (count != NULL) {
+        *count = MODULE_COUNT;
+    }
+    return module_names;
+}
+
+const basl_doc_entry_t *basl_doc_list_module(
+    const char *module_name,
+    size_t *count
+) {
+    if (module_name == NULL) return NULL;
+
+    if (strcmp(module_name, "builtins") == 0) {
+        if (count) *count = BUILTIN_COUNT;
+        return builtin_docs;
+    }
+    if (strcmp(module_name, "fmt") == 0) {
+        if (count) *count = FMT_COUNT;
+        return fmt_docs;
+    }
+    if (strcmp(module_name, "math") == 0) {
+        if (count) *count = MATH_COUNT;
+        return math_docs;
+    }
+    if (strcmp(module_name, "args") == 0) {
+        if (count) *count = ARGS_COUNT;
+        return args_docs;
+    }
+    if (strcmp(module_name, "test") == 0) {
+        if (count) *count = TEST_COUNT;
+        return test_docs;
+    }
+
+    return NULL;
+}
+
+basl_status_t basl_doc_entry_render(
+    const basl_doc_entry_t *entry,
+    char **out_text,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    char *buf;
+    size_t len = 0;
+    size_t cap = 1024;
+
+    if (entry == NULL || out_text == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT,
+                               "doc: invalid arguments");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    buf = malloc(cap);
+    if (buf == NULL) {
+        basl_error_set_literal(error, BASL_STATUS_OUT_OF_MEMORY, "out of memory");
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+
+    /* Name/signature */
+    if (entry->signature != NULL) {
+        len += (size_t)snprintf(buf + len, cap - len, "%s\n\n", entry->signature);
+    } else {
+        len += (size_t)snprintf(buf + len, cap - len, "%s\n\n", entry->name);
+    }
+
+    /* Summary */
+    if (entry->summary != NULL) {
+        len += (size_t)snprintf(buf + len, cap - len, "%s\n", entry->summary);
+    }
+
+    /* Description */
+    if (entry->description != NULL) {
+        len += (size_t)snprintf(buf + len, cap - len, "\n%s\n", entry->description);
+    }
+
+    /* Example */
+    if (entry->example != NULL) {
+        len += (size_t)snprintf(buf + len, cap - len, "\nExample:\n  %s\n",
+                                entry->example);
+    }
+
+    *out_text = buf;
+    if (out_length) *out_length = len;
+    return BASL_STATUS_OK;
+}

--- a/tests/doc_registry_test.c
+++ b/tests/doc_registry_test.c
@@ -1,0 +1,66 @@
+#include "basl_test.h"
+#include "basl/doc_registry.h"
+
+TEST(DocRegistryTest, LookupBuiltin) {
+    const basl_doc_entry_t *entry = basl_doc_lookup("len");
+    ASSERT_NE(entry, NULL);
+    EXPECT_STREQ(entry->name, "len");
+    ASSERT_NE(entry->signature, NULL);
+    ASSERT_NE(entry->summary, NULL);
+}
+
+TEST(DocRegistryTest, LookupModule) {
+    const basl_doc_entry_t *entry = basl_doc_lookup("math");
+    ASSERT_NE(entry, NULL);
+    EXPECT_STREQ(entry->name, "math");
+    EXPECT_EQ(entry->signature, NULL);  /* Modules have no signature */
+    ASSERT_NE(entry->summary, NULL);
+}
+
+TEST(DocRegistryTest, LookupQualified) {
+    const basl_doc_entry_t *entry = basl_doc_lookup("math.sqrt");
+    ASSERT_NE(entry, NULL);
+    EXPECT_STREQ(entry->name, "math.sqrt");
+    ASSERT_NE(entry->signature, NULL);
+}
+
+TEST(DocRegistryTest, LookupNotFound) {
+    const basl_doc_entry_t *entry = basl_doc_lookup("nonexistent");
+    EXPECT_EQ(entry, NULL);
+}
+
+TEST(DocRegistryTest, ListModules) {
+    size_t count = 0;
+    const char **modules = basl_doc_list_modules(&count);
+    ASSERT_NE(modules, NULL);
+    EXPECT_GT(count, 0u);
+}
+
+TEST(DocRegistryTest, ListModuleContents) {
+    size_t count = 0;
+    const basl_doc_entry_t *entries = basl_doc_list_module("math", &count);
+    ASSERT_NE(entries, NULL);
+    EXPECT_GT(count, 1u);  /* Module entry + functions */
+}
+
+TEST(DocRegistryTest, RenderEntry) {
+    const basl_doc_entry_t *entry = basl_doc_lookup("len");
+    char *text = NULL;
+    size_t len = 0;
+    basl_error_t error = {0};
+
+    ASSERT_EQ(basl_doc_entry_render(entry, &text, &len, &error), BASL_STATUS_OK);
+    ASSERT_NE(text, NULL);
+    EXPECT_GT(len, 0u);
+    free(text);
+}
+
+void register_doc_registry_tests(void) {
+    REGISTER_TEST(DocRegistryTest, LookupBuiltin);
+    REGISTER_TEST(DocRegistryTest, LookupModule);
+    REGISTER_TEST(DocRegistryTest, LookupQualified);
+    REGISTER_TEST(DocRegistryTest, LookupNotFound);
+    REGISTER_TEST(DocRegistryTest, ListModules);
+    REGISTER_TEST(DocRegistryTest, ListModuleContents);
+    REGISTER_TEST(DocRegistryTest, RenderEntry);
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -30,6 +30,7 @@ extern void register_token_tests(void);
 extern void register_toml_tests(void);
 extern void register_semantic_tests(void);
 extern void register_lsp_tests(void);
+extern void register_doc_registry_tests(void);
 extern void register_type_tests(void);
 extern void register_value_tests(void);
 extern void register_vm_tests(void);
@@ -64,6 +65,7 @@ int main(void) {
     register_toml_tests();
     register_semantic_tests();
     register_lsp_tests();
+    register_doc_registry_tests();
     register_type_tests();
     register_value_tests();
     register_vm_tests();


### PR DESCRIPTION
## Summary

Adds a unified documentation system for BASL that works everywhere: CLI, REPL, and for all code types (builtins, stdlib, user code).

## Changes

### Doc Registry (`src/doc_registry.c`, `include/basl/doc_registry.h`)
- `basl_doc_lookup()` - lookup docs by name
- `basl_doc_list_modules()` - list all documented modules
- `basl_doc_list_module()` - list entries in a module
- `basl_doc_entry_render()` - format doc for display

### Documented Modules
| Module | Functions |
|--------|-----------|
| builtins | len, type, str, int, float, exit |
| fmt | print, println, eprintln |
| math | sqrt, abs, floor, ceil, pow, sin, cos, tan, log, exp |
| args | get |
| test | assert, assert_eq |

### CLI Enhancements
- `basl doc` - lists all modules
- `basl doc <module>` - shows module docs and function list
- `basl doc <name>` - shows function/builtin docs
- `basl doc <file.basl>` - user code docs (unchanged)

### REPL
- `:doc` - lists modules
- `:doc <name>` - shows documentation

## Testing
- 7 new doc registry tests
- All 560 tests passing

## Design
Uses embedded doc strings (Option 1 from discussion) for zero external dependencies and single code path maintenance. Binary size impact is ~5KB.