### PR TITLE
SDL3 bindings: Slice 12 — Renderer Drawing Extras

### DIFF
--- a/examples/sdl_debug_text.vigil
+++ b/examples/sdl_debug_text.vigil
@@ -1,0 +1,94 @@
+// sdl_debug_text.vigil — Slice 12 demo: built-in debug text rendering
+//
+// Draws real-time FPS and renderer info using SDL's built-in debug font.
+// Press Escape to quit.
+
+import "sdl";
+import "fmt";
+
+fn main() -> i32 {
+    bool init_ok, err ie = sdl.init(sdl.INIT_VIDEO());
+    if (ie != ok) {
+        fmt.eprintln(f"SDL init failed: {ie.message()}");
+        return 1;
+    }
+    defer sdl.quit();
+
+    sdl.Window win, err we = sdl.Window.create("Debug Text Demo", 640, 480, 0);
+    if (we != ok) {
+        fmt.eprintln(f"Window failed: {we.message()}");
+        return 1;
+    }
+
+    sdl.Renderer ren, err re = sdl.Renderer.create(win, "");
+    if (re != ok) {
+        fmt.eprintln(f"Renderer failed: {re.message()}");
+        win.destroy();
+        return 1;
+    }
+
+    sdl.Event ev, err ee = sdl.Event.new();
+    if (ee != ok) {
+        ren.destroy();
+        win.destroy();
+        return 1;
+    }
+
+    string ren_name = ren.get_name();
+    i32 ow, i32 oh = ren.get_output_size();
+    fmt.println(f"Renderer: {ren_name}, output: {ow}x{oh}");
+
+    i64 freq = sdl.get_performance_frequency();
+    i64 last = sdl.get_performance_counter();
+    i32 frames = 0;
+    i32 fps = 0;
+    i64 fps_timer = sdl.get_ticks();
+
+    bool running = true;
+    while (running) {
+        while (ev.poll()) {
+            if (ev.type() == sdl.EVENT_QUIT()) {
+                running = false;
+            }
+        }
+        if (sdl.is_key_pressed(sdl.SCANCODE_ESCAPE())) {
+            running = false;
+        }
+
+        // FPS counter
+        frames = frames + 1;
+        i64 now_ticks = sdl.get_ticks();
+        if (now_ticks - fps_timer >= i64(1000)) {
+            fps = frames;
+            frames = 0;
+            fps_timer = now_ticks;
+        }
+
+        bool c1, err e1 = ren.set_draw_color(30, 30, 30, 255);
+        bool c2, err e2 = ren.clear();
+
+        // Draw debug text — white
+        bool c3, err e3 = ren.set_draw_color(255, 255, 255, 255);
+        bool t1, err te1 = ren.render_debug_text(10.0, 10.0, f"FPS: {fps}");
+        bool t2, err te2 = ren.render_debug_text(10.0, 26.0, f"Renderer: {ren_name}");
+        bool t3, err te3 = ren.render_debug_text(10.0, 42.0, f"Output: {ow}x{oh}");
+
+        // Draw colored text
+        bool c4, err e4 = ren.set_draw_color(0, 255, 0, 255);
+        bool t4, err te4 = ren.render_debug_text(10.0, 74.0, "Green text");
+        bool c5, err e5 = ren.set_draw_color(255, 80, 80, 255);
+        bool t5, err te5 = ren.render_debug_text(10.0, 90.0, "Red text");
+
+        // Mouse position
+        f64 mx, f64 my = sdl.get_mouse_state();
+        bool c6, err e6 = ren.set_draw_color(200, 200, 0, 255);
+        bool t6, err te6 = ren.render_debug_text(10.0, 122.0, f"Mouse: {mx}, {my}");
+
+        bool c7, err e7 = ren.present();
+        sdl.delay(16);
+    }
+
+    ren.destroy();
+    win.destroy();
+    return 0;
+}

--- a/plugins/sdl/sdl.c
+++ b/plugins/sdl/sdl.c
@@ -668,6 +668,8 @@ static const int p_i64[] = {VIGIL_TYPE_I64};
 static const int p_str[] = {VIGIL_TYPE_STRING};
 static const int p_str_str[] = {VIGIL_TYPE_STRING, VIGIL_TYPE_STRING};
 static const int p_i32_str_str[] = {VIGIL_TYPE_I32, VIGIL_TYPE_STRING, VIGIL_TYPE_STRING};
+static const int p_f64_f64_str[] = {VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_STRING};
+static const int p_f64[] = {VIGIL_TYPE_F64};
 static const int p_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32};
 static const int p_i32_i32_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
 static const int p_str_i32_i32_i32[] = {VIGIL_TYPE_STRING, VIGIL_TYPE_I32, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
@@ -2281,6 +2283,157 @@ SDL_CONST_FN(LOGICAL_LETTERBOX, SDL_LOGICAL_PRESENTATION_LETTERBOX)
 SDL_CONST_FN(LOGICAL_OVERSCAN, SDL_LOGICAL_PRESENTATION_OVERSCAN)
 SDL_CONST_FN(LOGICAL_INTEGER_SCALE, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE)
 
+/* ── Slice 12: Renderer Drawing Extras ────────────────────────────── */
+
+/* ren.render_debug_text(f64 x, f64 y, string text) -> (bool, err) */
+static vigil_status_t sdl_renderer_render_debug_text(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    float x = (float)sdl_arg_f64(vm, base, 1);
+    float y = (float)sdl_arg_f64(vm, base, 2);
+    char text[4096];
+    sdl_arg_str(vm, base, 3, text, sizeof(text));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_RenderDebugText(ren, x, y, text))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.set_viewport(i32 x, i32 y, i32 w, i32 h) -> (bool, err) — zeros to reset */
+static vigil_status_t sdl_renderer_set_viewport(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t x = sdl_arg_i32(vm, base, 1);
+    int32_t y = sdl_arg_i32(vm, base, 2);
+    int32_t w = sdl_arg_i32(vm, base, 3);
+    int32_t h = sdl_arg_i32(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (!ren)
+        return sdl_push_bool_sdl_err(vm, SDL_ERR_ARG, error);
+    if (w == 0 && h == 0)
+    {
+        if (SDL_SetRenderViewport(ren, NULL))
+            return sdl_push_bool_ok(vm, error);
+    }
+    else
+    {
+        SDL_Rect rect = {x, y, w, h};
+        if (SDL_SetRenderViewport(ren, &rect))
+            return sdl_push_bool_ok(vm, error);
+    }
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.set_draw_blend_mode(i32 mode) -> (bool, err) */
+static vigil_status_t sdl_renderer_set_draw_blend_mode(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    int32_t mode = sdl_arg_i32(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_SetRenderDrawBlendMode(ren, (SDL_BlendMode)mode))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.get_draw_blend_mode() -> i32 */
+static vigil_status_t sdl_renderer_get_draw_blend_mode(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_BlendMode mode = SDL_BLENDMODE_NONE;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren)
+        SDL_GetRenderDrawBlendMode(ren, &mode);
+    return sdl_push_i32(vm, (int32_t)mode, error);
+}
+
+/* ren.set_color_scale(f64 scale) -> (bool, err) */
+static vigil_status_t sdl_renderer_set_color_scale(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    float scale = (float)sdl_arg_f64(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_SetRenderColorScale(ren, scale))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.get_color_scale() -> f64 */
+static vigil_status_t sdl_renderer_get_color_scale(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    float scale = 1.0f;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren)
+        SDL_GetRenderColorScale(ren, &scale);
+    return sdl_push_f64(vm, (double)scale, error);
+}
+
+/* ren.flush() -> (bool, err) */
+static vigil_status_t sdl_renderer_flush(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren && SDL_FlushRenderer(ren))
+        return sdl_push_bool_ok(vm, error);
+    return sdl_push_bool_sdl_err(vm, SDL_ERR_IO, error);
+}
+
+/* ren.get_output_size() -> (i32, i32) */
+static vigil_status_t sdl_renderer_get_output_size(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    int w = 0, h = 0;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren)
+        SDL_GetRenderOutputSize(ren, &w, &h);
+    vigil_status_t st = sdl_push_i32(vm, (int32_t)w, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_i32(vm, (int32_t)h, error);
+}
+
+/* ren.get_current_output_size() -> (i32, i32) */
+static vigil_status_t sdl_renderer_get_current_output_size(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    int w = 0, h = 0;
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    if (ren)
+        SDL_GetCurrentRenderOutputSize(ren, &w, &h);
+    vigil_status_t st = sdl_push_i32(vm, (int32_t)w, error);
+    if (st != VIGIL_STATUS_OK)
+        return st;
+    return sdl_push_i32(vm, (int32_t)h, error);
+}
+
+/* ren.get_name() -> string */
+static vigil_status_t sdl_renderer_get_name(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t rh = sdl_field_i64(vm, base, REN_HANDLE);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    SDL_Renderer *ren = (SDL_Renderer *)SDL_HANDLE_GET(renderers, rh);
+    return sdl_push_string(vm, ren ? SDL_GetRendererName(ren) : "", error);
+}
+
 /* Texture access constants */
 SDL_CONST_FN(TEXTUREACCESS_STATIC, SDL_TEXTUREACCESS_STATIC)
 SDL_CONST_FN(TEXTUREACCESS_STREAMING, SDL_TEXTUREACCESS_STREAMING)
@@ -2597,6 +2750,17 @@ static const vigil_native_class_method_t sdl_renderer_methods[] = {
     SDL_METHOD("get_scale", 9U, sdl_renderer_get_scale, 0U, NULL, VIGIL_TYPE_F64, 2U, rt_f64_f64),
     SDL_METHOD("set_clip_rect", 13U, sdl_renderer_set_clip_rect, 4U, p_i32_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
     SDL_METHOD("set_logical_size", 16U, sdl_renderer_set_logical_size, 3U, p_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    /* Slice 12: drawing extras */
+    SDL_METHOD("render_debug_text", 17U, sdl_renderer_render_debug_text, 3U, p_f64_f64_str, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_viewport", 12U, sdl_renderer_set_viewport, 4U, p_i32_i32_i32_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("set_draw_blend_mode", 19U, sdl_renderer_set_draw_blend_mode, 1U, p_i32, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("get_draw_blend_mode", 19U, sdl_renderer_get_draw_blend_mode, 0U, NULL, VIGIL_TYPE_I32, 1U, NULL),
+    SDL_METHOD("set_color_scale", 15U, sdl_renderer_set_color_scale, 1U, p_f64, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("get_color_scale", 15U, sdl_renderer_get_color_scale, 0U, NULL, VIGIL_TYPE_F64, 1U, NULL),
+    SDL_METHOD("flush", 5U, sdl_renderer_flush, 0U, NULL, VIGIL_TYPE_BOOL, 2U, rt_bool_err),
+    SDL_METHOD("get_output_size", 15U, sdl_renderer_get_output_size, 0U, NULL, VIGIL_TYPE_I32, 2U, rt_i32_i32),
+    SDL_METHOD("get_current_output_size", 23U, sdl_renderer_get_current_output_size, 0U, NULL, VIGIL_TYPE_I32, 2U, rt_i32_i32),
+    SDL_METHOD("get_name", 8U, sdl_renderer_get_name, 0U, NULL, VIGIL_TYPE_STRING, 1U, NULL),
 };
 
 /* ── Event class descriptor ──────────────────────────────────────── */

--- a/src/doc_registry.c
+++ b/src/doc_registry.c
@@ -1643,6 +1643,25 @@ static const vigil_doc_entry_t sdl_docs[] = {
     {"sdl.LOGICAL_LETTERBOX", "sdl.LOGICAL_LETTERBOX() -> i32", "Letterbox to fit.", NULL, NULL},
     {"sdl.LOGICAL_OVERSCAN", "sdl.LOGICAL_OVERSCAN() -> i32", "Overscan to fill.", NULL, NULL},
     {"sdl.LOGICAL_INTEGER_SCALE", "sdl.LOGICAL_INTEGER_SCALE() -> i32", "Integer scaling.", NULL, NULL},
+    /* Renderer drawing extras (slice 12) */
+    {"sdl.Renderer.render_debug_text", "ren.render_debug_text(x: f64, y: f64, text: string) -> (bool, err)",
+     "Draw debug text.", "Uses SDL's built-in 8x8 font. Set color with set_draw_color first.",
+     "ren.render_debug_text(10.0, 10.0, \"FPS: 60\")"},
+    {"sdl.Renderer.set_viewport", "ren.set_viewport(x: i32, y: i32, w: i32, h: i32) -> (bool, err)",
+     "Set the drawing area.", "Pass all zeros to reset to the full target.", NULL},
+    {"sdl.Renderer.set_draw_blend_mode", "ren.set_draw_blend_mode(mode: i32) -> (bool, err)",
+     "Set blend mode for draw operations.", "Use BLENDMODE_* constants.", NULL},
+    {"sdl.Renderer.get_draw_blend_mode", "ren.get_draw_blend_mode() -> i32", "Get current draw blend mode.", NULL,
+     NULL},
+    {"sdl.Renderer.set_color_scale", "ren.set_color_scale(scale: f64) -> (bool, err)",
+     "Set color scale for render operations.", NULL, NULL},
+    {"sdl.Renderer.get_color_scale", "ren.get_color_scale() -> f64", "Get current color scale.", NULL, NULL},
+    {"sdl.Renderer.flush", "ren.flush() -> (bool, err)", "Flush pending render commands.", NULL, NULL},
+    {"sdl.Renderer.get_output_size", "ren.get_output_size() -> (i32, i32)", "Get renderer output size in pixels.", NULL,
+     NULL},
+    {"sdl.Renderer.get_current_output_size", "ren.get_current_output_size() -> (i32, i32)",
+     "Get current output size in pixels.", NULL, NULL},
+    {"sdl.Renderer.get_name", "ren.get_name() -> string", "Get renderer driver name.", NULL, NULL},
 };
 
 #define SDL_DOC_COUNT (sizeof(sdl_docs) / sizeof(sdl_docs[0]))


### PR DESCRIPTION
## Summary

11 new Renderer methods for drawing, viewport control, and output queries.

### Headline: `render_debug_text`

```vigil
ren.set_draw_color(255, 255, 255, 255);
ren.render_debug_text(10.0, 10.0, f"FPS: {fps}");
```

Built-in 8x8 debug font — text rendering without SDL_ttf. Enables HUD overlays, debug info, and basic UI text.

### All new methods

| Method | Signature | Description |
|--------|-----------|-------------|
| `render_debug_text` | `(f64, f64, string) -> (bool, err)` | Draw text with built-in font |
| `set_viewport` | `(i32, i32, i32, i32) -> (bool, err)` | Set drawing area (zeros to reset) |
| `set_draw_blend_mode` | `(i32) -> (bool, err)` | Set blend mode for primitives |
| `get_draw_blend_mode` | `() -> i32` | Get current blend mode |
| `set_color_scale` | `(f64) -> (bool, err)` | Set color scale |
| `get_color_scale` | `() -> f64` | Get color scale |
| `flush` | `() -> (bool, err)` | Flush pending commands |
| `get_output_size` | `() -> (i32, i32)` | Output size in pixels |
| `get_current_output_size` | `() -> (i32, i32)` | Current output size |
| `get_name` | `() -> string` | Renderer driver name |

### Validation

- `make build` ✅
- `make test` — 32/32 pass ✅
- `vigil check` on all 12 `examples/sdl_*.vigil` ✅

Refs #307