### PR TITLE
Fix regvm stack depth mismatch in fused compare+jump

### DIFF
--- a/src/regvm.c
+++ b/src/regvm.c
@@ -1974,6 +1974,14 @@ vigil_status_t vigil_reg_translate(const vigil_chunk_t *stack_chunk, vigil_reg_c
             if (!in_chain && (depth_at[target] >= 0 || depth_at[direct_target] >= 0))
                 in_chain = 1;
 
+            /* When the target has a POP that the else-path would skip, other
+               jumps (or the LOOP back-edge) may also reach that POP via the
+               jump-target list, creating a stack-depth mismatch.  Fall back
+               to the safe in_chain path which keeps the boolean on the stack
+               and lets the POP execute normally. */
+            if (!in_chain && direct_target != target)
+                in_chain = 1;
+
             if (in_chain)
             {
                 uint8_t res = vs_push(&vs);


### PR DESCRIPTION
## Summary

- Fixes a register VM translation bug where fused compare+jump opcodes (e.g. `GREATER_I32_JUMP_IF_FALSE`) targeting a `POP` instruction caused a "regvm jump target stack depth mismatch" error at runtime
- The optimized else-path skipped the POP by redirecting to `direct_target`, but `collect_jump_targets` still listed the original target, causing stale reachability and a stack depth divergence of 1
- Forces the safe `in_chain` code path when `direct_target != target`, keeping the boolean on the virtual stack so the POP executes correctly

## Test plan

- [x] `examples/fs_stress_test.vigil` — previously failed, now passes (97/97)
- [x] `examples/thread_stress_test.vigil` — previously failed, now passes (all checks)
- [x] All 32 unit/integration tests pass (`make test`)
- [x] All other example scripts verified: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)