### PR TITLE
Expand editor integration coverage

### DIFF
--- a/integration_tests/test_editor.py
+++ b/integration_tests/test_editor.py
@@ -44,8 +44,12 @@ class EditorInstallTest(unittest.TestCase):
                 env_override={"HOME": d},
             )
             self.assertEqual(rc, 0, f"stderr: {out}")
-            ft = Path(d) / ".config" / "nvim" / "after" / "ftdetect" / "vigil.vim"
-            syn = Path(d) / ".config" / "nvim" / "after" / "syntax" / "vigil.vim"
+            if os.name == "nt":
+                ft = Path(d) / "AppData" / "Local" / "nvim" / "after" / "ftdetect" / "vigil.vim"
+                syn = Path(d) / "AppData" / "Local" / "nvim" / "after" / "syntax" / "vigil.vim"
+            else:
+                ft = Path(d) / ".config" / "nvim" / "after" / "ftdetect" / "vigil.vim"
+                syn = Path(d) / ".config" / "nvim" / "after" / "syntax" / "vigil.vim"
             self.assertTrue(ft.exists())
             self.assertTrue(syn.exists())
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -32,11 +32,6 @@ static int pwrite_len(const char *path, const char *content, size_t length)
     return vigil_platform_write_file(path, content, length, NULL) == VIGIL_STATUS_OK;
 }
 
-static int pappend(const char *path, const char *content)
-{
-    return vigil_platform_append_file(path, content, strlen(content), NULL) == VIGIL_STATUS_OK;
-}
-
 static int pread(const char *path, char **out_content, size_t *out_length)
 {
     char *content = NULL;
@@ -401,7 +396,9 @@ static vigil_editor_result_t install_vscode(const char *vigil_bin, const char *h
         return result_err("path too long");
     printf("Creating %s\n", path);
     if (!pwrite(path, vscode_langconf))
+    {
         return result_err("failed to write language config");
+    }
 
     /* Install npm dependencies (not available on iOS/Android) */
 #if !defined(__APPLE__) || !defined(TARGET_OS_IPHONE)
@@ -507,6 +504,38 @@ static int emacs_init_block(char *buf, size_t cap, const char *mode_path)
     return 1;
 }
 
+static int emacs_write_init_with_block(const char *init_path, const char *existing, size_t existing_length,
+                                       const char *block)
+{
+    size_t block_length = strlen(block);
+    size_t needs_newline = 0;
+    size_t out_length;
+    char *out;
+
+    if (existing && strstr(existing, emacs_marker_begin) != NULL)
+        return 1;
+    if (existing_length > 0 && existing[existing_length - 1] != '\n')
+        needs_newline = 1;
+    out_length = existing_length + needs_newline + block_length;
+    out = (char *)malloc(out_length + 1);
+    if (!out)
+        return 0;
+    if (existing_length > 0)
+        memcpy(out, existing, existing_length);
+    if (needs_newline)
+        out[existing_length] = '\n';
+    memcpy(out + existing_length + needs_newline, block, block_length);
+    out[out_length] = '\0';
+
+    if (!pwrite_len(init_path, out, out_length))
+    {
+        free(out);
+        return 0;
+    }
+    free(out);
+    return 1;
+}
+
 static vigil_editor_result_t install_emacs(const char *vigil_bin, const char *home)
 {
     char dir[1024], init_path[1024], mode_path[1024], block[3072];
@@ -528,18 +557,10 @@ static vigil_editor_result_t install_emacs(const char *vigil_bin, const char *ho
 
     if (pread(init_path, &init_content, &init_length))
     {
-        if (strstr(init_content, emacs_marker_begin) == NULL)
+        if (!emacs_write_init_with_block(init_path, init_content, init_length, block))
         {
-            if (init_length > 0 && init_content[init_length - 1] != '\n' && !pappend(init_path, "\n"))
-            {
-                free(init_content);
-                return result_err("failed to update init.el");
-            }
-            if (!pappend(init_path, block))
-            {
-                free(init_content);
-                return result_err("failed to update init.el");
-            }
+            free(init_content);
+            return result_err("failed to update init.el");
         }
         free(init_content);
     }

--- a/tests/editor_test.c
+++ b/tests/editor_test.c
@@ -32,6 +32,15 @@ static void editor_test_sublime_syntax_path(char *buf, size_t cap, const char *t
 #endif
 }
 
+static void editor_test_nvim_ft_path(char *buf, size_t cap, const char *tmpdir)
+{
+#ifdef _WIN32
+    snprintf(buf, cap, "%s/AppData/Local/nvim/after/ftdetect/vigil.vim", tmpdir);
+#else
+    snprintf(buf, cap, "%s/.config/nvim/after/ftdetect/vigil.vim", tmpdir);
+#endif
+}
+
 static int editor_test_install_cycle_ok(const char *editor, const char *tmpdir, const char *installed_path)
 {
     vigil_editor_result_t r = vigil_editor_install(editor, "/usr/local/bin/vigil", tmpdir);
@@ -62,6 +71,35 @@ static int editor_test_emacs_init_contains(const char *path, const char *needle)
     found = strstr(content, needle) != NULL;
     free(content);
     return found;
+}
+
+static int editor_test_emacs_cycle_ok(const char *tmpdir)
+{
+    char mode_path[512];
+    char init_path[512];
+    vigil_editor_result_t r;
+
+    snprintf(mode_path, sizeof(mode_path), "%s/.emacs.d/vigil-mode.el", tmpdir);
+    snprintf(init_path, sizeof(init_path), "%s/.emacs.d/init.el", tmpdir);
+
+    r = vigil_editor_install("emacs", "/usr/local/bin/vigil", tmpdir);
+    if (r.status != VIGIL_STATUS_OK)
+        return 0;
+    if (vigil_editor_is_installed("emacs", tmpdir) != 1)
+        return 0;
+    if (editor_test_exists(mode_path) != 1)
+        return 0;
+    if (!editor_test_emacs_init_contains(init_path, "vigil-mode"))
+        return 0;
+
+    r = vigil_editor_uninstall("emacs", tmpdir);
+    if (r.status != VIGIL_STATUS_OK)
+        return 0;
+    if (vigil_editor_is_installed("emacs", tmpdir) != 0)
+        return 0;
+    if (editor_test_exists(mode_path) != 0)
+        return 0;
+    return 1;
 }
 
 /* ── supported editors ───────────────────────────────────────────── */
@@ -131,7 +169,7 @@ TEST(EditorIntegration, NvimInstallUninstallRoundTrip)
     char tmpdir[256];
     char ft[512];
     editor_test_tmpdir(tmpdir, sizeof(tmpdir), "nvim", __LINE__);
-    snprintf(ft, sizeof(ft), "%s/.config/nvim/after/ftdetect/vigil.vim", tmpdir);
+    editor_test_nvim_ft_path(ft, sizeof(ft), tmpdir);
     EXPECT_TRUE(editor_test_install_cycle_ok("nvim", tmpdir, ft));
     vigil_platform_remove_all(tmpdir, NULL);
 }
@@ -139,24 +177,8 @@ TEST(EditorIntegration, NvimInstallUninstallRoundTrip)
 TEST(EditorIntegration, EmacsInstallUninstallRoundTrip)
 {
     char tmpdir[256];
-    char mode_path[512];
-    char init_path[512];
-    vigil_editor_result_t r;
     editor_test_tmpdir(tmpdir, sizeof(tmpdir), "emacs", __LINE__);
-    snprintf(mode_path, sizeof(mode_path), "%s/.emacs.d/vigil-mode.el", tmpdir);
-    snprintf(init_path, sizeof(init_path), "%s/.emacs.d/init.el", tmpdir);
-
-    r = vigil_editor_install("emacs", "/usr/local/bin/vigil", tmpdir);
-    EXPECT_EQ(r.status, VIGIL_STATUS_OK);
-    EXPECT_EQ(vigil_editor_is_installed("emacs", tmpdir), 1);
-    EXPECT_EQ(editor_test_exists(mode_path), 1);
-    EXPECT_TRUE(editor_test_emacs_init_contains(init_path, "vigil-mode"));
-
-    r = vigil_editor_uninstall("emacs", tmpdir);
-    EXPECT_EQ(r.status, VIGIL_STATUS_OK);
-    EXPECT_EQ(vigil_editor_is_installed("emacs", tmpdir), 0);
-    EXPECT_EQ(editor_test_exists(mode_path), 0);
-
+    EXPECT_TRUE(editor_test_emacs_cycle_ok(tmpdir));
     vigil_platform_remove_all(tmpdir, NULL);
 }
 


### PR DESCRIPTION
## Summary
- add editor integration support for nvim, emacs, and sublime
- refactor editor integration dispatch to a table-driven registry in src/editor.c
- extend unit and integration coverage for supported editors, install/uninstall, and status flows

## Validation
- make build
- ctest --test-dir build --output-on-failure
- VIGIL_BIN=./build/vigil python3 integration_tests/test_editor.py