### PR TITLE
Refactor assignment target semantics

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -13132,7 +13132,7 @@ static vigil_status_t vigil_parser_parse_assignment_statement_internal(vigil_par
 {
     vigil_status_t status;
     assignment_target_t t;
-    const vigil_token_t *operator_token;
+    const vigil_token_t *operator_token = NULL;
     vigil_expression_result_t value_result;
     vigil_opcode_t compound_opcode;
 

--- a/tests/compiler_test.c
+++ b/tests/compiler_test.c
@@ -167,6 +167,54 @@ static void ExpectSingleCompilerDiagnostic(int *vigil_test_failed_, const char *
     EXPECT_STREQ(actual_message, expected_message);
 }
 
+static void ExpectSingleCompilerDiagnosticMulti(int *vigil_test_failed_, const struct TestSource *sources,
+                                                size_t source_count, const char *entry_path,
+                                                const char *expected_message)
+{
+    vigil_runtime_t *runtime = NULL;
+    vigil_error_t error = {0};
+    vigil_source_registry_t registry;
+    vigil_diagnostic_list_t diagnostics;
+    vigil_object_t *function = NULL;
+    vigil_source_id_t source_id = 0U;
+    const char *actual_message = NULL;
+    size_t index;
+    vigil_status_t status;
+
+    (void)vigil_test_failed_;
+    ASSERT_EQ(vigil_runtime_open(&runtime, NULL, &error), VIGIL_STATUS_OK);
+    vigil_source_registry_init(&registry, runtime);
+    vigil_diagnostic_list_init(&diagnostics, runtime);
+
+    for (index = 0U; index < source_count; index += 1U)
+    {
+        RegisterSource(vigil_test_failed_, &registry, sources[index].path, sources[index].text, &error);
+    }
+    for (index = 1U; index <= vigil_source_registry_count(&registry); index += 1U)
+    {
+        const vigil_source_file_t *source = vigil_source_registry_get(&registry, (vigil_source_id_t)index);
+
+        if (source != NULL && strcmp(vigil_string_c_str(&source->path), entry_path) == 0)
+        {
+            source_id = source->id;
+            break;
+        }
+    }
+
+    ASSERT_NE(source_id, 0U);
+    status = vigil_compile_source(&registry, source_id, &function, &diagnostics, &error);
+    ASSERT_EQ(status, VIGIL_STATUS_SYNTAX_ERROR);
+    ASSERT_EQ(vigil_diagnostic_list_count(&diagnostics), 1U);
+    actual_message = vigil_string_c_str(&vigil_diagnostic_list_get(&diagnostics, 0U)->message);
+    EXPECT_STREQ(actual_message, expected_message);
+
+    if (function != NULL)
+        vigil_object_release(&function);
+    vigil_diagnostic_list_free(&diagnostics);
+    vigil_source_registry_free(&registry);
+    vigil_runtime_close(&runtime);
+}
+
 TEST(VigilCompilerTest, CompilesAndExecutesArithmeticAndLocals)
 {
     EXPECT_EQ(CompileAndRun(vigil_test_failed_, "fn main() -> i32 {"
@@ -1982,34 +2030,15 @@ TEST(VigilCompilerTest, RejectsAssignmentToImportedConstants)
 
 TEST(VigilCompilerTest, RejectsAssignmentToImportedFunctions)
 {
-    vigil_runtime_t *runtime = NULL;
-    vigil_error_t error = {0};
-    vigil_source_registry_t registry;
-    vigil_diagnostic_list_t diagnostics;
-    vigil_object_t *function = NULL;
-    vigil_source_id_t source_id;
+    const struct TestSource sources[] = {{"/project/lib.vigil", "pub fn value() -> i32 { return 3; }"},
+                                         {"/project/main.vigil", "import \"lib\";"
+                                                                 "fn main() -> i32 {"
+                                                                 "    lib.value = 4;"
+                                                                 "    return 0;"
+                                                                 "}"}};
 
-    ASSERT_EQ(vigil_runtime_open(&runtime, NULL, &error), VIGIL_STATUS_OK);
-    vigil_source_registry_init(&registry, runtime);
-    vigil_diagnostic_list_init(&diagnostics, runtime);
-
-    RegisterSource(vigil_test_failed_, &registry, "/project/lib.vigil", "pub fn value() -> i32 { return 3; }", &error);
-    source_id = RegisterSource(vigil_test_failed_, &registry, "/project/main.vigil",
-                               "import \"lib\";"
-                               "fn main() -> i32 {"
-                               "    lib.value = 4;"
-                               "    return 0;"
-                               "}",
-                               &error);
-
-    EXPECT_EQ(vigil_compile_source(&registry, source_id, &function, &diagnostics, &error), VIGIL_STATUS_SYNTAX_ERROR);
-    ASSERT_EQ(vigil_diagnostic_list_count(&diagnostics), 1U);
-    EXPECT_STREQ(vigil_string_c_str(&vigil_diagnostic_list_get(&diagnostics, 0U)->message),
-                 "module member is not assignable");
-
-    vigil_diagnostic_list_free(&diagnostics);
-    vigil_source_registry_free(&registry);
-    vigil_runtime_close(&runtime);
+    ExpectSingleCompilerDiagnosticMulti(vigil_test_failed_, sources, 2U, "/project/main.vigil",
+                                        "module member is not assignable");
 }
 
 TEST(VigilCompilerTest, RejectsClassesMissingInterfaceMethods)


### PR DESCRIPTION
## Summary
- separate assignment target writability and operator validation from assignment emission
- split chained assignment target resolution from intermediate target access emission
- add compiler coverage for imported function assignment diagnostics

## Testing
- make build
- ctest --test-dir build --output-on-failure