### PR TITLE
Introduce lowered function body IR

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -12971,33 +12971,43 @@ static vigil_status_t try_compile_constructor_or_extern(vigil_program_state_t *p
     return VIGIL_STATUS_OK;
 }
 
+static vigil_status_t materialize_lowered_function_body(vigil_program_state_t *program,
+                                                        const vigil_function_decl_t *decl,
+                                                        vigil_lowered_function_body_t *body,
+                                                        vigil_object_t **out_object)
+{
+    vigil_status_t status;
+
+    *out_object = NULL;
+    status = vigil_function_object_new(program->registry->runtime, decl->name, decl->name_length, decl->param_count,
+                                       decl->return_count, &body->chunk, out_object, program->error);
+    if (status != VIGIL_STATUS_OK)
+    {
+        vigil_lowered_function_body_free(body);
+        return status;
+    }
+
+    memset(&body->chunk, 0, sizeof(body->chunk));
+    return VIGIL_STATUS_OK;
+}
+
 static vigil_status_t compile_function_body(vigil_program_state_t *program, size_t function_index,
                                             const vigil_parser_state_t *parent_state)
 {
     vigil_status_t status;
-    vigil_parser_state_t state;
     vigil_function_decl_t *decl;
     vigil_object_t *object;
-    vigil_statement_result_t body_result;
+    vigil_lowered_function_body_t body;
 
-    status = vigil_semantic_analyze_function_body(program, function_index, parent_state, &state, &body_result);
+    vigil_lowered_function_body_init(&body);
+    status = vigil_semantic_lower_function_body(program, function_index, parent_state, &body);
     if (status != VIGIL_STATUS_OK)
-    {
-        vigil_chunk_free(&state.chunk);
-        vigil_parser_state_free(&state);
         return status;
-    }
 
     decl = &program->functions.functions[function_index];
-    object = NULL;
-    status = vigil_function_object_new(program->registry->runtime, decl->name, decl->name_length, decl->param_count,
-                                       decl->return_count, &state.chunk, &object, program->error);
-    vigil_parser_state_free(&state);
+    status = materialize_lowered_function_body(program, decl, &body, &object);
     if (status != VIGIL_STATUS_OK)
-    {
-        vigil_chunk_free(&state.chunk);
         return status;
-    }
 
     decl->object = object;
     return VIGIL_STATUS_OK;

--- a/src/compiler_semantics.c
+++ b/src/compiler_semantics.c
@@ -613,6 +613,24 @@ vigil_status_t vigil_semantic_prepare_program(vigil_program_state_t *program, vi
     return VIGIL_STATUS_OK;
 }
 
+void vigil_lowered_function_body_init(vigil_lowered_function_body_t *body)
+{
+    if (body == NULL)
+        return;
+
+    memset(body, 0, sizeof(*body));
+}
+
+void vigil_lowered_function_body_free(vigil_lowered_function_body_t *body)
+{
+    if (body == NULL)
+        return;
+
+    vigil_chunk_free(&body->chunk);
+    body->function_index = 0U;
+    body->guaranteed_return = 0;
+}
+
 vigil_status_t vigil_semantic_analyze_function_body(vigil_program_state_t *program, size_t function_index,
                                                     const vigil_parser_state_t *parent_state,
                                                     vigil_parser_state_t *state,
@@ -653,6 +671,38 @@ vigil_status_t vigil_semantic_analyze_function_body(vigil_program_state_t *progr
 
     decl = &program->functions.functions[function_index];
     return finalize_function_body_return_analysis(program, state, decl, function_index, out_body_result);
+}
+
+vigil_status_t vigil_semantic_lower_function_body(vigil_program_state_t *program, size_t function_index,
+                                                  const vigil_parser_state_t *parent_state,
+                                                  vigil_lowered_function_body_t *out_body)
+{
+    vigil_status_t status;
+    vigil_parser_state_t state;
+    vigil_statement_result_t body_result;
+
+    if (out_body == NULL)
+    {
+        vigil_error_set_literal(program == NULL ? NULL : program->error, VIGIL_STATUS_INVALID_ARGUMENT,
+                                "out_body must not be null");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    vigil_lowered_function_body_init(out_body);
+    status = vigil_semantic_analyze_function_body(program, function_index, parent_state, &state, &body_result);
+    if (status != VIGIL_STATUS_OK)
+    {
+        vigil_chunk_free(&state.chunk);
+        vigil_parser_state_free(&state);
+        return status;
+    }
+
+    out_body->chunk = state.chunk;
+    memset(&state.chunk, 0, sizeof(state.chunk));
+    out_body->function_index = function_index;
+    out_body->guaranteed_return = body_result.guaranteed_return;
+    vigil_parser_state_free(&state);
+    return VIGIL_STATUS_OK;
 }
 
 vigil_status_t vigil_semantic_check_function_with_parent(vigil_program_state_t *program, size_t function_index,

--- a/src/internal/vigil_compiler_semantics.h
+++ b/src/internal/vigil_compiler_semantics.h
@@ -63,6 +63,11 @@ vigil_status_t vigil_program_parse_import(vigil_program_state_t *program, size_t
 vigil_status_t vigil_semantic_prepare_program(vigil_program_state_t *program, vigil_source_id_t source_id,
                                               vigil_compile_mode_t mode, int allow_repl_main_synthesis);
 vigil_status_t vigil_semantic_parse_program_declarations(vigil_program_state_t *program);
+void vigil_lowered_function_body_init(vigil_lowered_function_body_t *body);
+void vigil_lowered_function_body_free(vigil_lowered_function_body_t *body);
+vigil_status_t vigil_semantic_lower_function_body(vigil_program_state_t *program, size_t function_index,
+                                                  const vigil_parser_state_t *parent_state,
+                                                  vigil_lowered_function_body_t *out_body);
 vigil_status_t vigil_semantic_analyze_function_body(vigil_program_state_t *program, size_t function_index,
                                                     const vigil_parser_state_t *parent_state,
                                                     vigil_parser_state_t *state,

--- a/src/internal/vigil_compiler_types.h
+++ b/src/internal/vigil_compiler_types.h
@@ -303,6 +303,16 @@ typedef struct vigil_statement_result
     int guaranteed_return;
 } vigil_statement_result_t;
 
+/* Minimal backend-facing lowered body artifact.
+ * The semantic layer owns production of this validated body representation,
+ * and the current bytecode backend materializes function objects from it. */
+typedef struct vigil_lowered_function_body
+{
+    vigil_chunk_t chunk;
+    size_t function_index;
+    int guaranteed_return;
+} vigil_lowered_function_body_t;
+
 typedef struct vigil_binding_target
 {
     vigil_parser_type_t type;


### PR DESCRIPTION
## Summary
- introduce a minimal lowered function-body artifact owned by the semantic layer
- have semantic lowering produce that artifact before bytecode object materialization
- make compiler function-body compilation consume the lowered artifact instead of parser state directly

## Validation
- make build
- ctest --test-dir build --output-on-failure