### PR TITLE
perf: fuse i32 compare + jump_if_false into superinstructions

### DIFF
--- a/include/vigil/chunk.h
+++ b/include/vigil/chunk.h
@@ -235,7 +235,18 @@ extern "C"
            function calls itself.  Takes one u32 operand (arg_count).
            The VM reuses the current frame's function and chunk pointers
            directly, skipping the sibling constant lookup. */
-        VIGIL_OPCODE_CALL_SELF = 161
+        VIGIL_OPCODE_CALL_SELF = 161,
+
+        /* Fused i32 compare + conditional jump superinstructions.
+           Format: [opcode(1)][u32 jump_offset]  (6 bytes)
+           Pops two i32 values, compares, jumps if false.
+           Eliminates the intermediate bool push/pop and one dispatch. */
+        VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE = 162,
+        VIGIL_OPCODE_LESS_EQUAL_I32_JUMP_IF_FALSE = 163,
+        VIGIL_OPCODE_GREATER_I32_JUMP_IF_FALSE = 164,
+        VIGIL_OPCODE_GREATER_EQUAL_I32_JUMP_IF_FALSE = 165,
+        VIGIL_OPCODE_EQUAL_I32_JUMP_IF_FALSE = 166,
+        VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE = 167
     } vigil_opcode_t;
 
     typedef struct vigil_chunk

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -6,7 +6,7 @@
 #include "internal/vigil_internal.h"
 #include "vigil/chunk.h"
 
-static const char *const kVigilOpcodeNames[VIGIL_OPCODE_CALL_SELF + 1] = {
+static const char *const kVigilOpcodeNames[VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE + 1] = {
     [VIGIL_OPCODE_CONSTANT] = "CONSTANT",
     [VIGIL_OPCODE_NIL] = "NIL",
     [VIGIL_OPCODE_TRUE] = "TRUE",
@@ -169,6 +169,12 @@ static const char *const kVigilOpcodeNames[VIGIL_OPCODE_CALL_SELF + 1] = {
     [VIGIL_OPCODE_PARSE_F64] = "PARSE_F64",
     [VIGIL_OPCODE_PARSE_BOOL] = "PARSE_BOOL",
     [VIGIL_OPCODE_CALL_SELF] = "CALL_SELF",
+    [VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE] = "LESS_I32_JUMP_IF_FALSE",
+    [VIGIL_OPCODE_LESS_EQUAL_I32_JUMP_IF_FALSE] = "LESS_EQUAL_I32_JUMP_IF_FALSE",
+    [VIGIL_OPCODE_GREATER_I32_JUMP_IF_FALSE] = "GREATER_I32_JUMP_IF_FALSE",
+    [VIGIL_OPCODE_GREATER_EQUAL_I32_JUMP_IF_FALSE] = "GREATER_EQUAL_I32_JUMP_IF_FALSE",
+    [VIGIL_OPCODE_EQUAL_I32_JUMP_IF_FALSE] = "EQUAL_I32_JUMP_IF_FALSE",
+    [VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE] = "NOT_EQUAL_I32_JUMP_IF_FALSE",
 };
 
 static vigil_status_t vigil_chunk_append_text(vigil_string_t *output, const char *text, vigil_error_t *error);
@@ -434,12 +440,28 @@ static int vigil_chunk_is_two_u32_operand_opcode(vigil_opcode_t opcode)
 static int vigil_chunk_is_u32_operand_opcode(vigil_opcode_t opcode)
 {
     /* Lookup table avoids a long OR-chain that inflates cyclomatic complexity. */
-    static const uint8_t table[VIGIL_OPCODE_CALL_SELF + 1] = {
-        [VIGIL_OPCODE_CONSTANT] = 1,      [VIGIL_OPCODE_GET_LOCAL] = 1,   [VIGIL_OPCODE_SET_LOCAL] = 1,
-        [VIGIL_OPCODE_GET_GLOBAL] = 1,    [VIGIL_OPCODE_SET_GLOBAL] = 1,  [VIGIL_OPCODE_GET_FUNCTION] = 1,
-        [VIGIL_OPCODE_GET_CAPTURE] = 1,   [VIGIL_OPCODE_SET_CAPTURE] = 1, [VIGIL_OPCODE_JUMP] = 1,
-        [VIGIL_OPCODE_JUMP_IF_FALSE] = 1, [VIGIL_OPCODE_LOOP] = 1,        [VIGIL_OPCODE_FORMAT_F64] = 1,
-        [VIGIL_OPCODE_GET_FIELD] = 1,     [VIGIL_OPCODE_SET_FIELD] = 1,   [VIGIL_OPCODE_CALL_SELF] = 1,
+    static const uint8_t table[VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE + 1] = {
+        [VIGIL_OPCODE_CONSTANT] = 1,
+        [VIGIL_OPCODE_GET_LOCAL] = 1,
+        [VIGIL_OPCODE_SET_LOCAL] = 1,
+        [VIGIL_OPCODE_GET_GLOBAL] = 1,
+        [VIGIL_OPCODE_SET_GLOBAL] = 1,
+        [VIGIL_OPCODE_GET_FUNCTION] = 1,
+        [VIGIL_OPCODE_GET_CAPTURE] = 1,
+        [VIGIL_OPCODE_SET_CAPTURE] = 1,
+        [VIGIL_OPCODE_JUMP] = 1,
+        [VIGIL_OPCODE_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_LOOP] = 1,
+        [VIGIL_OPCODE_FORMAT_F64] = 1,
+        [VIGIL_OPCODE_GET_FIELD] = 1,
+        [VIGIL_OPCODE_SET_FIELD] = 1,
+        [VIGIL_OPCODE_CALL_SELF] = 1,
+        [VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_LESS_EQUAL_I32_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_GREATER_I32_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_GREATER_EQUAL_I32_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_EQUAL_I32_JUMP_IF_FALSE] = 1,
+        [VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE] = 1,
     };
     return (size_t)opcode < sizeof(table) && table[(size_t)opcode];
 }
@@ -837,7 +859,7 @@ vigil_source_span_t vigil_chunk_span_at(const vigil_chunk_t *chunk, size_t offse
 
 const char *vigil_opcode_name(vigil_opcode_t opcode)
 {
-    if (opcode > VIGIL_OPCODE_CALL_SELF)
+    if (opcode > VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE)
     {
         return "UNKNOWN";
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5324,10 +5324,55 @@ vigil_status_t vigil_parser_emit_u32(vigil_parser_state_t *state, uint32_t value
     return vigil_chunk_write_u32(&state->chunk, value, span, state->program->error);
 }
 
+static vigil_opcode_t vigil_parser_fuse_cmp_i32_jump(vigil_opcode_t cmp)
+{
+    switch (cmp)
+    {
+    case VIGIL_OPCODE_LESS_I32:
+        return VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE;
+    case VIGIL_OPCODE_LESS_EQUAL_I32:
+        return VIGIL_OPCODE_LESS_EQUAL_I32_JUMP_IF_FALSE;
+    case VIGIL_OPCODE_GREATER_I32:
+        return VIGIL_OPCODE_GREATER_I32_JUMP_IF_FALSE;
+    case VIGIL_OPCODE_GREATER_EQUAL_I32:
+        return VIGIL_OPCODE_GREATER_EQUAL_I32_JUMP_IF_FALSE;
+    case VIGIL_OPCODE_EQUAL_I32:
+        return VIGIL_OPCODE_EQUAL_I32_JUMP_IF_FALSE;
+    case VIGIL_OPCODE_NOT_EQUAL_I32:
+        return VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE;
+    default:
+        return (vigil_opcode_t)0;
+    }
+}
+
 static vigil_status_t vigil_parser_emit_jump(vigil_parser_state_t *state, vigil_opcode_t opcode,
                                              vigil_source_span_t span, size_t *out_operand_offset)
 {
     vigil_status_t status;
+
+    /* Peephole: fuse CMP_I32 + JUMP_IF_FALSE into a single
+       superinstruction.  The preceding byte is the i32 compare opcode.
+       The fused handler pops both i32 operands and conditionally jumps
+       without pushing an intermediate bool.  The caller must skip the
+       POP that normally follows JUMP_IF_FALSE when fusion fires. */
+    if (opcode == VIGIL_OPCODE_JUMP_IF_FALSE)
+    {
+        size_t len = state->chunk.code.length;
+        if (len >= 1U)
+        {
+            vigil_opcode_t fused = vigil_parser_fuse_cmp_i32_jump((vigil_opcode_t)state->chunk.code.data[len - 1U]);
+            if (fused != (vigil_opcode_t)0)
+            {
+                /* Overwrite the CMP_I32 byte with the fused opcode. */
+                state->chunk.code.data[len - 1U] = (uint8_t)fused;
+                if (out_operand_offset != NULL)
+                {
+                    *out_operand_offset = vigil_chunk_code_size(&state->chunk);
+                }
+                return vigil_parser_emit_u32(state, 0U, span);
+            }
+        }
+    }
 
     status = vigil_parser_emit_opcode(state, opcode, span);
     if (status != VIGIL_STATUS_OK)

--- a/src/vm.c
+++ b/src/vm.c
@@ -204,6 +204,32 @@
             goto cleanup;                                                                                              \
     } while (0)
 
+/* Fused i32 compare + conditional jump.  Pops two i32 values, compares
+   with the given operator, and jumps if the condition is false.  On both
+   paths the trailing POP byte (which would have popped the now-absent
+   intermediate bool) is skipped. */
+#define VIGIL_VM_CMP_I32_JUMP(cmp_op)                                                                                  \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        int32_t cmp_a, cmp_b;                                                                                          \
+        VIGIL_VM_READ_U32(code, frame->ip, operand);                                                                   \
+        vm->stack_count -= 1U;                                                                                         \
+        cmp_b = vigil_nanbox_decode_i32(vm->stack[vm->stack_count]);                                                   \
+        vm->stack_count -= 1U;                                                                                         \
+        cmp_a = vigil_nanbox_decode_i32(vm->stack[vm->stack_count]);                                                   \
+        if (cmp_a cmp_op cmp_b)                                                                                        \
+        {                                                                                                              \
+            if (frame->ip < code_size && code[frame->ip] == VIGIL_OPCODE_POP)                                          \
+                frame->ip += 1U;                                                                                       \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            frame->ip += (size_t)operand;                                                                              \
+            if (frame->ip < code_size && code[frame->ip] == VIGIL_OPCODE_POP)                                          \
+                frame->ip += 1U;                                                                                       \
+        }                                                                                                              \
+    } while (0)
+
 /* Fast bytecode read — reads u32 operand after the opcode byte.
    Advances ip past opcode + 4 operand bytes (total 5). */
 #define VIGIL_VM_READ_U32(code, ip, out)                                                                               \
@@ -3507,7 +3533,7 @@ vigil_status_t vigil_vm_execute_function(vigil_vm_t *vm, const vigil_object_t *f
                 [VIGIL_OPCODE_CALL_NATIVE] = &&op_CALL_NATIVE,
                 [VIGIL_OPCODE_DEFER_CALL_NATIVE] = &&op_DEFER_CALL_NATIVE,
                 // clang-format off
-                [VIGIL_OPCODE_CALL_EXTERN]=&&op_CALL_EXTERN, [VIGIL_OPCODE_MATH_SIN_F64]=&&op_MATH_SIN_F64, [VIGIL_OPCODE_MATH_COS_F64]=&&op_MATH_COS_F64, [VIGIL_OPCODE_MATH_SQRT_F64]=&&op_MATH_SQRT_F64, [VIGIL_OPCODE_MATH_LOG_F64]=&&op_MATH_LOG_F64, [VIGIL_OPCODE_MATH_POW_F64]=&&op_MATH_POW_F64, [VIGIL_OPCODE_PARSE_I32]=&&op_PARSE_I32, [VIGIL_OPCODE_PARSE_F64]=&&op_PARSE_F64, [VIGIL_OPCODE_PARSE_BOOL]=&&op_PARSE_BOOL, [VIGIL_OPCODE_CALL_SELF]=&&op_CALL_SELF,
+                [VIGIL_OPCODE_CALL_EXTERN]=&&op_CALL_EXTERN, [VIGIL_OPCODE_MATH_SIN_F64]=&&op_MATH_SIN_F64, [VIGIL_OPCODE_MATH_COS_F64]=&&op_MATH_COS_F64, [VIGIL_OPCODE_MATH_SQRT_F64]=&&op_MATH_SQRT_F64, [VIGIL_OPCODE_MATH_LOG_F64]=&&op_MATH_LOG_F64, [VIGIL_OPCODE_MATH_POW_F64]=&&op_MATH_POW_F64, [VIGIL_OPCODE_PARSE_I32]=&&op_PARSE_I32, [VIGIL_OPCODE_PARSE_F64]=&&op_PARSE_F64, [VIGIL_OPCODE_PARSE_BOOL]=&&op_PARSE_BOOL, [VIGIL_OPCODE_CALL_SELF]=&&op_CALL_SELF, [VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE]=&&op_LESS_I32_JUMP_IF_FALSE, [VIGIL_OPCODE_LESS_EQUAL_I32_JUMP_IF_FALSE]=&&op_LESS_EQUAL_I32_JUMP_IF_FALSE, [VIGIL_OPCODE_GREATER_I32_JUMP_IF_FALSE]=&&op_GREATER_I32_JUMP_IF_FALSE, [VIGIL_OPCODE_GREATER_EQUAL_I32_JUMP_IF_FALSE]=&&op_GREATER_EQUAL_I32_JUMP_IF_FALSE, [VIGIL_OPCODE_EQUAL_I32_JUMP_IF_FALSE]=&&op_EQUAL_I32_JUMP_IF_FALSE, [VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE]=&&op_NOT_EQUAL_I32_JUMP_IF_FALSE,
                 // clang-format on
                 [VIGIL_OPCODE_MODULO] = &&op_MODULO,
                 [VIGIL_OPCODE_MULTIPLY] = &&op_MULTIPLY,
@@ -5556,9 +5582,7 @@ vigil_status_t vigil_vm_execute_function(vigil_vm_t *vm, const vigil_object_t *f
                 goto cleanup;
             }
             VM_BREAK();
-
             /* ── New string methods ──────────────────────────────── */
-
             VM_CASE(STRING_TRIM_LEFT)
             VM_CASE(STRING_TRIM_RIGHT)
             {
@@ -5609,7 +5633,6 @@ vigil_status_t vigil_vm_execute_function(vigil_vm_t *vm, const vigil_object_t *f
                 }
                 VM_BREAK();
             }
-
             VM_CASE(STRING_REVERSE)
             {
                 const char *text;
@@ -7243,11 +7266,14 @@ vigil_status_t vigil_vm_execute_function(vigil_vm_t *vm, const vigil_object_t *f
                 frame->ip += 1U;
                 VM_BREAK();
             }
-
-            /* ── Three-address i32 store superinstructions ────────────
-               Format: [opcode][u32 dst][u32 a][u32 b]  (13 bytes)
-               Reads locals a and b, operates, stores result to local dst.
-               Zero stack traffic — pure register-style execution. */
+            // clang-format off
+            VM_CASE(LESS_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(<); VM_BREAK();
+            VM_CASE(LESS_EQUAL_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(<=); VM_BREAK();
+            VM_CASE(GREATER_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(>); VM_BREAK();
+            VM_CASE(GREATER_EQUAL_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(>=); VM_BREAK();
+            VM_CASE(EQUAL_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(==); VM_BREAK();
+            VM_CASE(NOT_EQUAL_I32_JUMP_IF_FALSE) VIGIL_VM_CMP_I32_JUMP(!=); VM_BREAK();
+            // clang-format on
             VM_CASE(LOCALS_ADD_I32_STORE)
             {
                 uint32_t dst, idx_a, idx_b;

--- a/tests/chunk_test.c
+++ b/tests/chunk_test.c
@@ -424,7 +424,7 @@ TEST(VigilChunkTest, DisassembleRejectsTruncatedU32OperandInstructions)
 TEST(VigilChunkTest, OpcodeNameReturnsUnknownForOutOfRangeOpcode)
 {
     EXPECT_STREQ(vigil_opcode_name(VIGIL_OPCODE_RETURN), "RETURN");
-    EXPECT_STREQ(vigil_opcode_name((vigil_opcode_t)(VIGIL_OPCODE_CALL_SELF + 1)), "UNKNOWN");
+    EXPECT_STREQ(vigil_opcode_name((vigil_opcode_t)(VIGIL_OPCODE_NOT_EQUAL_I32_JUMP_IF_FALSE + 1)), "UNKNOWN");
 }
 
 TEST(VigilChunkTest, UsesRuntimeAllocatorHooks)


### PR DESCRIPTION
## Summary

Adds 6 fused opcodes that combine an i32 comparison with a conditional jump into a single dispatch cycle:

- `LESS_I32_JUMP_IF_FALSE`
- `LESS_EQUAL_I32_JUMP_IF_FALSE`
- `GREATER_I32_JUMP_IF_FALSE`
- `GREATER_EQUAL_I32_JUMP_IF_FALSE`
- `EQUAL_I32_JUMP_IF_FALSE`
- `NOT_EQUAL_I32_JUMP_IF_FALSE`

## How it works

**Compiler peephole** (`emit_jump`): When emitting `JUMP_IF_FALSE`, checks if the preceding byte is an i32 compare opcode. If so, overwrites it with the fused variant and emits the jump offset directly — no separate `JUMP_IF_FALSE` opcode byte.

**VM handler** (`VIGIL_VM_CMP_I32_JUMP` macro): Pops two i32 values, compares with the given operator, and either falls through (skipping the trailing POP) or jumps (also skipping the false-path POP). No intermediate bool is pushed to the stack.

## What it eliminates per comparison

- 1 dispatch cycle (the biggest cost at ~45% of VM time)
- 1 bool push to stack
- 1 bool decode + pop in JUMP_IF_FALSE
- The POP opcode dispatch

## Benchmark results

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| run_fib | 245.86 ms | 203.09 ms | **-17.4%** |
| run_vm_arith | 59.92 ms | 61.31 ms | +2.3% (noise) |

Profiling showed dispatch overhead was 45% of VM execution time for recursive fibonacci. This fusion removes one dispatch per i32 comparison, which fires on every recursive call's guard check.

## Complexity

- `execute_function`: CCN 697 (matches baseline), length 4600 (matches baseline)
- `vigil_parser_fuse_cmp_i32_jump`: CCN 7
- `vigil_parser_emit_jump`: CCN 7