### PR TITLE
Add url module for URL parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ add_library(basl ${BASL_LIBRARY_TYPE}
     src/stdlib/regex_engine.c
     src/stdlib/test.c
     src/stdlib/unsafe.c
+    src/stdlib/url.c
+    src/url.c
 )
 
 # ── Platform abstraction layer ──────────────────────────────────────
@@ -197,6 +199,7 @@ if(BASL_BUILD_TESTS)
         tests/lexer_test.c
         tests/log_test.c
         tests/toml_test.c
+        tests/url_test.c
         tests/map_test.c
         tests/platform_test.c
         tests/runtime_test.c

--- a/include/basl/stdlib.h
+++ b/include/basl/stdlib.h
@@ -19,6 +19,7 @@ extern BASL_API const basl_native_module_t basl_stdlib_readline;
 extern BASL_API const basl_native_module_t basl_stdlib_regex;
 extern BASL_API const basl_native_module_t basl_stdlib_test;
 extern BASL_API const basl_native_module_t basl_stdlib_unsafe;
+extern BASL_API const basl_native_module_t basl_stdlib_url;
 
 /* Register all built-in stdlib modules into a native registry. */
 static inline basl_status_t basl_stdlib_register_all(
@@ -42,7 +43,9 @@ static inline basl_status_t basl_stdlib_register_all(
     if (status != BASL_STATUS_OK) return status;
     status = basl_native_registry_add(registry, &basl_stdlib_test, error);
     if (status != BASL_STATUS_OK) return status;
-    return basl_native_registry_add(registry, &basl_stdlib_unsafe, error);
+    status = basl_native_registry_add(registry, &basl_stdlib_unsafe, error);
+    if (status != BASL_STATUS_OK) return status;
+    return basl_native_registry_add(registry, &basl_stdlib_url, error);
 }
 
 /* Check if an import name is a native stdlib module. */
@@ -58,7 +61,8 @@ static inline int basl_stdlib_is_native_module(
            (name_length == 8U && memcmp(name, "readline", 8U) == 0) ||
            (name_length == 5U && memcmp(name, "regex", 5U) == 0) ||
            (name_length == 4U && memcmp(name, "test", 4U) == 0) ||
-           (name_length == 6U && memcmp(name, "unsafe", 6U) == 0);
+           (name_length == 6U && memcmp(name, "unsafe", 6U) == 0) ||
+           (name_length == 3U && memcmp(name, "url", 3U) == 0);
 }
 
 #ifdef __cplusplus

--- a/include/basl/url.h
+++ b/include/basl/url.h
@@ -1,0 +1,110 @@
+/* BASL URL parsing library.
+ *
+ * Implements RFC 3986 URI parsing with percent-encoding/decoding.
+ * Pure C11, no external dependencies.
+ */
+#ifndef BASL_URL_H
+#define BASL_URL_H
+
+#include "basl/export.h"
+#include "basl/status.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Parsed URL structure.
+ * All strings are owned by the structure and freed by basl_url_free().
+ */
+typedef struct basl_url {
+    char *scheme;       /* e.g. "https" */
+    char *username;     /* userinfo username (decoded) */
+    char *password;     /* userinfo password (decoded), NULL if not set */
+    char *host;         /* hostname or IP (decoded) */
+    char *port;         /* port string, NULL if not specified */
+    char *path;         /* path (decoded) */
+    char *raw_query;    /* query string without '?' (encoded) */
+    char *fragment;     /* fragment without '#' (decoded) */
+} basl_url_t;
+
+/**
+ * Parse a URL string into components.
+ * Returns BASL_STATUS_OK on success.
+ */
+BASL_API basl_status_t basl_url_parse(
+    const char *url_string,
+    size_t url_length,
+    basl_url_t *out_url,
+    basl_error_t *error
+);
+
+/**
+ * Free all memory owned by a parsed URL.
+ */
+BASL_API void basl_url_free(basl_url_t *url);
+
+/**
+ * Reconstruct a URL string from components.
+ * Caller must free the returned string.
+ */
+BASL_API basl_status_t basl_url_string(
+    const basl_url_t *url,
+    char **out_string,
+    size_t *out_length,
+    basl_error_t *error
+);
+
+/**
+ * Percent-encode a string for use in a URL path.
+ * Caller must free the returned string.
+ */
+BASL_API basl_status_t basl_url_path_escape(
+    const char *input,
+    size_t input_length,
+    char **out_escaped,
+    size_t *out_length,
+    basl_error_t *error
+);
+
+/**
+ * Percent-encode a string for use in a URL query.
+ * Caller must free the returned string.
+ */
+BASL_API basl_status_t basl_url_query_escape(
+    const char *input,
+    size_t input_length,
+    char **out_escaped,
+    size_t *out_length,
+    basl_error_t *error
+);
+
+/**
+ * Decode a percent-encoded string.
+ * Caller must free the returned string.
+ */
+BASL_API basl_status_t basl_url_unescape(
+    const char *input,
+    size_t input_length,
+    char **out_decoded,
+    size_t *out_length,
+    basl_error_t *error
+);
+
+/**
+ * Get the hostname from a URL (without port).
+ */
+BASL_API const char *basl_url_hostname(const basl_url_t *url);
+
+/**
+ * Check if URL is absolute (has scheme).
+ */
+BASL_API int basl_url_is_absolute(const basl_url_t *url);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BASL_URL_H */

--- a/integration_tests/test_url.py
+++ b/integration_tests/test_url.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Integration tests for BASL url module."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+BASL_BIN = os.environ.get("BASL_BIN", "./build/basl")
+
+
+def run_basl(code: str) -> tuple[int, str, str]:
+    """Run BASL code and return (exit_code, stdout, stderr)."""
+    with tempfile.TemporaryDirectory(prefix="basl_url_") as tmpdir:
+        path = Path(tmpdir) / "test.basl"
+        path.write_text(code)
+        result = subprocess.run(
+            [BASL_BIN, "run", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+
+class UrlSchemeTest(unittest.TestCase):
+    """Tests for url.scheme()"""
+
+    def test_scheme_https(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.scheme("https://example.com") == "https") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_scheme_http(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.scheme("http://example.com") == "http") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+class UrlHostTest(unittest.TestCase):
+    """Tests for url.host()"""
+
+    def test_host_simple(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.host("https://example.com/path") == "example.com") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_host_with_port(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.host("https://example.com:8080/path") == "example.com") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+class UrlPortTest(unittest.TestCase):
+    """Tests for url.port()"""
+
+    def test_port_present(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.port("https://example.com:8080") == "8080") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_port_absent(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.port("https://example.com") == "") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+class UrlPathTest(unittest.TestCase):
+    """Tests for url.path()"""
+
+    def test_path_simple(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.path("https://example.com/foo/bar") == "/foo/bar") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+class UrlQueryTest(unittest.TestCase):
+    """Tests for url.query()"""
+
+    def test_query_simple(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.query("https://example.com?a=1&b=2") == "a=1&b=2") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+class UrlEncodeDecodeTest(unittest.TestCase):
+    """Tests for url.encode() and url.decode()"""
+
+    def test_encode_spaces(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.encode("hello world") == "hello+world") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_decode_percent(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.decode("hello%20world") == "hello world") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+    def test_decode_plus(self):
+        code = '''import "url";
+fn main() -> i32 {
+    if (url.decode("hello+world") == "hello world") { return 0; }
+    return 1;
+}'''
+        rc, out, err = run_basl(code)
+        self.assertEqual(rc, 0, f"stderr: {err}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/doc_registry.c
+++ b/src/doc_registry.c
@@ -541,6 +541,85 @@ static const basl_doc_entry_t random_docs[] = {
 
 #define RANDOM_COUNT (sizeof(random_docs) / sizeof(random_docs[0]))
 
+/* ── url Module Docs ──────────────────────────────────────── */
+
+static const basl_doc_entry_t url_docs[] = {
+    {
+        "url",
+        NULL,
+        "URL parsing and manipulation.",
+        "The url module provides functions for parsing and manipulating URLs\n"
+        "according to RFC 3986.",
+        NULL
+    },
+    {
+        "url.parse",
+        "url.parse(url: string) -> string",
+        "Parse a URL into components.",
+        "Returns components as pipe-separated string:\n"
+        "scheme|user|pass|host|port|path|query|fragment",
+        "url.parse(\"https://user:pass@example.com:8080/path?q=1#frag\")"
+    },
+    {
+        "url.scheme",
+        "url.scheme(url: string) -> string",
+        "Get the scheme (protocol) from a URL.",
+        "Returns the scheme component (e.g. \"https\", \"http\").",
+        "url.scheme(\"https://example.com\")  // \"https\""
+    },
+    {
+        "url.host",
+        "url.host(url: string) -> string",
+        "Get the hostname from a URL.",
+        "Returns the host component without port.",
+        "url.host(\"https://example.com:8080/path\")  // \"example.com\""
+    },
+    {
+        "url.port",
+        "url.port(url: string) -> string",
+        "Get the port from a URL.",
+        "Returns the port as a string, or empty if not specified.",
+        "url.port(\"https://example.com:8080\")  // \"8080\""
+    },
+    {
+        "url.path",
+        "url.path(url: string) -> string",
+        "Get the path from a URL.",
+        "Returns the decoded path component.",
+        "url.path(\"https://example.com/foo/bar\")  // \"/foo/bar\""
+    },
+    {
+        "url.query",
+        "url.query(url: string) -> string",
+        "Get the query string from a URL.",
+        "Returns the raw query string without the leading '?'.",
+        "url.query(\"https://example.com?a=1&b=2\")  // \"a=1&b=2\""
+    },
+    {
+        "url.fragment",
+        "url.fragment(url: string) -> string",
+        "Get the fragment from a URL.",
+        "Returns the decoded fragment without the leading '#'.",
+        "url.fragment(\"https://example.com#section\")  // \"section\""
+    },
+    {
+        "url.encode",
+        "url.encode(s: string) -> string",
+        "Percent-encode a string for use in URLs.",
+        "Encodes special characters as %XX sequences.",
+        "url.encode(\"hello world\")  // \"hello+world\""
+    },
+    {
+        "url.decode",
+        "url.decode(s: string) -> string",
+        "Decode a percent-encoded string.",
+        "Decodes %XX sequences and '+' to space.",
+        "url.decode(\"hello%20world\")  // \"hello world\""
+    },
+};
+
+#define URL_COUNT (sizeof(url_docs) / sizeof(url_docs[0]))
+
 /* ── Module List ──────────────────────────────────────────── */
 
 static const char *module_names[] = {
@@ -552,6 +631,7 @@ static const char *module_names[] = {
     "strings",
     "regex",
     "random",
+    "url",
 };
 
 #define MODULE_COUNT (sizeof(module_names) / sizeof(module_names[0]))
@@ -620,6 +700,13 @@ const basl_doc_entry_t *basl_doc_lookup(const char *name) {
         }
     }
 
+    /* Check url */
+    for (i = 0; i < URL_COUNT; i++) {
+        if (strcmp(url_docs[i].name, name) == 0) {
+            return &url_docs[i];
+        }
+    }
+
     (void)len;
     return NULL;
 }
@@ -668,6 +755,10 @@ const basl_doc_entry_t *basl_doc_list_module(
     if (strcmp(module_name, "random") == 0) {
         if (count) *count = RANDOM_COUNT;
         return random_docs;
+    }
+    if (strcmp(module_name, "url") == 0) {
+        if (count) *count = URL_COUNT;
+        return url_docs;
     }
 
     return NULL;

--- a/src/stdlib/url.c
+++ b/src/stdlib/url.c
@@ -1,0 +1,322 @@
+/* BASL standard library: url module.
+ *
+ * Provides URL parsing and manipulation.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "basl/url.h"
+#include "basl/native_module.h"
+#include "basl/type.h"
+#include "basl/value.h"
+#include "basl/vm.h"
+#include "basl/runtime.h"
+
+#include "internal/basl_nanbox.h"
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static bool get_string_arg(basl_vm_t *vm, size_t base, size_t idx,
+                           const char **str, size_t *len) {
+    basl_value_t v = basl_vm_stack_get(vm, base + idx);
+    if (!basl_nanbox_is_object(v)) return false;
+    basl_object_t *obj = (basl_object_t *)basl_nanbox_decode_ptr(v);
+    if (!obj || basl_object_type(obj) != BASL_OBJECT_STRING) return false;
+    *str = basl_string_object_c_str(obj);
+    *len = basl_string_object_length(obj);
+    return true;
+}
+
+static basl_status_t push_string(basl_vm_t *vm, const char *str, size_t len,
+                                  basl_error_t *error) {
+    basl_object_t *obj = NULL;
+    basl_status_t s = basl_string_object_new(basl_vm_runtime(vm), str, len, &obj, error);
+    if (s != BASL_STATUS_OK) return s;
+    basl_value_t val;
+    basl_value_init_object(&val, &obj);
+    s = basl_vm_stack_push(vm, &val, error);
+    basl_value_release(&val);
+    return s;
+}
+
+/* ── url.parse(url: string) -> string ────────────────────────────── */
+
+static basl_status_t basl_url_parse_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    char result[2048];
+    size_t len;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    len = (size_t)snprintf(result, sizeof(result), "%s|%s|%s|%s|%s|%s|%s|%s",
+        url.scheme ? url.scheme : "",
+        url.username ? url.username : "",
+        url.password ? url.password : "",
+        url.host ? url.host : "",
+        url.port ? url.port : "",
+        url.path ? url.path : "",
+        url.raw_query ? url.raw_query : "",
+        url.fragment ? url.fragment : "");
+
+    basl_url_free(&url);
+    return push_string(vm, result, len, error);
+}
+
+/* ── url.scheme(url: string) -> string ───────────────────────────── */
+
+static basl_status_t basl_url_scheme_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.scheme ? url.scheme : "", url.scheme ? strlen(url.scheme) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.host(url: string) -> string ─────────────────────────────── */
+
+static basl_status_t basl_url_host_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.host ? url.host : "", url.host ? strlen(url.host) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.port(url: string) -> string ─────────────────────────────── */
+
+static basl_status_t basl_url_port_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.port ? url.port : "", url.port ? strlen(url.port) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.path(url: string) -> string ─────────────────────────────── */
+
+static basl_status_t basl_url_path_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.path ? url.path : "", url.path ? strlen(url.path) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.query(url: string) -> string ────────────────────────────── */
+
+static basl_status_t basl_url_query_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.raw_query ? url.raw_query : "", url.raw_query ? strlen(url.raw_query) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.fragment(url: string) -> string ─────────────────────────── */
+
+static basl_status_t basl_url_fragment_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *url_str;
+    size_t url_len;
+    basl_url_t url;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &url_str, &url_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_parse(url_str, url_len, &url, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, url.fragment ? url.fragment : "", url.fragment ? strlen(url.fragment) : 0, error);
+    basl_url_free(&url);
+    return s;
+}
+
+/* ── url.encode(s: string) -> string ─────────────────────────────── */
+
+static basl_status_t basl_url_encode_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *input;
+    size_t input_len;
+    char *encoded;
+    size_t encoded_len;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &input, &input_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_query_escape(input, input_len, &encoded, &encoded_len, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, encoded, encoded_len, error);
+    free(encoded);
+    return s;
+}
+
+/* ── url.decode(s: string) -> string ─────────────────────────────── */
+
+static basl_status_t basl_url_decode_fn(
+    basl_vm_t *vm, size_t arg_count, basl_error_t *error
+) {
+    size_t base = basl_vm_stack_depth(vm) - arg_count;
+    const char *input;
+    size_t input_len;
+    char *decoded;
+    size_t decoded_len;
+    basl_status_t s;
+
+    if (!get_string_arg(vm, base, 0, &input, &input_len)) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+
+    if (basl_url_unescape(input, input_len, &decoded, &decoded_len, error) != BASL_STATUS_OK) {
+        basl_vm_stack_pop_n(vm, arg_count);
+        return push_string(vm, "", 0, error);
+    }
+    basl_vm_stack_pop_n(vm, arg_count);
+
+    s = push_string(vm, decoded, decoded_len, error);
+    free(decoded);
+    return s;
+}
+
+/* ── Module definition ───────────────────────────────────────────── */
+
+static const int str_param[] = {BASL_TYPE_STRING};
+
+static const basl_native_module_function_t basl_url_functions[] = {
+    {"parse", 5U, basl_url_parse_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"scheme", 6U, basl_url_scheme_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"host", 4U, basl_url_host_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"port", 4U, basl_url_port_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"path", 4U, basl_url_path_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"query", 5U, basl_url_query_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"fragment", 8U, basl_url_fragment_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"encode", 6U, basl_url_encode_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+    {"decode", 6U, basl_url_decode_fn, 1U, str_param, BASL_TYPE_STRING, 1U, NULL, 0},
+};
+
+#define URL_FUNCTION_COUNT \
+    (sizeof(basl_url_functions) / sizeof(basl_url_functions[0]))
+
+BASL_API const basl_native_module_t basl_stdlib_url = {
+    "url", 3U,
+    basl_url_functions,
+    URL_FUNCTION_COUNT,
+    NULL, 0U
+};

--- a/src/url.c
+++ b/src/url.c
@@ -1,0 +1,429 @@
+/* BASL URL parsing library implementation.
+ *
+ * Implements RFC 3986 URI parsing.
+ */
+#include "basl/url.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "internal/basl_internal.h"
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static char *str_ndup(const char *s, size_t n) {
+    char *r = malloc(n + 1);
+    if (r) {
+        memcpy(r, s, n);
+        r[n] = '\0';
+    }
+    return r;
+}
+
+static int hex_digit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    return -1;
+}
+
+static int is_unreserved(char c) {
+    return isalnum((unsigned char)c) || c == '-' || c == '.' || c == '_' || c == '~';
+}
+
+/* ── Percent Encoding/Decoding ───────────────────────────────────── */
+
+basl_status_t basl_url_unescape(
+    const char *input,
+    size_t input_length,
+    char **out_decoded,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    char *result;
+    size_t i, j;
+
+    if (!input || !out_decoded) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "null argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    result = malloc(input_length + 1);
+    if (!result) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_OUT_OF_MEMORY, "out of memory");
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+
+    for (i = 0, j = 0; i < input_length; i++) {
+        if (input[i] == '%' && i + 2 < input_length) {
+            int h1 = hex_digit(input[i + 1]);
+            int h2 = hex_digit(input[i + 2]);
+            if (h1 >= 0 && h2 >= 0) {
+                result[j++] = (char)((h1 << 4) | h2);
+                i += 2;
+                continue;
+            }
+        }
+        if (input[i] == '+') {
+            result[j++] = ' ';  /* Query string convention */
+        } else {
+            result[j++] = input[i];
+        }
+    }
+    result[j] = '\0';
+
+    *out_decoded = result;
+    if (out_length) *out_length = j;
+    return BASL_STATUS_OK;
+}
+
+static basl_status_t percent_encode(
+    const char *input,
+    size_t input_length,
+    int encode_slash,
+    int encode_plus,
+    char **out_escaped,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    static const char hex[] = "0123456789ABCDEF";
+    char *result;
+    size_t i, j, needed;
+
+    if (!input || !out_escaped) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "null argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    /* Calculate needed size */
+    needed = 0;
+    for (i = 0; i < input_length; i++) {
+        unsigned char c = (unsigned char)input[i];
+        if (is_unreserved((char)c) || (!encode_slash && c == '/')) {
+            needed++;
+        } else {
+            needed += 3;
+        }
+    }
+
+    result = malloc(needed + 1);
+    if (!result) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_OUT_OF_MEMORY, "out of memory");
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+
+    for (i = 0, j = 0; i < input_length; i++) {
+        unsigned char c = (unsigned char)input[i];
+        if (is_unreserved((char)c) || (!encode_slash && c == '/')) {
+            result[j++] = (char)c;
+        } else if (!encode_plus && c == ' ') {
+            result[j++] = '+';
+        } else {
+            result[j++] = '%';
+            result[j++] = hex[c >> 4];
+            result[j++] = hex[c & 0x0F];
+        }
+    }
+    result[j] = '\0';
+
+    *out_escaped = result;
+    if (out_length) *out_length = j;
+    return BASL_STATUS_OK;
+}
+
+basl_status_t basl_url_path_escape(
+    const char *input,
+    size_t input_length,
+    char **out_escaped,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    return percent_encode(input, input_length, 1, 1, out_escaped, out_length, error);
+}
+
+basl_status_t basl_url_query_escape(
+    const char *input,
+    size_t input_length,
+    char **out_escaped,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    return percent_encode(input, input_length, 1, 0, out_escaped, out_length, error);
+}
+
+/* ── URL Parsing ─────────────────────────────────────────────────── */
+
+basl_status_t basl_url_parse(
+    const char *url_string,
+    size_t url_length,
+    basl_url_t *out_url,
+    basl_error_t *error
+) {
+    const char *p, *end, *scheme_end, *authority_start, *authority_end;
+    const char *userinfo_end, *host_start, *host_end, *port_start;
+    const char *path_start, *path_end, *query_start, *query_end;
+    const char *fragment_start;
+
+    if (!url_string || !out_url) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "null argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    memset(out_url, 0, sizeof(*out_url));
+    p = url_string;
+    end = url_string + url_length;
+
+    /* Parse scheme (if present) */
+    scheme_end = NULL;
+    for (const char *s = p; s < end; s++) {
+        if (*s == ':') {
+            scheme_end = s;
+            break;
+        }
+        if (*s == '/' || *s == '?' || *s == '#') break;
+        if (s == p && !isalpha((unsigned char)*s)) break;
+        if (s > p && !isalnum((unsigned char)*s) && *s != '+' && *s != '-' && *s != '.') break;
+    }
+
+    if (scheme_end) {
+        out_url->scheme = str_ndup(p, (size_t)(scheme_end - p));
+        p = scheme_end + 1;
+    }
+
+    /* Parse authority (if present) */
+    authority_start = NULL;
+    authority_end = NULL;
+    if (p + 1 < end && p[0] == '/' && p[1] == '/') {
+        p += 2;
+        authority_start = p;
+        /* Find end of authority */
+        for (authority_end = p; authority_end < end; authority_end++) {
+            if (*authority_end == '/' || *authority_end == '?' || *authority_end == '#') break;
+        }
+
+        /* Parse userinfo (if present) */
+        userinfo_end = NULL;
+        for (const char *s = authority_start; s < authority_end; s++) {
+            if (*s == '@') {
+                userinfo_end = s;
+                break;
+            }
+        }
+
+        if (userinfo_end) {
+            /* Parse username:password */
+            const char *colon = NULL;
+            for (const char *s = authority_start; s < userinfo_end; s++) {
+                if (*s == ':') {
+                    colon = s;
+                    break;
+                }
+            }
+            if (colon) {
+                char *decoded;
+                basl_url_unescape(authority_start, (size_t)(colon - authority_start), &decoded, NULL, NULL);
+                out_url->username = decoded;
+                basl_url_unescape(colon + 1, (size_t)(userinfo_end - colon - 1), &decoded, NULL, NULL);
+                out_url->password = decoded;
+            } else {
+                char *decoded;
+                basl_url_unescape(authority_start, (size_t)(userinfo_end - authority_start), &decoded, NULL, NULL);
+                out_url->username = decoded;
+            }
+            host_start = userinfo_end + 1;
+        } else {
+            host_start = authority_start;
+        }
+
+        /* Parse host:port */
+        host_end = authority_end;
+        port_start = NULL;
+
+        /* Handle IPv6 addresses */
+        if (host_start < authority_end && *host_start == '[') {
+            const char *bracket = memchr(host_start, ']', (size_t)(authority_end - host_start));
+            if (bracket) {
+                host_end = bracket + 1;
+                if (host_end < authority_end && *host_end == ':') {
+                    port_start = host_end + 1;
+                }
+            }
+        } else {
+            /* Find port separator */
+            for (const char *s = host_start; s < authority_end; s++) {
+                if (*s == ':') {
+                    host_end = s;
+                    port_start = s + 1;
+                    break;
+                }
+            }
+        }
+
+        if (host_start < host_end) {
+            /* Remove brackets from IPv6 */
+            if (*host_start == '[' && *(host_end - 1) == ']') {
+                out_url->host = str_ndup(host_start + 1, (size_t)(host_end - host_start - 2));
+            } else {
+                char *decoded;
+                basl_url_unescape(host_start, (size_t)(host_end - host_start), &decoded, NULL, NULL);
+                out_url->host = decoded;
+            }
+        }
+
+        if (port_start && port_start < authority_end) {
+            out_url->port = str_ndup(port_start, (size_t)(authority_end - port_start));
+        }
+
+        p = authority_end;
+    }
+
+    /* Parse path */
+    path_start = p;
+    path_end = p;
+    for (; path_end < end; path_end++) {
+        if (*path_end == '?' || *path_end == '#') break;
+    }
+    if (path_start < path_end) {
+        char *decoded;
+        basl_url_unescape(path_start, (size_t)(path_end - path_start), &decoded, NULL, NULL);
+        out_url->path = decoded;
+    }
+    p = path_end;
+
+    /* Parse query */
+    query_start = NULL;
+    query_end = NULL;
+    if (p < end && *p == '?') {
+        p++;
+        query_start = p;
+        for (query_end = p; query_end < end; query_end++) {
+            if (*query_end == '#') break;
+        }
+        out_url->raw_query = str_ndup(query_start, (size_t)(query_end - query_start));
+        p = query_end;
+    }
+
+    /* Parse fragment */
+    if (p < end && *p == '#') {
+        p++;
+        fragment_start = p;
+        char *decoded;
+        basl_url_unescape(fragment_start, (size_t)(end - fragment_start), &decoded, NULL, NULL);
+        out_url->fragment = decoded;
+    }
+
+    return BASL_STATUS_OK;
+}
+
+void basl_url_free(basl_url_t *url) {
+    if (!url) return;
+    free(url->scheme);
+    free(url->username);
+    free(url->password);
+    free(url->host);
+    free(url->port);
+    free(url->path);
+    free(url->raw_query);
+    free(url->fragment);
+    memset(url, 0, sizeof(*url));
+}
+
+/* ── URL String Building ─────────────────────────────────────────── */
+
+basl_status_t basl_url_string(
+    const basl_url_t *url,
+    char **out_string,
+    size_t *out_length,
+    basl_error_t *error
+) {
+    char *result;
+    size_t len, cap;
+
+    if (!url || !out_string) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_INVALID_ARGUMENT, "null argument");
+        return BASL_STATUS_INVALID_ARGUMENT;
+    }
+
+    cap = 256;
+    result = malloc(cap);
+    if (!result) {
+        if (error) basl_error_set_literal(error, BASL_STATUS_OUT_OF_MEMORY, "out of memory");
+        return BASL_STATUS_OUT_OF_MEMORY;
+    }
+    len = 0;
+
+    /* Scheme */
+    if (url->scheme && url->scheme[0]) {
+        len += (size_t)snprintf(result + len, cap - len, "%s:", url->scheme);
+    }
+
+    /* Authority */
+    if (url->host && url->host[0]) {
+        len += (size_t)snprintf(result + len, cap - len, "//");
+
+        /* Userinfo */
+        if (url->username && url->username[0]) {
+            char *escaped;
+            basl_url_path_escape(url->username, strlen(url->username), &escaped, NULL, NULL);
+            len += (size_t)snprintf(result + len, cap - len, "%s", escaped);
+            free(escaped);
+            if (url->password) {
+                basl_url_path_escape(url->password, strlen(url->password), &escaped, NULL, NULL);
+                len += (size_t)snprintf(result + len, cap - len, ":%s", escaped);
+                free(escaped);
+            }
+            len += (size_t)snprintf(result + len, cap - len, "@");
+        }
+
+        /* Host (check for IPv6) */
+        if (strchr(url->host, ':')) {
+            len += (size_t)snprintf(result + len, cap - len, "[%s]", url->host);
+        } else {
+            len += (size_t)snprintf(result + len, cap - len, "%s", url->host);
+        }
+
+        /* Port */
+        if (url->port && url->port[0]) {
+            len += (size_t)snprintf(result + len, cap - len, ":%s", url->port);
+        }
+    }
+
+    /* Path */
+    if (url->path && url->path[0]) {
+        char *escaped;
+        basl_url_path_escape(url->path, strlen(url->path), &escaped, NULL, NULL);
+        /* Ensure path starts with / if we have authority */
+        if (url->host && url->host[0] && escaped[0] != '/') {
+            len += (size_t)snprintf(result + len, cap - len, "/");
+        }
+        len += (size_t)snprintf(result + len, cap - len, "%s", escaped);
+        free(escaped);
+    }
+
+    /* Query */
+    if (url->raw_query && url->raw_query[0]) {
+        len += (size_t)snprintf(result + len, cap - len, "?%s", url->raw_query);
+    }
+
+    /* Fragment */
+    if (url->fragment && url->fragment[0]) {
+        char *escaped;
+        basl_url_path_escape(url->fragment, strlen(url->fragment), &escaped, NULL, NULL);
+        len += (size_t)snprintf(result + len, cap - len, "#%s", escaped);
+        free(escaped);
+    }
+
+    *out_string = result;
+    if (out_length) *out_length = len;
+    return BASL_STATUS_OK;
+}
+
+const char *basl_url_hostname(const basl_url_t *url) {
+    return url ? url->host : NULL;
+}
+
+int basl_url_is_absolute(const basl_url_t *url) {
+    return url && url->scheme && url->scheme[0];
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -28,6 +28,7 @@ extern void register_string_tests(void);
 extern void register_symbol_tests(void);
 extern void register_token_tests(void);
 extern void register_toml_tests(void);
+extern void register_url_tests(void);
 extern void register_semantic_tests(void);
 extern void register_lsp_tests(void);
 extern void register_doc_registry_tests(void);
@@ -63,6 +64,7 @@ int main(void) {
     register_symbol_tests();
     register_token_tests();
     register_toml_tests();
+    register_url_tests();
     register_semantic_tests();
     register_lsp_tests();
     register_doc_registry_tests();

--- a/tests/url_test.c
+++ b/tests/url_test.c
@@ -1,0 +1,135 @@
+/* Unit tests for BASL URL parsing library. */
+#include "basl_test.h"
+#include "basl/url.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ── Parse Tests ─────────────────────────────────────────────────── */
+
+TEST(BaslUrlTest, ParseFull) {
+    basl_url_t url;
+    basl_status_t s = basl_url_parse(
+        "https://user:pass@example.com:8080/path?query=1#frag", 52, &url, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(url.scheme, "https");
+    EXPECT_STREQ(url.username, "user");
+    EXPECT_STREQ(url.password, "pass");
+    EXPECT_STREQ(url.host, "example.com");
+    EXPECT_STREQ(url.port, "8080");
+    EXPECT_STREQ(url.path, "/path");
+    EXPECT_STREQ(url.raw_query, "query=1");
+    EXPECT_STREQ(url.fragment, "frag");
+    basl_url_free(&url);
+}
+
+TEST(BaslUrlTest, ParseSimple) {
+    basl_url_t url;
+    basl_status_t s = basl_url_parse("http://example.com", 18, &url, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(url.scheme, "http");
+    EXPECT_STREQ(url.host, "example.com");
+    EXPECT_EQ(url.port, NULL);
+    basl_url_free(&url);
+}
+
+TEST(BaslUrlTest, ParsePathOnly) {
+    basl_url_t url;
+    basl_status_t s = basl_url_parse("/foo/bar", 8, &url, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_EQ(url.scheme, NULL);
+    EXPECT_EQ(url.host, NULL);
+    EXPECT_STREQ(url.path, "/foo/bar");
+    basl_url_free(&url);
+}
+
+TEST(BaslUrlTest, ParseWithQuery) {
+    basl_url_t url;
+    basl_status_t s = basl_url_parse("http://example.com?a=1&b=2", 26, &url, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(url.raw_query, "a=1&b=2");
+    basl_url_free(&url);
+}
+
+TEST(BaslUrlTest, ParseIPv6) {
+    basl_url_t url;
+    basl_status_t s = basl_url_parse("http://[::1]:8080/path", 22, &url, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(url.host, "::1");
+    EXPECT_STREQ(url.port, "8080");
+    basl_url_free(&url);
+}
+
+/* ── Encoding Tests ──────────────────────────────────────────────── */
+
+TEST(BaslUrlTest, EncodeSpaces) {
+    char *encoded;
+    size_t len;
+    basl_status_t s = basl_url_query_escape("hello world", 11, &encoded, &len, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(encoded, "hello+world");
+    free(encoded);
+}
+
+TEST(BaslUrlTest, EncodeSpecial) {
+    char *encoded;
+    size_t len;
+    basl_status_t s = basl_url_query_escape("a=b&c=d", 7, &encoded, &len, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(encoded, "a%3Db%26c%3Dd");
+    free(encoded);
+}
+
+TEST(BaslUrlTest, DecodePercent) {
+    char *decoded;
+    size_t len;
+    basl_status_t s = basl_url_unescape("hello%20world", 13, &decoded, &len, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(decoded, "hello world");
+    free(decoded);
+}
+
+TEST(BaslUrlTest, DecodePlus) {
+    char *decoded;
+    size_t len;
+    basl_status_t s = basl_url_unescape("hello+world", 11, &decoded, &len, NULL);
+    ASSERT_EQ(s, BASL_STATUS_OK);
+    EXPECT_STREQ(decoded, "hello world");
+    free(decoded);
+}
+
+/* ── Utility Tests ───────────────────────────────────────────────── */
+
+TEST(BaslUrlTest, IsAbsolute) {
+    basl_url_t url;
+    basl_url_parse("https://example.com", 19, &url, NULL);
+    EXPECT_TRUE(basl_url_is_absolute(&url));
+    basl_url_free(&url);
+
+    basl_url_parse("/path/only", 10, &url, NULL);
+    EXPECT_FALSE(basl_url_is_absolute(&url));
+    basl_url_free(&url);
+}
+
+TEST(BaslUrlTest, Hostname) {
+    basl_url_t url;
+    basl_url_parse("https://example.com:8080/path", 29, &url, NULL);
+    EXPECT_STREQ(basl_url_hostname(&url), "example.com");
+    basl_url_free(&url);
+}
+
+/* ── Test Registration ───────────────────────────────────────────── */
+
+void register_url_tests(void) {
+    REGISTER_TEST(BaslUrlTest, ParseFull);
+    REGISTER_TEST(BaslUrlTest, ParseSimple);
+    REGISTER_TEST(BaslUrlTest, ParsePathOnly);
+    REGISTER_TEST(BaslUrlTest, ParseWithQuery);
+    REGISTER_TEST(BaslUrlTest, ParseIPv6);
+    REGISTER_TEST(BaslUrlTest, EncodeSpaces);
+    REGISTER_TEST(BaslUrlTest, EncodeSpecial);
+    REGISTER_TEST(BaslUrlTest, DecodePercent);
+    REGISTER_TEST(BaslUrlTest, DecodePlus);
+    REGISTER_TEST(BaslUrlTest, IsAbsolute);
+    REGISTER_TEST(BaslUrlTest, Hostname);
+}


### PR DESCRIPTION
## Summary
Adds a `url` standard library module for URL parsing and manipulation per RFC 3986.

## Functions
- `url.parse(url: string) -> string` - Parse URL into pipe-separated components
- `url.scheme(url: string) -> string` - Get scheme (http, https, etc.)
- `url.host(url: string) -> string` - Get hostname
- `url.port(url: string) -> string` - Get port
- `url.path(url: string) -> string` - Get path
- `url.query(url: string) -> string` - Get query string
- `url.fragment(url: string) -> string` - Get fragment
- `url.encode(s: string) -> string` - Percent-encode string for URLs
- `url.decode(s: string) -> string` - Decode percent-encoded string

## Features
- RFC 3986 compliant URL parsing
- IPv6 address support (`[::1]:8080`)
- Userinfo parsing (username:password)
- Percent encoding/decoding with `+` for spaces in query strings

## Implementation
- Pure C11, no external dependencies
- Reusable C library (`include/basl/url.h`, `src/url.c`)
- Native module wrapper (`src/stdlib/url.c`)

## Testing
- 11 unit tests for C library
- 11 integration tests for BASL module