### PR TITLE
SDL3 bindings: Slice 3 — Renderer (2D drawing)

### DIFF
--- a/examples/sdl_draw.vigil
+++ b/examples/sdl_draw.vigil
@@ -1,0 +1,48 @@
+import "fmt";
+import "sdl";
+
+fn main() -> i32 {
+    bool init_ok, err ie = sdl.init(sdl.INIT_VIDEO());
+    if (ie != ok) {
+        fmt.eprintln(f"SDL init failed: {ie.message()}");
+        return 1;
+    }
+    defer sdl.quit();
+
+    sdl.Window win, err we = sdl.Window.create("Vigil SDL Draw", 640, 480, 0);
+    if (we != ok) {
+        fmt.eprintln(f"Window failed: {we.message()}");
+        return 1;
+    }
+
+    sdl.Renderer ren, err re = sdl.Renderer.create(win, "");
+    if (re != ok) {
+        fmt.eprintln(f"Renderer failed: {re.message()}");
+        win.destroy();
+        return 1;
+    }
+
+    // Clear to dark gray
+    bool c1, err _ = ren.set_draw_color(25, 25, 25, 255);
+    bool c2, err _2 = ren.clear();
+
+    // Draw a red filled rectangle
+    bool c3, err _3 = ren.set_draw_color(255, 0, 0, 255);
+    bool c4, err _4 = ren.fill_rect(50.0, 50.0, 200.0, 150.0);
+
+    // Draw a green outline rectangle
+    bool c5, err _5 = ren.set_draw_color(0, 255, 0, 255);
+    bool c6, err _6 = ren.draw_rect(300.0, 50.0, 200.0, 150.0);
+
+    // Draw a blue line
+    bool c7, err _7 = ren.set_draw_color(0, 0, 255, 255);
+    bool c8, err _8 = ren.draw_line(50.0, 300.0, 550.0, 400.0);
+
+    bool c9, err _9 = ren.present();
+
+    fmt.println("Drew shapes. Closing.");
+
+    ren.destroy();
+    win.destroy();
+    return 0;
+}

--- a/plugins/sdl/sdl.c
+++ b/plugins/sdl/sdl.c
@@ -666,10 +666,197 @@ static vigil_status_t sdl_window_get_flags(vigil_vm_t *vm, size_t arg_count, vig
 static const int p_i32[] = {VIGIL_TYPE_I32};
 static const int p_str[] = {VIGIL_TYPE_STRING};
 static const int p_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32};
+static const int p_i32_i32_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
 static const int p_str_i32_i32_i32[] = {VIGIL_TYPE_STRING, VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
+static const int p_obj_str[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_STRING};
+static const int p_f64_f64[] = {VIGIL_TYPE_F64, VIGIL_TYPE_F64};
+static const int p_f64_f64_f64_f64[] = {VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
 static const int rt_bool_err[] = {VIGIL_TYPE_BOOL, VIGIL_TYPE_ERR};
 static const int rt_obj_err[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_ERR};
 static const int rt_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32};
+static const int rt_i32_i32_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
+
+/* ── Renderer handle registry ────────────────────────────────────── */
+
+SDL_HANDLE_REGISTRY(renderers);
+
+enum
+{
+    REN_HANDLE = 0,
+    REN_FIELD_COUNT
+};
+
+/* Renderer.create(sdl.Window win, string driver) -> (Renderer, err) */
+
+static vigil_status_t sdl_renderer_create(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    size_t ci = sdl_static_class_index(vm, base);
+    int64_t wh = sdl_field_i64(vm, base + 1, WIN_HANDLE);
+    char driver[64];
+    sdl_arg_str(vm, base, 2, driver, sizeof(driver));
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    SDL_Window *win = (SDL_Window *)SDL_HANDLE_GET(windows, wh);
+    if (!win)
+        return sdl_push_nil_and_err(vm, "invalid window handle", SDL_ERR_ARG, error);
+
+    const char *drv = driver[0] ? driver : NULL;
+    SDL_Renderer *ren = SDL_CreateRenderer(win, drv);
+    if (!ren)
+        return sdl_push_nil_and_sdl_err(vm, SDL_ERR_IO, error);
+
+    int64_t handle;
+    if (SDL_HANDLE_STORE(renderers, ren, &handle) < 0)
+    {
+        SDL_DestroyRenderer(ren);
+        return sdl_push_nil_and_err(vm, "too many renderers", SDL_ERR_STATE, error);
+    }
+
+    vigil_status_t st = sdl_push_handle_instance(vm, ci, handle, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_ok(vm, error);
+}
+
+static vigil_status_t sdl_renderer_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    (void)error;
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren)
+    {
+        SDL_DestroyRenderer(ren);
+        SDL_HANDLE_CLEAR(renderers, h);
+    }
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t sdl_renderer_clear(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderClear(ren))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_present(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderPresent(ren))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_set_draw_color(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t r = sdl_arg_i32(vm, base, 1);
+    int32_t g = sdl_arg_i32(vm, base, 2);
+    int32_t b = sdl_arg_i32(vm, base, 3);
+    int32_t a = sdl_arg_i32(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_SetRenderDrawColor(ren, (Uint8)r, (Uint8)g, (Uint8)b, (Uint8)a))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_get_draw_color(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    Uint8 r = 0, g = 0, b = 0, a = 0;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren)
+        SDL_GetRenderDrawColor(ren, &r, &g, &b, &a);
+    vigil_status_t st = sdl_push_i32(vm, r, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    st = sdl_push_i32(vm, g, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    st = sdl_push_i32(vm, b, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_i32(vm, a, error);
+}
+
+static vigil_status_t sdl_renderer_draw_point(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    float x = (float)sdl_arg_f64(vm, base, 1);
+    float y = (float)sdl_arg_f64(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderPoint(ren, x, y))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_draw_line(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    float x1 = (float)sdl_arg_f64(vm, base, 1);
+    float y1 = (float)sdl_arg_f64(vm, base, 2);
+    float x2 = (float)sdl_arg_f64(vm, base, 3);
+    float y2 = (float)sdl_arg_f64(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderLine(ren, x1, y1, x2, y2))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_draw_rect(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    SDL_FRect rect = {(float)sdl_arg_f64(vm, base, 1), (float)sdl_arg_f64(vm, base, 2), (float)sdl_arg_f64(vm, base, 3),
+                      (float)sdl_arg_f64(vm, base, 4)};
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderRect(ren, &rect))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_fill_rect(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    SDL_FRect rect = {(float)sdl_arg_f64(vm, base, 1), (float)sdl_arg_f64(vm, base, 2), (float)sdl_arg_f64(vm, base, 3),
+                      (float)sdl_arg_f64(vm, base, 4)};
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_RenderFillRect(ren, &rect))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+static vigil_status_t sdl_renderer_set_vsync(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t vsync = sdl_arg_i32(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, h);
+    if (ren && SDL_SetRenderVSync(ren, vsync))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
 
 /* ── Function helper macros ──────────────────────────────────────── */
 
@@ -753,9 +940,31 @@ static const vigil_native_class_method_t sdl_window_methods[] = {
     SDL_METHOD("get_flags", 9U, sdl_window_get_flags, 0U, NULL, VIGIL_TYPE_I32, 1U, NULL),
 };
 
+/* ── Renderer class descriptor ───────────────────────────────────── */
+
+static const vigil_native_class_field_t sdl_renderer_fields[] = {
+    SDL_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t sdl_renderer_methods[] = {
+    SDL_STATIC("create", 6U, sdl_renderer_create, 2U, p_obj_str, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    SDL_METHOD("destroy", 7U, sdl_renderer_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    SDL_METHOD("clear", 5U, sdl_renderer_clear, 0U, NULL, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("present", 7U, sdl_renderer_present, 0U, NULL, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_draw_color", 14U, sdl_renderer_set_draw_color, 4U, p_i32_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("get_draw_color", 14U, sdl_renderer_get_draw_color, 0U, NULL, VIGIL_TYPE_I32, 4U, rt_i32_i32_i32_i32),
+    SDL_METHOD("draw_point", 10U, sdl_renderer_draw_point, 2U, p_f64_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("draw_line", 9U, sdl_renderer_draw_line, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("draw_rect", 9U, sdl_renderer_draw_rect, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("fill_rect", 9U, sdl_renderer_fill_rect, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_vsync", 9U, sdl_renderer_set_vsync, 1U, p_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+};
+
 static const vigil_native_class_t sdl_classes[] = {
     {"Window", 6U, sdl_window_fields, WIN_FIELD_COUNT, sdl_window_methods,
      sizeof(sdl_window_methods) / sizeof(sdl_window_methods[0]), NULL},
+    {"Renderer", 8U, sdl_renderer_fields, REN_FIELD_COUNT, sdl_renderer_methods,
+     sizeof(sdl_renderer_methods) / sizeof(sdl_renderer_methods[0]), NULL},
 };
 /* clang-format on */
 

--- a/src/doc_registry.c
+++ b/src/doc_registry.c
@@ -1410,6 +1410,27 @@ static const vigil_doc_entry_t sdl_docs[] = {
     {"sdl.WINDOW_MINIMIZED", "sdl.WINDOW_MINIMIZED() -> i32", "Minimized window flag.", NULL, NULL},
     {"sdl.WINDOW_MAXIMIZED", "sdl.WINDOW_MAXIMIZED() -> i32", "Maximized window flag.", NULL, NULL},
     {"sdl.WINDOW_ALWAYS_ON_TOP", "sdl.WINDOW_ALWAYS_ON_TOP() -> i32", "Always-on-top window flag.", NULL, NULL},
+    /* Renderer class */
+    {"sdl.Renderer", NULL, "SDL 2D renderer handle.", "Create with sdl.Renderer.create(). Wraps an SDL_Renderer.",
+     NULL},
+    {"sdl.Renderer.create", "sdl.Renderer.create(win: sdl.Window, driver: string) -> (sdl.Renderer, err)",
+     "Create a 2D renderer for a window.", "Pass empty string for driver to use the default.",
+     "sdl.Renderer ren, err e = sdl.Renderer.create(win, \"\")"},
+    {"sdl.Renderer.destroy", "ren.destroy() -> void", "Destroy a renderer.", NULL, NULL},
+    {"sdl.Renderer.clear", "ren.clear() -> (bool, err)", "Clear the rendering target.", NULL, NULL},
+    {"sdl.Renderer.present", "ren.present() -> (bool, err)", "Present the rendered frame.", NULL, NULL},
+    {"sdl.Renderer.set_draw_color", "ren.set_draw_color(r: i32, g: i32, b: i32, a: i32) -> (bool, err)",
+     "Set the draw color (0-255 per channel).", NULL, "ren.set_draw_color(255, 0, 0, 255)"},
+    {"sdl.Renderer.get_draw_color", "ren.get_draw_color() -> (i32, i32, i32, i32)",
+     "Get the current draw color (r, g, b, a).", NULL, NULL},
+    {"sdl.Renderer.draw_point", "ren.draw_point(x: f64, y: f64) -> (bool, err)", "Draw a point.", NULL, NULL},
+    {"sdl.Renderer.draw_line", "ren.draw_line(x1: f64, y1: f64, x2: f64, y2: f64) -> (bool, err)", "Draw a line.", NULL,
+     NULL},
+    {"sdl.Renderer.draw_rect", "ren.draw_rect(x: f64, y: f64, w: f64, h: f64) -> (bool, err)",
+     "Draw a rectangle outline.", NULL, NULL},
+    {"sdl.Renderer.fill_rect", "ren.fill_rect(x: f64, y: f64, w: f64, h: f64) -> (bool, err)",
+     "Draw a filled rectangle.", NULL, NULL},
+    {"sdl.Renderer.set_vsync", "ren.set_vsync(vsync: i32) -> (bool, err)", "Set VSync mode.", NULL, NULL},
 };
 
 #define SDL_DOC_COUNT (sizeof(sdl_docs) / sizeof(sdl_docs[0]))


### PR DESCRIPTION
## Slice 3: Renderer (#307)

### sdl.Renderer native class — 11 methods

| Method | Signature |
|--------|-----------|
| `Renderer.create` | `(sdl.Window, string) -> (sdl.Renderer, err)` |
| `ren.destroy` | `() -> void` |
| `ren.clear` | `() -> (bool, err)` |
| `ren.present` | `() -> (bool, err)` |
| `ren.set_draw_color` | `(i32, i32, i32, i32) -> (bool, err)` |
| `ren.get_draw_color` | `() -> (i32, i32, i32, i32)` |
| `ren.draw_point` | `(f64, f64) -> (bool, err)` |
| `ren.draw_line` | `(f64, f64, f64, f64) -> (bool, err)` |
| `ren.draw_rect` | `(f64, f64, f64, f64) -> (bool, err)` |
| `ren.fill_rect` | `(f64, f64, f64, f64) -> (bool, err)` |
| `ren.set_vsync` | `(i32) -> (bool, err)` |

### Also includes
- Full `vigil doc` entries for all Renderer symbols
- `examples/sdl_draw.vigil` — draws colored rectangles, outlines, and lines

Ref: #307