### PR TITLE
bench: add run_fib benchmark for self-recursion tracking

### DIFF
--- a/benchmarks/cases/run_fib.vigil
+++ b/benchmarks/cases/run_fib.vigil
@@ -1,0 +1,14 @@
+fn fib(i32 n) -> i32 {
+    if (n < 2) {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+fn main() -> i32 {
+    i32 result = fib(32);
+    if (result == 2178309) {
+        return 0;
+    }
+    return 1;
+}

--- a/benchmarks/manifest.json
+++ b/benchmarks/manifest.json
@@ -60,6 +60,16 @@
       "warmups": 1,
       "iterations": 5,
       "timeout_seconds": 20
+    },
+    {
+      "name": "run_fib",
+      "command": [
+        "run",
+        "benchmarks/cases/run_fib.vigil"
+      ],
+      "warmups": 1,
+      "iterations": 5,
+      "timeout_seconds": 20
     }
   ]
 }


### PR DESCRIPTION
Adds a `run_fib` benchmark case (recursive Fibonacci) to the performance suite to track self-recursion call overhead over time.