### PR TITLE
Add backend bytecode invariant coverage

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -483,6 +483,65 @@ static vigil_status_t vigil_chunk_disassemble_call_extern(const vigil_chunk_t *c
     return VIGIL_STATUS_OK;
 }
 
+static vigil_status_t vigil_chunk_disassemble_increment_local(const vigil_chunk_t *chunk, size_t *offset,
+                                                              vigil_string_t *output, vigil_error_t *error)
+{
+    uint32_t local_index;
+    int8_t delta;
+    vigil_status_t status;
+
+    status = vigil_chunk_require_operand_bytes(chunk, *offset, 5U, "truncated increment-local instruction", error);
+    if (status != VIGIL_STATUS_OK)
+    {
+        return status;
+    }
+
+    local_index = vigil_chunk_decode_u32(chunk->code.data, *offset + 1U);
+    delta = (int8_t)chunk->code.data[*offset + 5U];
+    status = vigil_chunk_append_formatted(output, error, "failed to format increment-local operands", " %u %d",
+                                          local_index, (int)delta);
+    if (status != VIGIL_STATUS_OK)
+    {
+        return status;
+    }
+
+    *offset += 6U;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t vigil_chunk_disassemble_forloop(const vigil_chunk_t *chunk, size_t *offset,
+                                                      vigil_string_t *output, vigil_error_t *error)
+{
+    uint32_t local_index;
+    int8_t delta;
+    uint32_t limit_constant;
+    uint8_t comparison_kind;
+    uint32_t back_offset;
+    vigil_status_t status;
+
+    status = vigil_chunk_require_operand_bytes(chunk, *offset, 14U, "truncated for-loop instruction", error);
+    if (status != VIGIL_STATUS_OK)
+    {
+        return status;
+    }
+
+    local_index = vigil_chunk_decode_u32(chunk->code.data, *offset + 1U);
+    delta = (int8_t)chunk->code.data[*offset + 5U];
+    limit_constant = vigil_chunk_decode_u32(chunk->code.data, *offset + 6U);
+    comparison_kind = chunk->code.data[*offset + 10U];
+    back_offset = vigil_chunk_decode_u32(chunk->code.data, *offset + 11U);
+    status =
+        vigil_chunk_append_formatted(output, error, "failed to format for-loop operands", " %u %d %u %u %u",
+                                     local_index, (int)delta, limit_constant, (unsigned)comparison_kind, back_offset);
+    if (status != VIGIL_STATUS_OK)
+    {
+        return status;
+    }
+
+    *offset += 15U;
+    return VIGIL_STATUS_OK;
+}
+
 static vigil_status_t vigil_chunk_disassemble_two_u32_operands(const vigil_chunk_t *chunk, size_t *offset,
                                                                vigil_string_t *output, vigil_error_t *error,
                                                                const char *truncated_message,
@@ -594,6 +653,16 @@ static int vigil_chunk_is_two_u32_operand_opcode(vigil_opcode_t opcode)
            opcode == VIGIL_OPCODE_CALL_SELF;
 }
 
+static int vigil_chunk_is_increment_local_opcode(vigil_opcode_t opcode)
+{
+    return opcode == VIGIL_OPCODE_INCREMENT_LOCAL_I32 || opcode == VIGIL_OPCODE_INCREMENT_LOCAL_I64;
+}
+
+static int vigil_chunk_is_forloop_opcode(vigil_opcode_t opcode)
+{
+    return opcode == VIGIL_OPCODE_FORLOOP_I32 || opcode == VIGIL_OPCODE_FORLOOP_I64;
+}
+
 static int vigil_chunk_is_u32_operand_opcode(vigil_opcode_t opcode)
 {
     /* Lookup table avoids a long OR-chain that inflates cyclomatic complexity. */
@@ -663,6 +732,14 @@ static vigil_status_t vigil_chunk_disassemble_instruction(const vigil_chunk_t *c
             opcode == VIGIL_OPCODE_NEW_INSTANCE || opcode == VIGIL_OPCODE_DEFER_NEW_INSTANCE
                 ? "failed to format chunk constructor operand"
                 : "failed to format chunk collection operand");
+    }
+    if (vigil_chunk_is_increment_local_opcode(opcode))
+    {
+        return vigil_chunk_disassemble_increment_local(chunk, offset, output, error);
+    }
+    if (vigil_chunk_is_forloop_opcode(opcode))
+    {
+        return vigil_chunk_disassemble_forloop(chunk, offset, output, error);
     }
     if (opcode == VIGIL_OPCODE_RETURN)
     {

--- a/tests/backend_test.c
+++ b/tests/backend_test.c
@@ -53,6 +53,34 @@ static void InitBackendFixtures(int *vigil_test_failed_, backend_fixture_t *fixt
     ASSERT_EQ(vigil_diagnostic_list_count(&fixture->diagnostics), 0U);
 }
 
+static void MaterializeMainFunction(int *vigil_test_failed_, backend_fixture_t *fixture,
+                                    vigil_lowered_function_body_t *body, vigil_object_t **out_function)
+{
+    const vigil_function_decl_t *decl;
+
+    decl = vigil_binding_function_table_get(&fixture->program.functions, fixture->program.functions.main_index);
+    ASSERT_NE(decl, NULL);
+
+    vigil_lowered_function_body_init(body);
+    ASSERT_EQ(vigil_semantic_lower_function_body(&fixture->program, fixture->program.functions.main_index, NULL, body),
+              VIGIL_STATUS_OK);
+    *out_function = NULL;
+    ASSERT_EQ(vigil_compile_materialize_lowered_function_body(&fixture->program, decl, body, out_function),
+              VIGIL_STATUS_OK);
+    ASSERT_NE(*out_function, NULL);
+}
+
+static void ExpectChunkContains(int *vigil_test_failed_, vigil_runtime_t *runtime, const vigil_chunk_t *chunk,
+                                vigil_error_t *error, const char *needle)
+{
+    vigil_string_t output;
+
+    vigil_string_init(&output, runtime);
+    ASSERT_EQ(vigil_chunk_disassemble(chunk, &output, error), VIGIL_STATUS_OK);
+    EXPECT_TRUE(strstr(vigil_string_c_str(&output), needle) != NULL);
+    vigil_string_free(&output);
+}
+
 TEST(CompilerBackendTest, MaterializesLoweredMainFunctionBody)
 {
     static const char source[] = "fn main() -> i32 {"
@@ -61,20 +89,11 @@ TEST(CompilerBackendTest, MaterializesLoweredMainFunctionBody)
                                  "}";
     backend_fixture_t fixture;
     vigil_lowered_function_body_t body;
-    const vigil_function_decl_t *decl;
     vigil_object_t *function = NULL;
     vigil_value_t result;
 
     InitBackendFixtures(vigil_test_failed_, &fixture, source);
-
-    decl = vigil_binding_function_table_get(&fixture.program.functions, fixture.program.functions.main_index);
-    ASSERT_NE(decl, NULL);
-
-    vigil_lowered_function_body_init(&body);
-    ASSERT_EQ(vigil_semantic_lower_function_body(&fixture.program, fixture.program.functions.main_index, NULL, &body),
-              VIGIL_STATUS_OK);
-    ASSERT_EQ(vigil_compile_materialize_lowered_function_body(&fixture.program, decl, &body, &function),
-              VIGIL_STATUS_OK);
+    MaterializeMainFunction(vigil_test_failed_, &fixture, &body, &function);
     ASSERT_NE(function, NULL);
     EXPECT_STREQ(vigil_function_object_name(function), "main");
     EXPECT_EQ(vigil_function_object_arity(function), 0U);
@@ -85,6 +104,62 @@ TEST(CompilerBackendTest, MaterializesLoweredMainFunctionBody)
     ASSERT_EQ(vigil_vm_execute_function(fixture.vm, function, &result, &fixture.error), VIGIL_STATUS_OK);
     EXPECT_EQ(vigil_value_kind(&result), VIGIL_VALUE_INT);
     EXPECT_EQ(vigil_value_as_int(&result), 7);
+
+    vigil_value_release(&result);
+    vigil_object_release(&function);
+    FreeBackendFixtures(&fixture);
+}
+
+TEST(CompilerBackendTest, MaterializesLoweredConditionalBytecodeShape)
+{
+    static const char source[] = "fn main() -> i32 {"
+                                 "    if (1 < 2) {"
+                                 "        return 7;"
+                                 "    }"
+                                 "    return 4;"
+                                 "}";
+    backend_fixture_t fixture;
+    vigil_lowered_function_body_t body;
+    vigil_object_t *function;
+    vigil_value_t result;
+
+    InitBackendFixtures(vigil_test_failed_, &fixture, source);
+    MaterializeMainFunction(vigil_test_failed_, &fixture, &body, &function);
+
+    ExpectChunkContains(vigil_test_failed_, fixture.runtime, vigil_function_object_chunk(function), &fixture.error,
+                        "JUMP_IF_FALSE");
+    ExpectChunkContains(vigil_test_failed_, fixture.runtime, vigil_function_object_chunk(function), &fixture.error,
+                        "JUMP ");
+
+    vigil_value_init_nil(&result);
+    ASSERT_EQ(vigil_vm_execute_function(fixture.vm, function, &result, &fixture.error), VIGIL_STATUS_OK);
+    EXPECT_EQ(vigil_value_as_int(&result), 7);
+
+    vigil_value_release(&result);
+    vigil_object_release(&function);
+    FreeBackendFixtures(&fixture);
+}
+
+TEST(CompilerBackendTest, MaterializesLoweredForLoopProgram)
+{
+    static const char source[] = "fn main() -> i32 {"
+                                 "    i32 sum = 0;"
+                                 "    for (i32 i = 0; i < 5; i++) {"
+                                 "        sum += i;"
+                                 "    }"
+                                 "    return sum;"
+                                 "}";
+    backend_fixture_t fixture;
+    vigil_lowered_function_body_t body;
+    vigil_object_t *function;
+    vigil_value_t result;
+
+    InitBackendFixtures(vigil_test_failed_, &fixture, source);
+    MaterializeMainFunction(vigil_test_failed_, &fixture, &body, &function);
+
+    vigil_value_init_nil(&result);
+    ASSERT_EQ(vigil_vm_execute_function(fixture.vm, function, &result, &fixture.error), VIGIL_STATUS_OK);
+    EXPECT_EQ(vigil_value_as_int(&result), 10);
 
     vigil_value_release(&result);
     vigil_object_release(&function);
@@ -131,8 +206,41 @@ TEST(CompilerBackendTest, MaterializesSyntheticConstructorFunction)
     FreeBackendFixtures(&fixture);
 }
 
+TEST(CompilerBackendTest, MaterializesExternWrapperFunction)
+{
+    static const char source[] = "extern fn add(i32 a, i32 b) -> i32 from \"libm\";"
+                                 "fn main() -> i32 {"
+                                 "    return 0;"
+                                 "}";
+    backend_fixture_t fixture;
+    const vigil_extern_fn_decl_t *extern_decl;
+    vigil_function_decl_t *wrapper_decl;
+    int handled = 0;
+
+    InitBackendFixtures(vigil_test_failed_, &fixture, source);
+
+    ASSERT_EQ(fixture.program.extern_fn_count, 1U);
+    extern_decl = &fixture.program.extern_fns[0];
+    wrapper_decl = vigil_binding_function_table_get_mutable(&fixture.program.functions, extern_decl->function_index);
+    ASSERT_NE(wrapper_decl, NULL);
+    EXPECT_EQ(wrapper_decl->object, NULL);
+
+    ASSERT_EQ(
+        vigil_compile_backend_try_materialize_special_function(&fixture.program, extern_decl->function_index, &handled),
+        VIGIL_STATUS_OK);
+    EXPECT_EQ(handled, 1);
+    ASSERT_NE(wrapper_decl->object, NULL);
+    ExpectChunkContains(vigil_test_failed_, fixture.runtime, vigil_function_object_chunk(wrapper_decl->object),
+                        &fixture.error, "CALL_EXTERN");
+
+    FreeBackendFixtures(&fixture);
+}
+
 void register_backend_tests(void)
 {
     REGISTER_TEST(CompilerBackendTest, MaterializesLoweredMainFunctionBody);
+    REGISTER_TEST(CompilerBackendTest, MaterializesLoweredConditionalBytecodeShape);
+    REGISTER_TEST(CompilerBackendTest, MaterializesLoweredForLoopProgram);
     REGISTER_TEST(CompilerBackendTest, MaterializesSyntheticConstructorFunction);
+    REGISTER_TEST(CompilerBackendTest, MaterializesExternWrapperFunction);
 }

--- a/tests/chunk_test.c
+++ b/tests/chunk_test.c
@@ -196,6 +196,39 @@ static char *BuildBareReturnDisassemblyOutput(void)
     return result;
 }
 
+static char *BuildLoopSpecializationDisassemblyOutput(void)
+{
+    vigil_runtime_t *runtime = NULL;
+    vigil_error_t error = {0};
+    vigil_chunk_t chunk;
+    vigil_string_t output;
+    char *result = NULL;
+
+    if (vigil_runtime_open(&runtime, NULL, &error) != VIGIL_STATUS_OK)
+    {
+        return NULL;
+    }
+    vigil_chunk_init(&chunk, runtime);
+    vigil_string_init(&output, runtime);
+
+    if (AppendOpcodeU32(&chunk, VIGIL_OPCODE_INCREMENT_LOCAL_I32, 2U, &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_write_byte(&chunk, 1U, Span(1U, 0U, 0U), &error) == VIGIL_STATUS_OK &&
+        AppendOpcodeU32(&chunk, VIGIL_OPCODE_FORLOOP_I32, 2U, &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_write_byte(&chunk, 1U, Span(1U, 0U, 0U), &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_write_u32(&chunk, 3U, Span(1U, 0U, 0U), &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_write_byte(&chunk, 0U, Span(1U, 0U, 0U), &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_write_u32(&chunk, 12U, Span(1U, 0U, 0U), &error) == VIGIL_STATUS_OK &&
+        vigil_chunk_disassemble(&chunk, &output, &error) == VIGIL_STATUS_OK)
+    {
+        result = DuplicateString(vigil_string_c_str(&output));
+    }
+
+    vigil_string_free(&output);
+    vigil_chunk_free(&chunk);
+    vigil_runtime_close(&runtime);
+    return result;
+}
+
 static char *BuildDisassembleFailureMessage(vigil_opcode_t opcode)
 {
     vigil_runtime_t *runtime = NULL;
@@ -404,6 +437,18 @@ TEST(VigilChunkTest, DisassembleFormatsBareReturnWithoutOperand)
     free(text);
 }
 
+TEST(VigilChunkTest, DisassembleFormatsLoopSpecializationInstructions)
+{
+    static const char *const expected[] = {"INCREMENT_LOCAL_I32 2 1", "FORLOOP_I32 2 1 3 0 12"};
+    const char *missing;
+    char *text = BuildLoopSpecializationDisassemblyOutput();
+
+    ASSERT_NE(text, NULL);
+    missing = FindMissingSubstring(text, expected, sizeof(expected) / sizeof(expected[0]));
+    EXPECT_EQ(missing, NULL);
+    free(text);
+}
+
 TEST(VigilChunkTest, DisassembleRejectsTruncatedCallInstructions)
 {
     char *message = BuildDisassembleFailureMessage(VIGIL_OPCODE_CALL);
@@ -547,6 +592,7 @@ void register_chunk_tests(void)
     REGISTER_TEST(VigilChunkTest, DisassembleFormatsOpcodesAndConstants);
     REGISTER_TEST(VigilChunkTest, DisassembleFormatsOperandInstructions);
     REGISTER_TEST(VigilChunkTest, DisassembleFormatsBareReturnWithoutOperand);
+    REGISTER_TEST(VigilChunkTest, DisassembleFormatsLoopSpecializationInstructions);
     REGISTER_TEST(VigilChunkTest, DisassembleRejectsTruncatedCallInstructions);
     REGISTER_TEST(VigilChunkTest, DisassembleRejectsTruncatedCallValueInstructions);
     REGISTER_TEST(VigilChunkTest, DisassembleRejectsTruncatedClosureInstructions);


### PR DESCRIPTION
## Summary
- extend backend tests to cover conditional lowering, loop program materialization, and extern wrapper materialization
- add chunk disassembly coverage for loop specialization opcodes
- teach the chunk disassembler to format increment-local and for-loop instructions

## Testing
- make build
- VIGIL_TEST_FILTER=CompilerBackendTest ./build/vigil_tests
- VIGIL_TEST_FILTER=VigilChunkTest ./build/vigil_tests
- ctest --test-dir build --output-on-failure