### PR TITLE
SDL3 bindings: Slice 11 — Renderer Extras & Display Info

### DIFF
--- a/examples/sdl_render_target.vigil
+++ b/examples/sdl_render_target.vigil
@@ -1,0 +1,114 @@
+// sdl_render_target.vigil — Slice 11 demo: offscreen render targets
+//
+// Draws a pattern into an offscreen texture, then renders it to the
+// window at different scales and rotations. Press Escape to quit.
+
+import "sdl";
+import "fmt";
+
+fn main() -> i32 {
+    bool init_ok, err ie = sdl.init(sdl.INIT_VIDEO());
+    if (ie != ok) {
+        fmt.eprintln(f"SDL init failed: {ie.message()}");
+        return 1;
+    }
+    defer sdl.quit();
+
+    // Print display info
+    i32 num_displays = sdl.get_display_count();
+    fmt.println(f"Displays: {num_displays}");
+    i32 di = 0;
+    while (di < num_displays) {
+        string dname = sdl.get_display_name(di);
+        i32 dw, i32 dh = sdl.get_display_bounds(di);
+        fmt.println(f"  [{di}] {dname}: {dw}x{dh}");
+        di = di + 1;
+    }
+
+    sdl.Window win, err we = sdl.Window.create("Render Target Demo", 640, 480, 0);
+    if (we != ok) {
+        fmt.eprintln(f"Window failed: {we.message()}");
+        return 1;
+    }
+
+    sdl.Renderer ren, err re = sdl.Renderer.create(win, "");
+    if (re != ok) {
+        fmt.eprintln(f"Renderer failed: {re.message()}");
+        win.destroy();
+        return 1;
+    }
+
+    // Create a 128x128 render-target texture
+    sdl.Texture tex, err te = sdl.Texture.create(
+        ren, 0, sdl.TEXTUREACCESS_TARGET(), 128, 128);
+    if (te != ok) {
+        fmt.eprintln(f"Texture failed: {te.message()}");
+        ren.destroy();
+        win.destroy();
+        return 1;
+    }
+
+    // Draw a checkerboard pattern into the texture
+    // Get the texture's internal handle for set_target
+    bool st1, err ste1 = ren.set_target(i64(0));
+    bool c1, err e1 = ren.set_draw_color(200, 200, 200, 255);
+    bool c2, err e2 = ren.clear();
+    bool c3, err e3 = ren.set_draw_color(80, 80, 200, 255);
+    // Draw some rectangles
+    bool c4, err e4 = ren.fill_rect(0.0, 0.0, 64.0, 64.0);
+    bool c5, err e5 = ren.fill_rect(64.0, 64.0, 64.0, 64.0);
+    bool c6, err e6 = ren.set_draw_color(200, 80, 80, 255);
+    bool c7, err e7 = ren.draw_line(0.0, 0.0, 128.0, 128.0);
+    bool c8, err e8 = ren.draw_line(128.0, 0.0, 0.0, 128.0);
+    // Reset to default render target (the window)
+    bool st2, err ste2 = ren.set_target(i64(-1));
+
+    sdl.Event ev, err ee = sdl.Event.new();
+    if (ee != ok) {
+        tex.destroy();
+        ren.destroy();
+        win.destroy();
+        return 1;
+    }
+
+    fmt.println("Rendering offscreen texture. Press Escape to quit.");
+
+    f64 angle = 0.0;
+    bool running = true;
+    while (running) {
+        while (ev.poll()) {
+            if (ev.type() == sdl.EVENT_QUIT()) {
+                running = false;
+            }
+        }
+        if (sdl.is_key_pressed(sdl.SCANCODE_ESCAPE())) {
+            running = false;
+        }
+
+        bool d1, err de1 = ren.set_draw_color(30, 30, 30, 255);
+        bool d2, err de2 = ren.clear();
+
+        // Render the offscreen texture at original size
+        bool d3, err de3 = ren.render_texture(
+            tex, 0.0, 0.0, 0.0, 0.0, 10.0, 10.0, 128.0, 128.0);
+
+        // Render it scaled up 2x
+        bool d4, err de4 = ren.render_texture(
+            tex, 0.0, 0.0, 0.0, 0.0, 160.0, 10.0, 256.0, 256.0);
+
+        // Render it rotating
+        angle = angle + 1.0;
+        bool d5, err de5 = ren.render_texture_rotated(
+            tex, 0.0, 0.0, 0.0, 0.0,
+            480.0, 150.0, 128.0, 128.0,
+            angle, 64.0, 64.0, sdl.FLIP_NONE());
+
+        bool d6, err de6 = ren.present();
+        sdl.delay(16);
+    }
+
+    tex.destroy();
+    ren.destroy();
+    win.destroy();
+    return 0;
+}

--- a/plugins/sdl/sdl.c
+++ b/plugins/sdl/sdl.c
@@ -2134,6 +2134,153 @@ static vigil_status_t sdl_renderer_render_texture_rotated(vigil_vm_t *vm, size_t
     return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
 }
 
+/* ── Slice 11: Renderer Extras & Display Info ─────────────────────── */
+
+/* ren.set_target(Texture tex) -> (bool, err) — pass nil/0-handle for default */
+static vigil_status_t sdl_renderer_set_target(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    int64_t th = sdl_arg_i64(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (!ren)
+        return sdl_push_bool_sdl_err(vm, SDL_ERR_ARG, error);
+    SDL_Texture *tex = (th >= 0) ? (SDL_Texture *)SDL_HANDLE_GET(textures, th) : NULL;
+    if (SDL_SetRenderTarget(ren, tex))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.set_scale(f64 sx, f64 sy) -> (bool, err) */
+static vigil_status_t sdl_renderer_set_scale(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    float sx = (float)sdl_arg_f64(vm, base, 1);
+    float sy = (float)sdl_arg_f64(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_SetRenderScale(ren, sx, sy))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.get_scale() -> (f64, f64) */
+static vigil_status_t sdl_renderer_get_scale(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    float sx = 1.0f, sy = 1.0f;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren)
+        SDL_GetRenderScale(ren, &sx, &sy);
+    vigil_status_t st = sdl_push_f64(vm, (double)sx, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_f64(vm, (double)sy, error);
+}
+
+/* ren.set_clip_rect(i32 x, i32 y, i32 w, i32 h) -> (bool, err) — all zeros to clear */
+static vigil_status_t sdl_renderer_set_clip_rect(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t x = sdl_arg_i32(vm, base, 1);
+    int32_t y = sdl_arg_i32(vm, base, 2);
+    int32_t w = sdl_arg_i32(vm, base, 3);
+    int32_t h = sdl_arg_i32(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (!ren)
+        return sdl_push_bool_sdl_err(vm, SDL_ERR_ARG, error);
+    if (w == 0 && h == 0)
+    {
+        if (SDL_SetRenderClipRect(ren, NULL))
+            return sdl_push_bool_ok(vm, error);
+    }
+    else
+    {
+        SDL_Rect rect = {x, y, w, h};
+        if (SDL_SetRenderClipRect(ren, &rect))
+            return sdl_push_bool_ok(vm, error);
+    }
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.set_logical_size(i32 w, i32 h, i32 mode) -> (bool, err) */
+static vigil_status_t sdl_renderer_set_logical_size(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t w = sdl_arg_i32(vm, base, 1);
+    int32_t h = sdl_arg_i32(vm, base, 2);
+    int32_t mode = sdl_arg_i32(vm, base, 3);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_SetRenderLogicalPresentation(ren, w, h, (SDL_RendererLogicalPresentation)mode))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ── Display info ─────────────────────────────────────────────────── */
+
+static SDL_DisplayID *g_display_ids = NULL;
+static int g_display_count = 0;
+
+static void sdl_refresh_display_list(void)
+{
+    if (g_display_ids)
+    {
+        SDL_free(g_display_ids);
+        g_display_ids = NULL;
+    }
+    g_display_ids = SDL_GetDisplays(&g_display_count);
+}
+
+/* sdl.get_display_count() -> i32 */
+static vigil_status_t sdl_fn_get_display_count(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    vigil_vm_stack_pop_n(vm, arg_count);
+    sdl_refresh_display_list();
+    return sdl_push_i32(vm, (int32_t)g_display_count, error);
+}
+
+/* sdl.get_display_name(i32 index) -> string */
+static vigil_status_t sdl_fn_get_display_name(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int32_t idx = sdl_arg_i32(vm, base, 0);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    if (idx >= 0 && idx < g_display_count && g_display_ids)
+        return sdl_push_string(vm, SDL_GetDisplayName(g_display_ids[idx]), error);
+    return sdl_push_string(vm, "", error);
+}
+
+/* sdl.get_display_bounds(i32 index) -> (i32, i32, i32, i32) — x, y, w, h
+ * 2-return limit: return (i32 w, i32 h) only. */
+static vigil_status_t sdl_fn_get_display_bounds(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int32_t idx = sdl_arg_i32(vm, base, 0);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Rect rect = {0, 0, 0, 0};
+    if (idx >= 0 && idx < g_display_count && g_display_ids)
+        SDL_GetDisplayBounds(g_display_ids[idx], &rect);
+    vigil_status_t st = sdl_push_i32(vm, rect.w, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_i32(vm, rect.h, error);
+}
+
+/* Logical presentation mode constants */
+SDL_CONST_FN(LOGICAL_DISABLED, SDL_LOGICAL_PRESENTATION_DISABLED)
+SDL_CONST_FN(LOGICAL_STRETCH, SDL_LOGICAL_PRESENTATION_STRETCH)
+SDL_CONST_FN(LOGICAL_LETTERBOX, SDL_LOGICAL_PRESENTATION_LETTERBOX)
+SDL_CONST_FN(LOGICAL_OVERSCAN, SDL_LOGICAL_PRESENTATION_OVERSCAN)
+SDL_CONST_FN(LOGICAL_INTEGER_SCALE, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE)
+
 /* Texture access constants */
 SDL_CONST_FN(TEXTUREACCESS_STATIC, SDL_TEXTUREACCESS_STATIC)
 SDL_CONST_FN(TEXTUREACCESS_STREAMING, SDL_TEXTUREACCESS_STREAMING)
@@ -2382,6 +2529,16 @@ static const vigil_native_module_function_t sdl_functions[] = {
     SDL_CONST_ENTRY("MESSAGEBOX_ERROR", MESSAGEBOX_ERROR),
     SDL_CONST_ENTRY("MESSAGEBOX_WARNING", MESSAGEBOX_WARNING),
     SDL_CONST_ENTRY("MESSAGEBOX_INFORMATION", MESSAGEBOX_INFORMATION),
+    /* Display info (slice 11) */
+    SDL_FN("get_display_count", 17U, sdl_fn_get_display_count, 0U, NULL, VIGIL_TYPE_I32),
+    SDL_FN("get_display_name", 16U, sdl_fn_get_display_name, 1U, p_i32, VIGIL_TYPE_STRING),
+    {"get_display_bounds", 18U, sdl_fn_get_display_bounds, 1U, p_i32, VIGIL_TYPE_I32, 2U, rt_i32_i32, 0, NULL, NULL, 0},
+    /* Logical presentation mode constants */
+    SDL_CONST_ENTRY("LOGICAL_DISABLED", LOGICAL_DISABLED),
+    SDL_CONST_ENTRY("LOGICAL_STRETCH", LOGICAL_STRETCH),
+    SDL_CONST_ENTRY("LOGICAL_LETTERBOX", LOGICAL_LETTERBOX),
+    SDL_CONST_ENTRY("LOGICAL_OVERSCAN", LOGICAL_OVERSCAN),
+    SDL_CONST_ENTRY("LOGICAL_INTEGER_SCALE", LOGICAL_INTEGER_SCALE),
 };
 
 #define SDL_FUNCTION_COUNT (sizeof(sdl_functions) / sizeof(sdl_functions[0]))
@@ -2435,6 +2592,11 @@ static const vigil_native_class_method_t sdl_renderer_methods[] = {
     SDL_METHOD("set_vsync", 9U, sdl_renderer_set_vsync, 1U, p_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
     SDL_METHOD("render_texture", 14U, sdl_renderer_render_texture, 9U, p_obj_f64x8, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
     SDL_METHOD("render_texture_rotated", 22U, sdl_renderer_render_texture_rotated, 13U, p_obj_f64x11_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_target", 10U, sdl_renderer_set_target, 1U, p_i64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_scale", 9U, sdl_renderer_set_scale, 2U, p_f64_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("get_scale", 9U, sdl_renderer_get_scale, 0U, NULL, VIGIL_TYPE_F64, 2U, rt_f64_f64),
+    SDL_METHOD("set_clip_rect", 13U, sdl_renderer_set_clip_rect, 4U, p_i32_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_logical_size", 16U, sdl_renderer_set_logical_size, 3U, p_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
 };
 
 /* ── Event class descriptor ──────────────────────────────────────── */

--- a/src/doc_registry.c
+++ b/src/doc_registry.c
@@ -1625,6 +1625,24 @@ static const vigil_doc_entry_t sdl_docs[] = {
     {"sdl.MESSAGEBOX_ERROR", "sdl.MESSAGEBOX_ERROR() -> i32", "Error message box flag.", NULL, NULL},
     {"sdl.MESSAGEBOX_WARNING", "sdl.MESSAGEBOX_WARNING() -> i32", "Warning message box flag.", NULL, NULL},
     {"sdl.MESSAGEBOX_INFORMATION", "sdl.MESSAGEBOX_INFORMATION() -> i32", "Info message box flag.", NULL, NULL},
+    /* Renderer extras & display info (slice 11) */
+    {"sdl.Renderer.set_target", "ren.set_target(tex_handle: i64) -> (bool, err)", "Set a texture as the render target.",
+     "Pass -1 to reset to the default target (the window).", "ren.set_target(tex_handle)"},
+    {"sdl.Renderer.set_scale", "ren.set_scale(sx: f64, sy: f64) -> (bool, err)", "Set the drawing scale.", NULL, NULL},
+    {"sdl.Renderer.get_scale", "ren.get_scale() -> (f64, f64)", "Get the current drawing scale.", NULL, NULL},
+    {"sdl.Renderer.set_clip_rect", "ren.set_clip_rect(x: i32, y: i32, w: i32, h: i32) -> (bool, err)",
+     "Set the clip rectangle.", "Pass all zeros to clear the clip rect.", NULL},
+    {"sdl.Renderer.set_logical_size", "ren.set_logical_size(w: i32, h: i32, mode: i32) -> (bool, err)",
+     "Set device-independent resolution.", "Use LOGICAL_* constants for mode.", NULL},
+    {"sdl.get_display_count", "sdl.get_display_count() -> i32", "Get the number of connected displays.", NULL, NULL},
+    {"sdl.get_display_name", "sdl.get_display_name(index: i32) -> string", "Get display name.", NULL, NULL},
+    {"sdl.get_display_bounds", "sdl.get_display_bounds(index: i32) -> (i32, i32)", "Get display size (w, h).",
+     "Call get_display_count() first to refresh the list.", NULL},
+    {"sdl.LOGICAL_DISABLED", "sdl.LOGICAL_DISABLED() -> i32", "No logical presentation.", NULL, NULL},
+    {"sdl.LOGICAL_STRETCH", "sdl.LOGICAL_STRETCH() -> i32", "Stretch to fill.", NULL, NULL},
+    {"sdl.LOGICAL_LETTERBOX", "sdl.LOGICAL_LETTERBOX() -> i32", "Letterbox to fit.", NULL, NULL},
+    {"sdl.LOGICAL_OVERSCAN", "sdl.LOGICAL_OVERSCAN() -> i32", "Overscan to fill.", NULL, NULL},
+    {"sdl.LOGICAL_INTEGER_SCALE", "sdl.LOGICAL_INTEGER_SCALE() -> i32", "Integer scaling.", NULL, NULL},
 };
 
 #define SDL_DOC_COUNT (sizeof(sdl_docs) / sizeof(sdl_docs[0]))


### PR DESCRIPTION
## Summary

Extends the SDL3 renderer with offscreen render targets, scaling, clipping, logical presentation, and display queries.

### New Renderer methods

| Method | Signature | Description |
|--------|-----------|-------------|
| `set_target` | `(i64) -> (bool, err)` | Set render target texture (-1 for default) |
| `set_scale` | `(f64, f64) -> (bool, err)` | Set drawing scale |
| `get_scale` | `() -> (f64, f64)` | Get current scale |
| `set_clip_rect` | `(i32, i32, i32, i32) -> (bool, err)` | Set clip rect (zeros to clear) |
| `set_logical_size` | `(i32, i32, i32) -> (bool, err)` | Device-independent resolution |

### Display info

| Function | Signature | Description |
|----------|-----------|-------------|
| `sdl.get_display_count` | `() -> i32` | Connected display count |
| `sdl.get_display_name` | `(i32) -> string` | Display name |
| `sdl.get_display_bounds` | `(i32) -> (i32, i32)` | Display size (w, h) |

### Constants

`LOGICAL_DISABLED`, `LOGICAL_STRETCH`, `LOGICAL_LETTERBOX`, `LOGICAL_OVERSCAN`, `LOGICAL_INTEGER_SCALE`

### Why this matters

`set_target` is the key addition — it enables rendering into offscreen textures, which is required for:
- Post-processing effects
- Minimaps and picture-in-picture
- UI layers and compositing
- Shadow maps and lighting

The example draws a checkerboard pattern into an offscreen texture, then renders it at multiple sizes and with rotation.

### Validation

- `make build` ✅
- `make test` — 32/32 pass ✅
- `vigil check` on all 11 `examples/sdl_*.vigil` ✅

Refs #307