### PR TITLE
Optimize regvm arithmetic and array growth

### DIFF
--- a/src/regvm.c
+++ b/src/regvm.c
@@ -2873,6 +2873,96 @@ tr_fail:
 #endif
 #endif
 
+static inline int regvm_try_add_i64(int64_t left, int64_t right, int64_t *out_result)
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow)
+    return !__builtin_add_overflow(left, right, out_result);
+#endif
+#endif
+    return vigil_vm_checked_add(left, right, out_result) == VIGIL_STATUS_OK;
+}
+
+static inline int regvm_try_subtract_i64(int64_t left, int64_t right, int64_t *out_result)
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_sub_overflow)
+    return !__builtin_sub_overflow(left, right, out_result);
+#endif
+#endif
+    return vigil_vm_checked_subtract(left, right, out_result) == VIGIL_STATUS_OK;
+}
+
+static inline int regvm_try_multiply_i64(int64_t left, int64_t right, int64_t *out_result)
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
+    return !__builtin_mul_overflow(left, right, out_result);
+#endif
+#endif
+    return vigil_vm_checked_multiply(left, right, out_result) == VIGIL_STATUS_OK;
+}
+
+static inline int regvm_try_add_u64(uint64_t left, uint64_t right, uint64_t *out_result)
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow)
+    return !__builtin_add_overflow(left, right, out_result);
+#endif
+#endif
+    return vigil_vm_checked_uadd(left, right, out_result) == VIGIL_STATUS_OK;
+}
+
+static inline int regvm_try_subtract_u64(uint64_t left, uint64_t right, uint64_t *out_result)
+{
+    if (left < right)
+        return 0;
+    *out_result = left - right;
+    return 1;
+}
+
+static inline int regvm_try_multiply_u64(uint64_t left, uint64_t right, uint64_t *out_result)
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
+    return !__builtin_mul_overflow(left, right, out_result);
+#endif
+#endif
+    return vigil_vm_checked_umultiply(left, right, out_result) == VIGIL_STATUS_OK;
+}
+
+static inline int regvm_try_divide_i64(int64_t left, int64_t right, int64_t *out_result)
+{
+    if (right == 0 || (left == INT64_MIN && right == -1))
+        return 0;
+    *out_result = left / right;
+    return 1;
+}
+
+static inline int regvm_try_divide_u64(uint64_t left, uint64_t right, uint64_t *out_result)
+{
+    if (right == 0U)
+        return 0;
+    *out_result = left / right;
+    return 1;
+}
+
+static inline int regvm_try_modulo_i64(int64_t left, int64_t right, int64_t *out_result)
+{
+    if (right == 0 || (left == INT64_MIN && right == -1))
+        return 0;
+    *out_result = left % right;
+    return 1;
+}
+
+static inline int regvm_try_modulo_u64(uint64_t left, uint64_t right, uint64_t *out_result)
+{
+    if (right == 0U)
+        return 0;
+    *out_result = left % right;
+    return 1;
+}
+
 /* ── Defer drain helper ────────────────────────────────────────── */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static vigil_status_t regvm_drain_defers(vigil_vm_t *vm, size_t frame_idx, vigil_error_t *error)
@@ -3465,7 +3555,7 @@ r_dispatch_switch_check:
         int64_t a = regvm_decode_int(R[VREG_GET_B(i)]);
         int64_t b = regvm_decode_int(R[VREG_GET_C(i)]);
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_add(a, b, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_add_i64(a, b, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3476,7 +3566,7 @@ r_dispatch_switch_check:
         int64_t a = regvm_decode_int(R[VREG_GET_B(i)]);
         int64_t b = regvm_decode_int(R[VREG_GET_C(i)]);
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_subtract(a, b, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_subtract_i64(a, b, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3487,7 +3577,7 @@ r_dispatch_switch_check:
         int64_t a = regvm_decode_int(R[VREG_GET_B(i)]);
         int64_t b = regvm_decode_int(R[VREG_GET_C(i)]);
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_multiply(a, b, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_multiply_i64(a, b, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3500,7 +3590,7 @@ r_dispatch_switch_check:
         if (VIGIL_UNLIKELY(b == 0))
             goto r_divzero;
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_divide(a, b, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_divide_i64(a, b, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3513,7 +3603,7 @@ r_dispatch_switch_check:
         if (VIGIL_UNLIKELY(b == 0))
             goto r_divzero;
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_modulo(a, b, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_modulo_i64(a, b, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3657,7 +3747,7 @@ r_dispatch_switch_check:
         int64_t v = regvm_decode_int(R[VREG_GET_A(i)]);
         int64_t delta = (int64_t)(int8_t)VREG_GET_B(i);
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_add(v, delta, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_add_i64(v, delta, &r)))
             goto r_overflow;
         RSTORE(VREG_GET_A(i), vigil_nanbox_encode_int(r));
         RNEXT();
@@ -3899,7 +3989,7 @@ r_dispatch_switch_check:
         int64_t limit = regvm_decode_int(*kv);
         int64_t val = regvm_decode_int(R[idx]);
         int64_t r;
-        if (VIGIL_UNLIKELY(vigil_vm_checked_add(val, delta, &r) != VIGIL_STATUS_OK))
+        if (VIGIL_UNLIKELY(!regvm_try_add_i64(val, delta, &r)))
             goto r_overflow;
         RSTORE(idx, vigil_nanbox_encode_int(r));
         int cont = 0;
@@ -3938,7 +4028,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_uint(R[ra]) || vigil_nanbox_is_uint(R[rb]))
         {
             uint64_t a = regvm_decode_uint(R[ra]), b = regvm_decode_uint(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_uadd(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_add_u64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_uint(r);
@@ -3950,7 +4040,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_int(R[ra]) && vigil_nanbox_is_int(R[rb]))
         {
             int64_t a = regvm_decode_int(R[ra]), b = regvm_decode_int(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_add(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_add_i64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_int(r);
@@ -3989,7 +4079,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_uint(R[ra]) || vigil_nanbox_is_uint(R[rb]))
         {
             uint64_t a = regvm_decode_uint(R[ra]), b = regvm_decode_uint(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_usubtract(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_subtract_u64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_uint(r);
@@ -4001,7 +4091,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_int(R[ra]) && vigil_nanbox_is_int(R[rb]))
         {
             int64_t a = regvm_decode_int(R[ra]), b = regvm_decode_int(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_subtract(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_subtract_i64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_int(r);
@@ -4026,7 +4116,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_uint(R[ra]) || vigil_nanbox_is_uint(R[rb]))
         {
             uint64_t a = regvm_decode_uint(R[ra]), b = regvm_decode_uint(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_umultiply(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_multiply_u64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_uint(r);
@@ -4038,7 +4128,7 @@ r_dispatch_switch_check:
         if (vigil_nanbox_is_int(R[ra]) && vigil_nanbox_is_int(R[rb]))
         {
             int64_t a = regvm_decode_int(R[ra]), b = regvm_decode_int(R[rb]), r;
-            if (VIGIL_LIKELY(vigil_vm_checked_multiply(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_multiply_i64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_int(r);
@@ -4065,7 +4155,7 @@ r_dispatch_switch_check:
             uint64_t a = regvm_decode_uint(R[ra]), b = regvm_decode_uint(R[rb]), r;
             if (VIGIL_UNLIKELY(b == 0))
                 goto r_divzero;
-            if (VIGIL_LIKELY(vigil_vm_checked_udivide(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_divide_u64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_uint(r);
@@ -4079,7 +4169,7 @@ r_dispatch_switch_check:
             int64_t a = regvm_decode_int(R[ra]), b = regvm_decode_int(R[rb]), r;
             if (VIGIL_UNLIKELY(b == 0))
                 goto r_divzero;
-            if (VIGIL_LIKELY(vigil_vm_checked_divide(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_divide_i64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_int(r);
@@ -4106,7 +4196,7 @@ r_dispatch_switch_check:
             uint64_t a = regvm_decode_uint(R[ra]), b = regvm_decode_uint(R[rb]), r;
             if (VIGIL_UNLIKELY(b == 0))
                 goto r_divzero;
-            if (VIGIL_LIKELY(vigil_vm_checked_umodulo(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_modulo_u64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_uint(r);
@@ -4120,7 +4210,7 @@ r_dispatch_switch_check:
             int64_t a = regvm_decode_int(R[ra]), b = regvm_decode_int(R[rb]), r;
             if (VIGIL_UNLIKELY(b == 0))
                 goto r_divzero;
-            if (VIGIL_LIKELY(vigil_vm_checked_modulo(a, b, &r) == VIGIL_STATUS_OK))
+            if (VIGIL_LIKELY(regvm_try_modulo_i64(a, b, &r)))
             {
                 RRELEASE(rd);
                 R[rd] = regvm_encode_int(r);

--- a/src/value.c
+++ b/src/value.c
@@ -83,6 +83,7 @@ typedef struct vigil_array_object
     vigil_object_t base;
     vigil_value_t *items;
     size_t item_count;
+    size_t item_capacity;
 } vigil_array_object_t;
 
 typedef struct vigil_map_object
@@ -1423,6 +1424,7 @@ vigil_status_t vigil_array_object_new(vigil_runtime_t *runtime, const vigil_valu
 
         object->items = (vigil_value_t *)memory;
         object->item_count = item_count;
+        object->item_capacity = item_count;
         for (index = 0U; index < item_count; ++index)
         {
             object->items[index] = vigil_value_copy(&items[index]);
@@ -1466,6 +1468,7 @@ vigil_status_t vigil_array_object_append(vigil_object_t *object, const vigil_val
     vigil_value_t copy;
     void *memory;
     vigil_status_t status;
+    size_t new_capacity;
 
     vigil_error_clear(error);
     array_object = (vigil_array_object_t *)object;
@@ -1475,22 +1478,29 @@ vigil_status_t vigil_array_object_append(vigil_object_t *object, const vigil_val
         return VIGIL_STATUS_INVALID_ARGUMENT;
     }
 
-    memory = array_object->items;
-    if (array_object->item_count == 0U)
+    if (array_object->item_count == array_object->item_capacity)
     {
-        status = vigil_runtime_alloc(array_object->base.runtime, sizeof(*array_object->items), &memory, error);
-    }
-    else
-    {
-        status = vigil_runtime_realloc(array_object->base.runtime, &memory,
-                                       (array_object->item_count + 1U) * sizeof(*array_object->items), error);
-    }
-    if (status != VIGIL_STATUS_OK)
-    {
-        return status;
+        memory = array_object->items;
+        new_capacity = array_object->item_capacity == 0U ? 4U : array_object->item_capacity * 2U;
+        if (array_object->item_capacity == 0U)
+        {
+            status = vigil_runtime_alloc(array_object->base.runtime, new_capacity * sizeof(*array_object->items),
+                                         &memory, error);
+        }
+        else
+        {
+            status = vigil_runtime_realloc(array_object->base.runtime, &memory,
+                                           new_capacity * sizeof(*array_object->items), error);
+        }
+        if (status != VIGIL_STATUS_OK)
+        {
+            return status;
+        }
+
+        array_object->items = (vigil_value_t *)memory;
+        array_object->item_capacity = new_capacity;
     }
 
-    array_object->items = (vigil_value_t *)memory;
     copy = vigil_value_copy(value);
     array_object->items[array_object->item_count] = copy;
     array_object->item_count += 1U;
@@ -1500,10 +1510,7 @@ vigil_status_t vigil_array_object_append(vigil_object_t *object, const vigil_val
 int vigil_array_object_pop(vigil_object_t *object, vigil_value_t *out_value)
 {
     vigil_array_object_t *array_object;
-    vigil_error_t error;
     size_t index;
-    void *memory;
-    vigil_status_t status;
 
     if (out_value == NULL)
     {
@@ -1522,18 +1529,8 @@ int vigil_array_object_pop(vigil_object_t *object, vigil_value_t *out_value)
     array_object->item_count = index;
     if (index == 0U)
     {
-        memory = array_object->items;
-        vigil_runtime_free(array_object->base.runtime, &memory);
-        array_object->items = NULL;
+        /* Keep the allocation for reuse; repeated push/pop traffic is common. */
         return 1;
-    }
-
-    memory = array_object->items;
-    vigil_error_clear(&error);
-    status = vigil_runtime_realloc(array_object->base.runtime, &memory, index * sizeof(*array_object->items), &error);
-    if (status == VIGIL_STATUS_OK)
-    {
-        array_object->items = (vigil_value_t *)memory;
     }
     return 1;
 }


### PR DESCRIPTION
## Summary
Optimize two hot runtime paths that showed the highest payoff in profiling:
- inline the hottest regvm integer arithmetic overflow checks in the dispatch loop
- give arrays geometric growth and stop shrinking storage on every pop

## Validation
- `ctest --test-dir build --output-on-failure`
- `python3 scripts/run_benchmarks.py --vigil-bin ./build-perf/vigil --manifest benchmarks/manifest.json --output /tmp/vigil-candidate-final.json`
- `python3 scripts/compare_benchmarks.py --baseline /tmp/vigil-baseline-bench.json --candidate /tmp/vigil-candidate-final.json --thresholds benchmarks/thresholds.json`

## Benchmark snapshot
Compared with an `origin/main` release build baseline:
- `run_fib`: `238.42 ms -> 216.99 ms` (`-9.0%`)
- `run_vm_arith`: `49.93 ms -> 46.24 ms` (`-7.4%`)
- `run_parse_ops`: `12.54 ms -> 12.06 ms` (`-3.9%`)
- `run_regex_scan`: `12.35 ms -> 11.99 ms` (`-2.9%`)
- `run_math_ops`: `23.51 ms -> 22.94 ms` (`-2.4%`)
- `run_csv_roundtrip`: `22.87 ms -> 23.11 ms` (`+1.1%`, below regression thresholds)
- `check_checker_stress`: `12.02 ms -> 12.56 ms` (`+4.6%`, below regression thresholds)

RSS improved slightly across all measured cases in the same run.
