### PR TITLE
Extract semantic top-level traversal

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -64,7 +64,7 @@ static vigil_status_t vigil_compile_function_with_parent(vigil_program_state_t *
                                                          const vigil_parser_state_t *parent_state);
 static vigil_status_t vigil_compile_extern_fn(vigil_program_state_t *program, size_t function_index,
                                               const vigil_extern_fn_decl_t *ext);
-static vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public);
+vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public);
 static vigil_status_t parse_fn_params(vigil_program_state_t *program, size_t *cursor, vigil_function_decl_t *decl);
 const vigil_token_t *vigil_parser_peek(const vigil_parser_state_t *state);
 int vigil_parser_check(const vigil_parser_state_t *state, vigil_token_kind_t kind);
@@ -2236,7 +2236,7 @@ int vigil_program_parse_optional_pub(const vigil_program_state_t *program, size_
     return 0;
 }
 
-static int vigil_program_is_global_variable_declaration_start(const vigil_program_state_t *program, size_t cursor)
+int vigil_program_is_global_variable_declaration_start(const vigil_program_state_t *program, size_t cursor)
 {
     const vigil_token_t *name_token = NULL;
     const vigil_token_t *assign_token;
@@ -4027,7 +4027,7 @@ static vigil_status_t parse_extern_from_clause(vigil_program_state_t *program, s
     return VIGIL_STATUS_OK;
 }
 
-static vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public)
+vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public)
 {
     vigil_status_t status;
     const vigil_token_t *token;
@@ -4301,7 +4301,7 @@ static vigil_status_t parse_fn_body_bounds(vigil_program_state_t *program, size_
     return VIGIL_STATUS_OK;
 }
 
-static vigil_status_t parse_fn_declaration(vigil_program_state_t *program, size_t *cursor, int is_public)
+vigil_status_t parse_fn_declaration(vigil_program_state_t *program, size_t *cursor, int is_public)
 {
     vigil_status_t status;
     const vigil_token_t *name_token = NULL;
@@ -4345,92 +4345,6 @@ static vigil_status_t parse_fn_declaration(vigil_program_state_t *program, size_
         return status;
 
     program->functions.count++;
-    return VIGIL_STATUS_OK;
-}
-
-static vigil_status_t parse_repl_trailing_statements(vigil_program_state_t *program, size_t cursor)
-{
-    size_t end_cursor = cursor;
-    size_t depth = 0;
-    while (1)
-    {
-        const vigil_token_t *t = vigil_program_token_at(program, end_cursor);
-        if (t == NULL || t->kind == VIGIL_TOKEN_EOF)
-            break;
-        if (t->kind == VIGIL_TOKEN_LBRACE)
-            depth++;
-        else if (t->kind == VIGIL_TOKEN_RBRACE && depth)
-            depth--;
-        end_cursor++;
-    }
-    program->repl_stmts_start = cursor;
-    program->repl_stmts_end = end_cursor;
-    return VIGIL_STATUS_OK;
-}
-
-/* Returns VIGIL_STATUS_OK and sets *done=1 to break the loop, or *done=0 to continue. */
-static vigil_status_t parse_one_declaration(vigil_program_state_t *program, size_t *cursor, int *done)
-{
-    vigil_status_t status;
-    const vigil_token_t *token;
-    int is_public;
-
-    *done = 0;
-    token = vigil_program_token_at(program, *cursor);
-    if (token == NULL || token->kind == VIGIL_TOKEN_EOF)
-    {
-        *done = 1;
-        return VIGIL_STATUS_OK;
-    }
-    is_public = vigil_program_parse_optional_pub(program, cursor);
-    token = vigil_program_token_at(program, *cursor);
-    if (token == NULL || token->kind == VIGIL_TOKEN_EOF)
-        return vigil_compile_report(program, vigil_program_eof_span(program), "expected declaration after 'pub'");
-
-    if (token->kind == VIGIL_TOKEN_IMPORT)
-    {
-        if (is_public)
-            return vigil_compile_report(program, token->span, "imports cannot be declared 'pub'");
-        return vigil_program_parse_import(program, cursor);
-    }
-    if (token->kind == VIGIL_TOKEN_CONST)
-        return vigil_program_parse_constant_declaration(program, cursor, is_public);
-    if (token->kind == VIGIL_TOKEN_ENUM)
-        return vigil_program_parse_enum_declaration(program, cursor, is_public);
-    if (token->kind == VIGIL_TOKEN_INTERFACE)
-        return vigil_program_parse_interface_declaration(program, cursor, is_public);
-    if (token->kind == VIGIL_TOKEN_CLASS)
-        return vigil_program_parse_class_declaration(program, cursor, is_public);
-    if (vigil_program_is_global_variable_declaration_start(program, *cursor))
-        return vigil_program_parse_global_variable_declaration(program, cursor, is_public);
-    if (token->kind == VIGIL_TOKEN_EXTERN)
-        return vigil_program_parse_extern_fn(program, cursor, is_public);
-    if (token->kind == VIGIL_TOKEN_FN)
-        return parse_fn_declaration(program, cursor, is_public);
-
-    if (program->compile_mode == VIGIL_COMPILE_MODE_REPL && !is_public)
-    {
-        status = parse_repl_trailing_statements(program, *cursor);
-        *done = 1;
-        return status;
-    }
-    return vigil_compile_report(program, token->span,
-                                "expected top-level 'import', 'const', 'enum', 'interface', 'class', variable "
-                                "declaration, 'extern fn', or 'fn'");
-}
-
-static vigil_status_t vigil_program_parse_declarations(vigil_program_state_t *program)
-{
-    vigil_status_t status;
-    size_t cursor = 0U;
-    int done = 0;
-
-    while (!done)
-    {
-        status = parse_one_declaration(program, &cursor, &done);
-        if (status != VIGIL_STATUS_OK)
-            return status;
-    }
     return VIGIL_STATUS_OK;
 }
 
@@ -4483,7 +4397,7 @@ vigil_status_t vigil_program_parse_source(vigil_program_state_t *program, vigil_
     previous_source = program->source;
     previous_tokens = program->tokens;
     vigil_program_set_module_context(program, source, program->modules[module_index].tokens);
-    status = vigil_program_parse_declarations(program);
+    status = vigil_semantic_parse_program_declarations(program);
     vigil_program_set_module_context(program, previous_source, previous_tokens);
     if (status != VIGIL_STATUS_OK)
     {

--- a/src/compiler_semantics.c
+++ b/src/compiler_semantics.c
@@ -189,6 +189,79 @@ static vigil_status_t vigil_semantic_synthesize_repl_main(vigil_program_state_t 
     return VIGIL_STATUS_OK;
 }
 
+static vigil_status_t parse_repl_trailing_statements(vigil_program_state_t *program, size_t cursor)
+{
+    size_t end_cursor = cursor;
+    size_t depth = 0U;
+
+    while (1)
+    {
+        const vigil_token_t *t = vigil_program_token_at(program, end_cursor);
+
+        if (t == NULL || t->kind == VIGIL_TOKEN_EOF)
+            break;
+        if (t->kind == VIGIL_TOKEN_LBRACE)
+            depth += 1U;
+        else if (t->kind == VIGIL_TOKEN_RBRACE && depth != 0U)
+            depth -= 1U;
+        end_cursor += 1U;
+    }
+    program->repl_stmts_start = cursor;
+    program->repl_stmts_end = end_cursor;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t parse_one_declaration(vigil_program_state_t *program, size_t *cursor, int *done)
+{
+    vigil_status_t status;
+    const vigil_token_t *token;
+    int is_public;
+
+    *done = 0;
+    token = vigil_program_token_at(program, *cursor);
+    if (token == NULL || token->kind == VIGIL_TOKEN_EOF)
+    {
+        *done = 1;
+        return VIGIL_STATUS_OK;
+    }
+    is_public = vigil_program_parse_optional_pub(program, cursor);
+    token = vigil_program_token_at(program, *cursor);
+    if (token == NULL || token->kind == VIGIL_TOKEN_EOF)
+        return vigil_compile_report(program, vigil_program_eof_span(program), "expected declaration after 'pub'");
+
+    if (token->kind == VIGIL_TOKEN_IMPORT)
+    {
+        if (is_public)
+            return vigil_compile_report(program, token->span, "imports cannot be declared 'pub'");
+        return vigil_program_parse_import(program, cursor);
+    }
+    if (token->kind == VIGIL_TOKEN_CONST)
+        return vigil_program_parse_constant_declaration(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_ENUM)
+        return vigil_program_parse_enum_declaration(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_INTERFACE)
+        return vigil_program_parse_interface_declaration(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_CLASS)
+        return vigil_program_parse_class_declaration(program, cursor, is_public);
+    if (vigil_program_is_global_variable_declaration_start(program, *cursor))
+        return vigil_program_parse_global_variable_declaration(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_EXTERN)
+        return vigil_program_parse_extern_fn(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_FN)
+        return parse_fn_declaration(program, cursor, is_public);
+
+    if (program->compile_mode == VIGIL_COMPILE_MODE_REPL && !is_public)
+    {
+        status = parse_repl_trailing_statements(program, *cursor);
+        *done = 1;
+        return status;
+    }
+
+    return vigil_compile_report(program, token->span,
+                                "expected top-level 'import', 'const', 'enum', 'interface', 'class', variable "
+                                "declaration, 'extern fn', or 'fn'");
+}
+
 static vigil_status_t emit_implicit_void_return(vigil_parser_state_t *state, vigil_source_span_t span)
 {
     return emit_opcode_u32(state, VIGIL_OPCODE_RETURN, 0U, span);
@@ -453,6 +526,21 @@ vigil_status_t vigil_program_parse_import(vigil_program_state_t *program, size_t
 cleanup:
     vigil_string_free(&import_path);
     return status;
+}
+
+vigil_status_t vigil_semantic_parse_program_declarations(vigil_program_state_t *program)
+{
+    vigil_status_t status;
+    size_t cursor = 0U;
+    int done = 0;
+
+    while (!done)
+    {
+        status = parse_one_declaration(program, &cursor, &done);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+    }
+    return VIGIL_STATUS_OK;
 }
 
 vigil_status_t vigil_semantic_prepare_program(vigil_program_state_t *program, vigil_source_id_t source_id,

--- a/src/internal/vigil_compiler_semantics.h
+++ b/src/internal/vigil_compiler_semantics.h
@@ -62,6 +62,7 @@ vigil_status_t vigil_semantic_parse_statement_sequence(vigil_parser_state_t *sta
 vigil_status_t vigil_program_parse_import(vigil_program_state_t *program, size_t *cursor);
 vigil_status_t vigil_semantic_prepare_program(vigil_program_state_t *program, vigil_source_id_t source_id,
                                               vigil_compile_mode_t mode, int allow_repl_main_synthesis);
+vigil_status_t vigil_semantic_parse_program_declarations(vigil_program_state_t *program);
 vigil_status_t vigil_semantic_analyze_function_body(vigil_program_state_t *program, size_t function_index,
                                                     const vigil_parser_state_t *parent_state,
                                                     vigil_parser_state_t *state,

--- a/src/internal/vigil_compiler_types.h
+++ b/src/internal/vigil_compiler_types.h
@@ -562,12 +562,15 @@ vigil_status_t vigil_program_parse_constant_expression(vigil_program_state_t *pr
 vigil_status_t vigil_program_parse_function_return_types(vigil_program_state_t *program, size_t *cursor,
                                                          const char *unsupported_message, vigil_function_decl_t *decl);
 int vigil_program_parse_optional_pub(const vigil_program_state_t *program, size_t *cursor);
+int vigil_program_is_global_variable_declaration_start(const vigil_program_state_t *program, size_t cursor);
 vigil_status_t vigil_program_parse_global_variable_declaration(vigil_program_state_t *program, size_t *cursor,
                                                                int is_public);
 vigil_status_t vigil_program_parse_constant_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_enum_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_interface_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_class_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
+vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public);
+vigil_status_t parse_fn_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 
 /* compiler_strings.c — string/f-string parsing */
 vigil_status_t vigil_parser_parse_fstring_literal(vigil_parser_state_t *state, const vigil_token_t *token,


### PR DESCRIPTION
## Summary
- move top-level declaration traversal and REPL trailing-statement handling into the semantic module
- keep compiler-owned code focused on concrete declaration parsing and source/module bookkeeping
- expose only the minimal private declaration helpers the semantic traversal now needs

## Testing
- make build
- ctest --test-dir build --output-on-failure