### PR TITLE
Refactor TOML datetime parsing

### DIFF
--- a/src/toml.c
+++ b/src/toml.c
@@ -1273,24 +1273,118 @@ static int parse_n_digits(toml_parser_t *p, int n)
     return val;
 }
 
+static vigil_status_t parse_fractional_nanoseconds(toml_parser_t *p, int *nanosecond)
+{
+    int frac;
+    int digits;
+
+    frac = 0;
+    digits = 0;
+    while (is_digit(parser_peek(p)) && digits < 9)
+    {
+        frac = frac * 10 + (parser_peek(p) - '0');
+        parser_advance(p);
+        digits++;
+    }
+    while (digits < 9)
+    {
+        frac *= 10;
+        digits++;
+    }
+    *nanosecond = frac;
+    while (is_digit(parser_peek(p)))
+        parser_advance(p);
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t parse_time_fraction(toml_parser_t *p, vigil_toml_datetime_t *dt, vigil_error_t *error)
+{
+    (void)error;
+    if (parser_match(p, '.'))
+        return parse_fractional_nanoseconds(p, &dt->nanosecond);
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t parse_time_fields(toml_parser_t *p, vigil_toml_datetime_t *dt, vigil_error_t *error)
+{
+    dt->hour = parse_n_digits(p, 2);
+    if (dt->hour < 0)
+        return parser_error(p, "invalid hour", error);
+    if (!parser_match(p, ':'))
+        return parser_error(p, "expected ':' in time", error);
+    dt->minute = parse_n_digits(p, 2);
+    if (dt->minute < 0)
+        return parser_error(p, "invalid minute", error);
+    if (!parser_match(p, ':'))
+        return parser_error(p, "expected ':' in time", error);
+    dt->second = parse_n_digits(p, 2);
+    if (dt->second < 0)
+        return parser_error(p, "invalid second", error);
+    return parse_time_fraction(p, dt, error);
+}
+
+static vigil_status_t parse_datetime_offset(toml_parser_t *p, vigil_toml_datetime_t *dt, vigil_error_t *error)
+{
+    char c;
+
+    c = parser_peek(p);
+    if (c == 'Z' || c == 'z')
+    {
+        parser_advance(p);
+        dt->has_offset = 1;
+        dt->offset_minutes = 0;
+        return VIGIL_STATUS_OK;
+    }
+    if (c == '+' || c == '-')
+    {
+        int sign;
+        int oh;
+        int om;
+
+        sign = (c == '-') ? -1 : 1;
+        parser_advance(p);
+        oh = parse_n_digits(p, 2);
+        if (oh < 0)
+            return parser_error(p, "invalid offset hour", error);
+        if (!parser_match(p, ':'))
+            return parser_error(p, "expected ':' in offset", error);
+        om = parse_n_digits(p, 2);
+        if (om < 0)
+            return parser_error(p, "invalid offset minute", error);
+        dt->has_offset = 1;
+        dt->offset_minutes = sign * (oh * 60 + om);
+    }
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t parse_month_and_day(toml_parser_t *p, vigil_toml_datetime_t *dt, vigil_error_t *error)
+{
+    if (!parser_match(p, '-'))
+        return parser_error(p, "expected '-' in date", error);
+    dt->month = parse_n_digits(p, 2);
+    if (dt->month < 0)
+        return parser_error(p, "invalid month", error);
+    if (!parser_match(p, '-'))
+        return parser_error(p, "expected '-' in date", error);
+    dt->day = parse_n_digits(p, 2);
+    if (dt->day < 0)
+        return parser_error(p, "invalid day", error);
+    return VIGIL_STATUS_OK;
+}
+
 static vigil_status_t parse_datetime_after_year(toml_parser_t *p, int year, vigil_toml_value_t **out,
                                                 vigil_error_t *error)
 {
     vigil_toml_datetime_t dt;
+    vigil_status_t s;
+
     memset(&dt, 0, sizeof(dt));
     dt.year = year;
     dt.has_date = 1;
 
-    if (!parser_match(p, '-'))
-        return parser_error(p, "expected '-' in date", error);
-    dt.month = parse_n_digits(p, 2);
-    if (dt.month < 0)
-        return parser_error(p, "invalid month", error);
-    if (!parser_match(p, '-'))
-        return parser_error(p, "expected '-' in date", error);
-    dt.day = parse_n_digits(p, 2);
-    if (dt.day < 0)
-        return parser_error(p, "invalid day", error);
+    s = parse_month_and_day(p, &dt, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
 
     /* Optional time part. */
     {
@@ -1299,66 +1393,12 @@ static vigil_status_t parse_datetime_after_year(toml_parser_t *p, int year, vigi
         {
             parser_advance(p);
             dt.has_time = 1;
-            dt.hour = parse_n_digits(p, 2);
-            if (dt.hour < 0)
-                return parser_error(p, "invalid hour", error);
-            if (!parser_match(p, ':'))
-                return parser_error(p, "expected ':' in time", error);
-            dt.minute = parse_n_digits(p, 2);
-            if (dt.minute < 0)
-                return parser_error(p, "invalid minute", error);
-            if (!parser_match(p, ':'))
-                return parser_error(p, "expected ':' in time", error);
-            dt.second = parse_n_digits(p, 2);
-            if (dt.second < 0)
-                return parser_error(p, "invalid second", error);
-
-            /* Fractional seconds. */
-            if (parser_match(p, '.'))
-            {
-                int frac = 0, digits = 0;
-                while (is_digit(parser_peek(p)) && digits < 9)
-                {
-                    frac = frac * 10 + (parser_peek(p) - '0');
-                    parser_advance(p);
-                    digits++;
-                }
-                /* Pad to nanoseconds. */
-                while (digits < 9)
-                {
-                    frac *= 10;
-                    digits++;
-                }
-                dt.nanosecond = frac;
-                /* Skip extra precision digits. */
-                while (is_digit(parser_peek(p)))
-                    parser_advance(p);
-            }
-
-            /* Offset. */
-            c = parser_peek(p);
-            if (c == 'Z' || c == 'z')
-            {
-                parser_advance(p);
-                dt.has_offset = 1;
-                dt.offset_minutes = 0;
-            }
-            else if (c == '+' || c == '-')
-            {
-                int sign = (c == '-') ? -1 : 1;
-                int oh, om;
-                parser_advance(p);
-                oh = parse_n_digits(p, 2);
-                if (oh < 0)
-                    return parser_error(p, "invalid offset hour", error);
-                if (!parser_match(p, ':'))
-                    return parser_error(p, "expected ':' in offset", error);
-                om = parse_n_digits(p, 2);
-                if (om < 0)
-                    return parser_error(p, "invalid offset minute", error);
-                dt.has_offset = 1;
-                dt.offset_minutes = sign * (oh * 60 + om);
-            }
+            s = parse_time_fields(p, &dt, error);
+            if (s != VIGIL_STATUS_OK)
+                return s;
+            s = parse_datetime_offset(p, &dt, error);
+            if (s != VIGIL_STATUS_OK)
+                return s;
         }
     }
 
@@ -1369,6 +1409,8 @@ static vigil_status_t parse_datetime_after_year(toml_parser_t *p, int year, vigi
 static vigil_status_t parse_local_time(toml_parser_t *p, int hour, vigil_toml_value_t **out, vigil_error_t *error)
 {
     vigil_toml_datetime_t dt;
+    vigil_status_t s;
+
     memset(&dt, 0, sizeof(dt));
     dt.has_time = 1;
     dt.hour = hour;
@@ -1382,24 +1424,9 @@ static vigil_status_t parse_local_time(toml_parser_t *p, int hour, vigil_toml_va
     dt.second = parse_n_digits(p, 2);
     if (dt.second < 0)
         return parser_error(p, "invalid second", error);
-    if (parser_match(p, '.'))
-    {
-        int frac = 0, digits = 0;
-        while (is_digit(parser_peek(p)) && digits < 9)
-        {
-            frac = frac * 10 + (parser_peek(p) - '0');
-            parser_advance(p);
-            digits++;
-        }
-        while (digits < 9)
-        {
-            frac *= 10;
-            digits++;
-        }
-        dt.nanosecond = frac;
-        while (is_digit(parser_peek(p)))
-            parser_advance(p);
-    }
+    s = parse_time_fraction(p, &dt, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
     return vigil_toml_datetime_new(p->allocator, &dt, out, error);
 }
 

--- a/tests/toml_test.c
+++ b/tests/toml_test.c
@@ -291,6 +291,16 @@ TEST_F(TomlTest, OffsetDateTime)
     EXPECT_EQ(dt->offset_minutes, 0);
 }
 
+TEST_F(TomlTest, OffsetDateTimeLowercaseSeparatorAndOffset)
+{
+    toml_parse_helper(FIXTURE(TomlTest), "dt = 2024-01-15t10:30:00z", vigil_test_failed_);
+    const vigil_toml_datetime_t *dt = vigil_toml_datetime_value(vigil_toml_table_get(FIXTURE(TomlTest)->root, "dt"));
+    EXPECT_TRUE(dt->has_date);
+    EXPECT_TRUE(dt->has_time);
+    EXPECT_TRUE(dt->has_offset);
+    EXPECT_EQ(dt->offset_minutes, 0);
+}
+
 TEST_F(TomlTest, OffsetDateTimeWithOffset)
 {
     toml_parse_helper(FIXTURE(TomlTest), "dt = 2024-01-15T10:30:00-05:00", vigil_test_failed_);
@@ -301,6 +311,15 @@ TEST_F(TomlTest, OffsetDateTimeWithOffset)
 TEST_F(TomlTest, LocalDateTime)
 {
     toml_parse_helper(FIXTURE(TomlTest), "dt = 2024-01-15T10:30:00", vigil_test_failed_);
+    const vigil_toml_datetime_t *dt = vigil_toml_datetime_value(vigil_toml_table_get(FIXTURE(TomlTest)->root, "dt"));
+    EXPECT_TRUE(dt->has_date);
+    EXPECT_TRUE(dt->has_time);
+    EXPECT_FALSE(dt->has_offset);
+}
+
+TEST_F(TomlTest, LocalDateTimeWithSpaceSeparator)
+{
+    toml_parse_helper(FIXTURE(TomlTest), "dt = 2024-01-15 10:30:00", vigil_test_failed_);
     const vigil_toml_datetime_t *dt = vigil_toml_datetime_value(vigil_toml_table_get(FIXTURE(TomlTest)->root, "dt"));
     EXPECT_TRUE(dt->has_date);
     EXPECT_TRUE(dt->has_time);
@@ -530,8 +549,10 @@ void register_toml_tests(void)
     REGISTER_TEST_F(TomlTest, NestedArray);
     REGISTER_TEST_F(TomlTest, ArrayOfTables);
     REGISTER_TEST_F(TomlTest, OffsetDateTime);
+    REGISTER_TEST_F(TomlTest, OffsetDateTimeLowercaseSeparatorAndOffset);
     REGISTER_TEST_F(TomlTest, OffsetDateTimeWithOffset);
     REGISTER_TEST_F(TomlTest, LocalDateTime);
+    REGISTER_TEST_F(TomlTest, LocalDateTimeWithSpaceSeparator);
     REGISTER_TEST_F(TomlTest, LocalDate);
     REGISTER_TEST_F(TomlTest, LocalTime);
     REGISTER_TEST_F(TomlTest, FractionalSeconds);


### PR DESCRIPTION
## Summary
- split TOML datetime parsing into focused helpers for date fields, time fields, fractional seconds, and offsets
- reuse the extracted fractional-second helper from local-time parsing to reduce duplicated parser logic
- add TOML datetime tests for lowercase / separators and space-separated local datetimes

## Testing
- scripts/run_clang_format.sh --check src/toml.c tests/toml_test.c
- cmake --build build
- ctest --test-dir build --output-on-failure
- python3 -m lizard src/toml.c

## Result
- removed  from the TOML lizard warning set
- TOML inherited warning set is now down to 3 functions: , , and 

## Note
- this PR is stacked on top of #195 so review the diff against 
