### PR TITLE
Extract semantic statement traversal

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -4772,7 +4772,7 @@ int vigil_parser_check(const vigil_parser_state_t *state, vigil_token_kind_t kin
     return token != NULL && token->kind == kind;
 }
 
-static int vigil_parser_is_at_end(const vigil_parser_state_t *state)
+int vigil_parser_is_at_end(const vigil_parser_state_t *state)
 {
     return vigil_parser_peek(state) == NULL;
 }
@@ -10024,6 +10024,8 @@ vigil_status_t vigil_parser_parse_expression_with_expected_type(vigil_parser_sta
 
 static vigil_status_t vigil_parser_parse_block_contents(vigil_parser_state_t *state,
                                                         vigil_statement_result_t *out_result);
+static int vigil_parser_should_stop_block_contents(const vigil_parser_state_t *state);
+static int vigil_parser_should_stop_switch_case_contents(const vigil_parser_state_t *state);
 
 static vigil_status_t vigil_parser_parse_block_statement(vigil_parser_state_t *state,
                                                          vigil_statement_result_t *out_result)
@@ -11419,33 +11421,8 @@ static vigil_status_t vigil_parser_parse_for_statement(vigil_parser_state_t *sta
 static vigil_status_t vigil_parser_parse_switch_case_contents(vigil_parser_state_t *state,
                                                               vigil_statement_result_t *out_result)
 {
-    vigil_status_t status;
-    vigil_statement_result_t declaration_result;
-    vigil_statement_result_t block_result;
-    const vigil_token_t *token;
-
-    vigil_statement_result_clear(&declaration_result);
-    vigil_statement_result_clear(&block_result);
-
-    while (!vigil_parser_is_at_end(state))
-    {
-        token = vigil_parser_peek(state);
-        if (token == NULL || token->kind == VIGIL_TOKEN_RBRACE || token->kind == VIGIL_TOKEN_CASE ||
-            token->kind == VIGIL_TOKEN_DEFAULT)
-        {
-            break;
-        }
-
-        status = vigil_parser_parse_declaration(state, &declaration_result);
-        if (status != VIGIL_STATUS_OK)
-        {
-            return status;
-        }
-        vigil_statement_result_merge_sequence(&block_result, &declaration_result);
-    }
-
-    vigil_statement_result_set_guaranteed_return(out_result, block_result.guaranteed_return);
-    return VIGIL_STATUS_OK;
+    return vigil_semantic_parse_statement_sequence(state, out_result, vigil_parser_parse_declaration,
+                                                   vigil_parser_should_stop_switch_case_contents);
 }
 
 static vigil_status_t parse_switch_default_case(vigil_parser_state_t *state, const vigil_token_t *token,
@@ -12839,6 +12816,20 @@ static vigil_status_t vigil_parser_parse_statement(vigil_parser_state_t *state, 
     return vigil_parser_parse_expression_statement(state, out_result);
 }
 
+static int vigil_parser_should_stop_block_contents(const vigil_parser_state_t *state)
+{
+    return vigil_parser_check(state, VIGIL_TOKEN_RBRACE);
+}
+
+static int vigil_parser_should_stop_switch_case_contents(const vigil_parser_state_t *state)
+{
+    const vigil_token_t *token;
+
+    token = vigil_parser_peek(state);
+    return token == NULL || token->kind == VIGIL_TOKEN_RBRACE || token->kind == VIGIL_TOKEN_CASE ||
+           token->kind == VIGIL_TOKEN_DEFAULT;
+}
+
 static int vigil_parser_is_variable_declaration_start(const vigil_parser_state_t *state)
 {
     const vigil_token_t *token;
@@ -12905,25 +12896,8 @@ static vigil_status_t vigil_parser_parse_declaration(vigil_parser_state_t *state
 static vigil_status_t vigil_parser_parse_block_contents(vigil_parser_state_t *state,
                                                         vigil_statement_result_t *out_result)
 {
-    vigil_status_t status;
-    vigil_statement_result_t declaration_result;
-    vigil_statement_result_t block_result;
-
-    vigil_statement_result_clear(&declaration_result);
-    vigil_statement_result_clear(&block_result);
-
-    while (!vigil_parser_is_at_end(state) && !vigil_parser_check(state, VIGIL_TOKEN_RBRACE))
-    {
-        status = vigil_parser_parse_declaration(state, &declaration_result);
-        if (status != VIGIL_STATUS_OK)
-        {
-            return status;
-        }
-        vigil_statement_result_merge_sequence(&block_result, &declaration_result);
-    }
-
-    vigil_statement_result_set_guaranteed_return(out_result, block_result.guaranteed_return);
-    return VIGIL_STATUS_OK;
+    return vigil_semantic_parse_statement_sequence(state, out_result, vigil_parser_parse_declaration,
+                                                   vigil_parser_should_stop_block_contents);
 }
 
 static vigil_status_t vigil_compile_seed_parameter_symbols(vigil_parser_state_t *state,

--- a/src/compiler_semantics.c
+++ b/src/compiler_semantics.c
@@ -77,6 +77,37 @@ vigil_status_t parse_parenthesized_bool_condition(vigil_parser_state_t *state, c
     return vigil_parser_expect(state, VIGIL_TOKEN_RPAREN, rparen_message, NULL);
 }
 
+vigil_status_t vigil_semantic_parse_statement_sequence(vigil_parser_state_t *state,
+                                                       vigil_statement_result_t *out_result,
+                                                       vigil_semantic_parse_step_t parse_step,
+                                                       vigil_semantic_stop_predicate_t should_stop)
+{
+    vigil_status_t status;
+    vigil_statement_result_t step_result;
+    vigil_statement_result_t block_result;
+
+    if (state == NULL || parse_step == NULL || should_stop == NULL)
+    {
+        vigil_error_set_literal(state == NULL ? NULL : state->program->error, VIGIL_STATUS_INVALID_ARGUMENT,
+                                "semantic statement sequence arguments are invalid");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    vigil_statement_result_clear(&step_result);
+    vigil_statement_result_clear(&block_result);
+
+    while (!vigil_parser_is_at_end(state) && !should_stop(state))
+    {
+        status = parse_step(state, &step_result);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+        vigil_statement_result_merge_sequence(&block_result, &step_result);
+    }
+
+    vigil_statement_result_set_guaranteed_return(out_result, block_result.guaranteed_return);
+    return VIGIL_STATUS_OK;
+}
+
 void assignment_target_init(assignment_target_t *t)
 {
     t->name_token = NULL;

--- a/src/internal/vigil_compiler_semantics.h
+++ b/src/internal/vigil_compiler_semantics.h
@@ -34,6 +34,10 @@ typedef struct
     int is_capture_local;
 } assignment_target_t;
 
+typedef int (*vigil_semantic_stop_predicate_t)(const vigil_parser_state_t *state);
+typedef vigil_status_t (*vigil_semantic_parse_step_t)(vigil_parser_state_t *state,
+                                                      vigil_statement_result_t *out_result);
+
 void vigil_statement_result_set_non_returning(vigil_statement_result_t *result);
 int vigil_statement_result_guarantees_return(const vigil_statement_result_t *result);
 void vigil_statement_result_merge_sequence(vigil_statement_result_t *result,
@@ -50,6 +54,10 @@ vigil_status_t parse_parenthesized_bool_condition(vigil_parser_state_t *state, c
                                                   const char *lparen_message, const char *rparen_message,
                                                   const char *scalar_message, const char *type_message,
                                                   vigil_expression_result_t *condition_result);
+vigil_status_t vigil_semantic_parse_statement_sequence(vigil_parser_state_t *state,
+                                                       vigil_statement_result_t *out_result,
+                                                       vigil_semantic_parse_step_t parse_step,
+                                                       vigil_semantic_stop_predicate_t should_stop);
 
 void assignment_target_init(assignment_target_t *t);
 int assignment_target_is_composite(const assignment_target_t *t);

--- a/src/internal/vigil_compiler_types.h
+++ b/src/internal/vigil_compiler_types.h
@@ -451,6 +451,7 @@ vigil_parser_type_t vigil_program_map_type_value(const vigil_program_state_t *pr
 const vigil_token_t *vigil_parser_peek(const vigil_parser_state_t *state);
 const vigil_token_t *vigil_parser_advance(vigil_parser_state_t *state);
 const vigil_token_t *vigil_parser_previous(const vigil_parser_state_t *state);
+int vigil_parser_is_at_end(const vigil_parser_state_t *state);
 int vigil_parser_check(const vigil_parser_state_t *state, vigil_token_kind_t kind);
 int vigil_parser_match(vigil_parser_state_t *state, vigil_token_kind_t kind);
 vigil_source_span_t vigil_parser_fallback_span(const vigil_parser_state_t *state);


### PR DESCRIPTION
## Summary
- move block and switch-case statement traversal loops into the semantic module
- keep parsing and bytecode emission in compiler-owned code paths
- expose the minimal parser-private hook needed by semantic traversal

## Testing
- make build
- ctest --test-dir build --output-on-failure