### PR TITLE
ci: add allocator enforcement check

### DIFF
--- a/.github/workflows/allocator.yml
+++ b/.github/workflows/allocator.yml
@@ -1,0 +1,15 @@
+name: Allocator
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  allocator-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for raw allocator calls
+        run: python3 scripts/check_allocator.py

--- a/scripts/check_allocator.py
+++ b/scripts/check_allocator.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Verify that converted source files use the custom allocator, not raw
+malloc/calloc/realloc/free.
+
+Run from the repository root:
+    python3 scripts/check_allocator.py
+
+Exit 0 if clean, 1 if any violation is found.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Regex matching raw allocation calls.  Negative lookbehind excludes
+# identifiers that *contain* the word (e.g. pkg_lock_free, doc_free_ptr,
+# vigil_toml_free).  We also skip macro wrappers like PKG_FREE.
+RAW_ALLOC_RE = re.compile(
+    r"(?<![_a-zA-Z0-9])"          # not preceded by identifier char
+    r"(malloc|calloc|realloc|free)"
+    r"\s*\("
+)
+
+# Patterns that indicate a legitimate use (wrapper helpers, comments, strings,
+# or an explicit suppression marker).
+FALSE_POSITIVE_RE = re.compile(
+    r"(PKG_FREE|PKG_ALLOC|doc_alloc|doc_realloc|doc_free"
+    r"|vigil_\w*free|vigil_\w*alloc|toml_free|curl_free"
+    r"|pkg_lock_free|pkg_spec_free"
+    r"|alloc-check:\s*exempt"
+    r"|//|/\*|\*|\")"
+)
+
+# Files that are allowed to use raw allocation.  Paths are relative to the
+# repository root.
+EXEMPT_FILES = {
+    # The default allocator implementation itself.
+    "src/allocator.c",
+    # CLI layer — owns the allocator, passes NULL for default.
+    "src/cli/main.c",
+    "src/cli_frontend.c",
+    "src/cli_test.c",
+    # Platform layer — OS callbacks with fixed signatures.
+    "src/platform/platform_posix.c",
+    "src/platform/platform_win32.c",
+    "src/platform/line_editor.c",
+    # Stdlib modules with architectural constraints.
+    "src/stdlib/thread.c",
+    "src/stdlib/atomic.c",
+    "src/stdlib/unsafe.c",
+    "src/stdlib/http.c",
+    "src/stdlib/fs.c",
+    # Public API without runtime parameter.
+    "src/value.c",
+    # Doc strings referencing unsafe.malloc etc.
+    "src/doc_registry.c",
+}
+
+
+def check_file(path: Path, root: Path) -> list[str]:
+    errors = []
+    rel = str(path.relative_to(root))
+    if rel in EXEMPT_FILES:
+        return errors
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        stripped = line.lstrip()
+        if stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        if RAW_ALLOC_RE.search(line) and not FALSE_POSITIVE_RE.search(line):
+            errors.append(f"{rel}:{lineno}: raw allocator call: {stripped.strip()}")
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    scan_dirs = [root / "src", root / "include" / "vigil"]
+    globs = ["*.c", "*.h"]
+
+    errors: list[str] = []
+    file_count = 0
+    for d in scan_dirs:
+        for g in globs:
+            for path in sorted(d.rglob(g)):
+                rel = str(path.relative_to(root))
+                if rel in EXEMPT_FILES:
+                    continue
+                file_count += 1
+                errors.extend(check_file(path, root))
+
+    if errors:
+        print(f"FAIL: {len(errors)} raw allocator call(s) in converted files:\n")
+        for e in errors:
+            print(f"  {e}")
+        return 1
+
+    print(f"OK: {file_count} files checked, no raw allocator violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/doc.c
+++ b/src/doc.c
@@ -10,14 +10,14 @@ static void *doc_alloc(const vigil_allocator_t *a, size_t size)
 {
     if (a != NULL && a->allocate != NULL)
         return a->allocate(a->user_data, size);
-    return malloc(size);
+    return malloc(size); /* alloc-check: exempt — NULL-allocator fallback */
 }
 
 static void *doc_realloc(const vigil_allocator_t *a, void *p, size_t size)
 {
     if (a != NULL && a->reallocate != NULL)
         return a->reallocate(a->user_data, p, size);
-    return realloc(p, size);
+    return realloc(p, size); /* alloc-check: exempt — NULL-allocator fallback */
 }
 
 static void doc_free_ptr(const vigil_allocator_t *a, void *p)
@@ -29,7 +29,7 @@ static void doc_free_ptr(const vigil_allocator_t *a, void *p)
         a->deallocate(a->user_data, p);
         return;
     }
-    free(p);
+    free(p); /* alloc-check: exempt — NULL-allocator fallback */
 }
 
 static char *doc_strdup(const vigil_allocator_t *a, const char *s, size_t len)

--- a/src/pkg.c
+++ b/src/pkg.c
@@ -603,7 +603,7 @@ static vigil_status_t write_project_toml(const char *project_root, vigil_toml_va
         return status;
 
     status = vigil_platform_write_file(toml_path, output, output_len, error);
-    free(output);
+    free(output); /* alloc-check: exempt — allocated by vigil_toml_emit */
     return status;
 }
 

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -485,7 +485,7 @@ char *vigil_semantic_type_to_string(const vigil_semantic_index_t *index, vigil_s
     result = (index != NULL && index->runtime != NULL)
                  ? (char *)vigil_runtime_allocator(index->runtime)
                        ->allocate(vigil_runtime_allocator(index->runtime)->user_data, len + 1)
-                 : malloc(len + 1);
+                 : malloc(len + 1); /* alloc-check: exempt — NULL-index fallback */
     if (result != NULL)
     {
         memcpy(result, name, len + 1);


### PR DESCRIPTION
Adds a CI job that prevents raw `malloc`/`calloc`/`realloc`/`free` from leaking back into files that have been converted to use `vigil_allocator_t`.

## How it works

`scripts/check_allocator.py` scans all `.c` and `.h` files under `src/` and `include/vigil/`, flagging any raw allocator calls that aren't in an exempt file or suppressed with an inline comment.

**File-level exemptions** (in the script's `EXEMPT_FILES` set):
- `src/allocator.c` — the default allocator implementation itself
- `src/cli/`, `src/cli_frontend.c`, `src/cli_test.c` — allocator provider side
- `src/platform/` — OS callbacks with fixed signatures
- `src/stdlib/thread.c`, `atomic.c`, `unsafe.c`, `http.c`, `fs.c` — architectural constraints
- `src/value.c` — public API without runtime parameter
- `src/doc_registry.c` — doc strings referencing `unsafe.realloc` etc.

**Line-level suppression**: add `/* alloc-check: exempt */` with a reason, e.g.:
```c
free(output); /* alloc-check: exempt — allocated by vigil_toml_emit */
```

## Changes
- `scripts/check_allocator.py` — the checker (118 files scanned today)
- `.github/workflows/allocator.yml` — runs on PRs
- 5 suppression comments added to known-intentional raw calls in `doc.c`, `pkg.c`, `semantic.c`