### PR TITLE
feat: Public unsafe buffer API for plugin raw memory access

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -241,3 +241,64 @@ cmake/
 ```
 
 The build system scans `plugins/*/plugin.cmake` automatically. No manual registration is needed.
+
+## Accessing Unsafe Buffers from Plugins
+
+Plugins that need to pass raw memory to C APIs (e.g. vertex data, shader bytecode, pixel buffers) can use the public unsafe buffer API declared in `vigil/unsafe_buffer.h`.
+
+### C API
+
+```c
+#include "vigil/unsafe_buffer.h"
+
+// Resolve a Vigil buffer handle to a raw pointer
+void *vigil_unsafe_buffer_get(int64_t slot, int32_t *out_size);
+
+// Allocate a buffer and return a handle for Vigil
+int64_t vigil_unsafe_buffer_alloc(int32_t size);
+
+// Free a buffer
+void vigil_unsafe_buffer_free(int64_t slot);
+
+// Register an externally-allocated buffer (takes ownership)
+int64_t vigil_unsafe_buffer_register(void *data, int32_t size);
+```
+
+### Usage Pattern
+
+Vigil scripts build data in unsafe buffers, then pass the handle (i64) to a plugin function:
+
+```vigil
+import "unsafe";
+import "my_plugin";
+
+// Allocate a buffer and fill it with vertex data
+i64 buf = unsafe.alloc(24);  // 2 vertices × 12 bytes each
+unsafe.set_f32(buf, 0, 100.0);   // x1
+unsafe.set_f32(buf, 4, 200.0);   // y1
+unsafe.set_f32(buf, 8, 1.0);     // z1
+unsafe.set_f32(buf, 12, 300.0);  // x2
+unsafe.set_f32(buf, 16, 400.0);  // y2
+unsafe.set_f32(buf, 20, 1.0);    // z2
+
+my_plugin.upload_vertices(buf, 2);
+unsafe.free(buf);
+```
+
+The plugin resolves the handle in C:
+
+```c
+static vigil_status_t my_upload_vertices(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    int64_t buf_handle = sdl_arg_i64(vm, base, 0);
+    int32_t size = 0;
+    void *data = vigil_unsafe_buffer_get(buf_handle, &size);
+    if (!data) return push_err(vm, "invalid buffer", ...);
+
+    // Pass raw pointer to C API
+    SomeAPI_UploadData(data, size);
+    return push_ok(vm, error);
+}
+```
+
+This keeps the safety model intact: buffer access is gated through `import "unsafe"` on the Vigil side, and plugins get validated pointer access through the public C API.

--- a/include/vigil/unsafe_buffer.h
+++ b/include/vigil/unsafe_buffer.h
@@ -1,0 +1,70 @@
+#ifndef VIGIL_UNSAFE_BUFFER_H
+#define VIGIL_UNSAFE_BUFFER_H
+
+/**
+ * Public API for the unsafe buffer registry.
+ *
+ * The unsafe module maintains a slot-based registry of raw byte buffers.
+ * Vigil scripts manage these via unsafe.alloc/free/get/set.  This header
+ * exposes the registry to native plugins so they can:
+ *
+ *   - Resolve a Vigil buffer handle (i64 slot) to a raw (ptr, size) pair
+ *     for passing to C APIs that require void* parameters.
+ *   - Allocate buffers from C code and return handles to Vigil.
+ *
+ * All functions are safe to call from any native module or plugin.
+ * Buffer handles are i64 slot indices; invalid handles return NULL/error.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "vigil/export.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * Look up a buffer by slot handle.
+     * Returns the raw data pointer and size, or NULL if the handle is invalid.
+     *
+     * @param slot   Buffer handle (from unsafe.alloc or vigil_unsafe_buffer_alloc).
+     * @param out_size  If non-NULL, receives the buffer size in bytes.
+     * @return  Pointer to the buffer data, or NULL if slot is invalid.
+     */
+    VIGIL_API void *vigil_unsafe_buffer_get(int64_t slot, int32_t *out_size);
+
+    /**
+     * Allocate a new buffer in the unsafe registry.
+     * Returns the slot handle (>= 0) or -1 if the registry is full.
+     *
+     * @param size  Buffer size in bytes (must be > 0).
+     * @return  Slot handle, or -1 on failure.
+     */
+    VIGIL_API int64_t vigil_unsafe_buffer_alloc(int32_t size);
+
+    /**
+     * Free a buffer in the unsafe registry.
+     *
+     * @param slot  Buffer handle to free.
+     */
+    VIGIL_API void vigil_unsafe_buffer_free(int64_t slot);
+
+    /**
+     * Register an externally-allocated buffer in the unsafe registry.
+     * The registry takes ownership — the buffer will be freed with free()
+     * when the slot is released via unsafe.free or vigil_unsafe_buffer_free.
+     *
+     * @param data  Pointer to the buffer (must be malloc/calloc-allocated).
+     * @param size  Buffer size in bytes.
+     * @return  Slot handle, or -1 if the registry is full.
+     */
+    VIGIL_API int64_t vigil_unsafe_buffer_register(void *data, int32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/stdlib/unsafe.c
+++ b/src/stdlib/unsafe.c
@@ -45,6 +45,7 @@
 
 #include "vigil/native_module.h"
 #include "vigil/type.h"
+#include "vigil/unsafe_buffer.h"
 #include "vigil/value.h"
 #include "vigil/vm.h"
 
@@ -142,6 +143,53 @@ static int buf_find_slot(void)
         if (!g_bufs[i].data)
             return i;
     return -1;
+}
+
+/* ── Public buffer API (see vigil/unsafe_buffer.h) ───────────────── */
+
+void *vigil_unsafe_buffer_get(int64_t slot, int32_t *out_size)
+{
+    if (slot < 0 || slot >= MAX_BUFS || !g_bufs[slot].data)
+        return NULL;
+    if (out_size)
+        *out_size = g_bufs[slot].size;
+    return g_bufs[slot].data;
+}
+
+int64_t vigil_unsafe_buffer_alloc(int32_t size)
+{
+    if (size <= 0)
+        return -1;
+    int slot = buf_find_slot();
+    if (slot < 0)
+        return -1;
+    g_bufs[slot].data = (uint8_t *)calloc((size_t)size, 1);
+    if (!g_bufs[slot].data)
+        return -1;
+    g_bufs[slot].size = size;
+    return (int64_t)slot;
+}
+
+void vigil_unsafe_buffer_free(int64_t slot)
+{
+    if (slot >= 0 && slot < MAX_BUFS && g_bufs[slot].data)
+    {
+        free(g_bufs[slot].data);
+        g_bufs[slot].data = NULL;
+        g_bufs[slot].size = 0;
+    }
+}
+
+int64_t vigil_unsafe_buffer_register(void *data, int32_t size)
+{
+    if (!data || size <= 0)
+        return -1;
+    int slot = buf_find_slot();
+    if (slot < 0)
+        return -1;
+    g_bufs[slot].data = (uint8_t *)data;
+    g_bufs[slot].size = size;
+    return (int64_t)slot;
 }
 
 /* ── unsafe.alloc(i32 size) -> i64 ───────────────────────────────── */

--- a/tests/unsafe_test.c
+++ b/tests/unsafe_test.c
@@ -10,6 +10,7 @@
 #include "vigil/native_module.h"
 #include "vigil/runtime.h"
 #include "vigil/stdlib.h"
+#include "vigil/unsafe_buffer.h"
 #include "vigil/vm.h"
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -894,6 +895,64 @@ TEST(Unsafe, Errno)
     unsafe_vm_teardown(&rt, &vm);
 }
 
+/* ── Public buffer API tests ─────────────────────────────────────── */
+
+TEST(Unsafe, BufferPublicAPI)
+{
+    /* Alloc via public API */
+    int64_t slot = vigil_unsafe_buffer_alloc(64);
+    EXPECT_TRUE(slot >= 0);
+
+    /* Get pointer and size */
+    int32_t size = 0;
+    void *ptr = vigil_unsafe_buffer_get(slot, &size);
+    EXPECT_TRUE(ptr != NULL);
+    EXPECT_EQ(64, size);
+
+    /* Write through pointer, read back */
+    ((uint8_t *)ptr)[0] = 0xAB;
+    ((uint8_t *)ptr)[63] = 0xCD;
+
+    void *ptr2 = vigil_unsafe_buffer_get(slot, NULL);
+    EXPECT_EQ(0xAB, ((uint8_t *)ptr2)[0]);
+    EXPECT_EQ(0xCD, ((uint8_t *)ptr2)[63]);
+
+    /* Invalid slot returns NULL */
+    EXPECT_TRUE(vigil_unsafe_buffer_get(-1, NULL) == NULL);
+    EXPECT_TRUE(vigil_unsafe_buffer_get(9999, NULL) == NULL);
+
+    /* Free */
+    vigil_unsafe_buffer_free(slot);
+    EXPECT_TRUE(vigil_unsafe_buffer_get(slot, NULL) == NULL);
+}
+
+TEST(Unsafe, BufferRegister)
+{
+    /* Register externally-allocated buffer */
+    void *data = calloc(32, 1);
+    EXPECT_TRUE(data != NULL);
+    ((uint8_t *)data)[0] = 0x42;
+
+    int64_t slot = vigil_unsafe_buffer_register(data, 32);
+    EXPECT_TRUE(slot >= 0);
+
+    int32_t size = 0;
+    void *ptr = vigil_unsafe_buffer_get(slot, &size);
+    EXPECT_EQ(data, ptr);
+    EXPECT_EQ(32, size);
+    EXPECT_EQ(0x42, ((uint8_t *)ptr)[0]);
+
+    /* Free releases the registered buffer */
+    vigil_unsafe_buffer_free(slot);
+    EXPECT_TRUE(vigil_unsafe_buffer_get(slot, NULL) == NULL);
+
+    /* NULL/zero rejects */
+    EXPECT_EQ(-1, vigil_unsafe_buffer_register(NULL, 10));
+    EXPECT_EQ(-1, vigil_unsafe_buffer_register((void *)1, 0));
+    EXPECT_EQ(-1, vigil_unsafe_buffer_alloc(0));
+    EXPECT_EQ(-1, vigil_unsafe_buffer_alloc(-1));
+}
+
 /* ── Registration ────────────────────────────────────────────────── */
 
 void register_unsafe_tests(void)
@@ -925,4 +984,6 @@ void register_unsafe_tests(void)
     REGISTER_TEST(Unsafe, OffsetofOutOfRange);
     REGISTER_TEST(Unsafe, StructSize);
     REGISTER_TEST(Unsafe, Errno);
+    REGISTER_TEST(Unsafe, BufferPublicAPI);
+    REGISTER_TEST(Unsafe, BufferRegister);
 }


### PR DESCRIPTION
## Summary

Exposes the unsafe module's buffer registry through a public C API, unblocking GPU API bindings and any plugin that needs to pass structured binary data to C libraries.

## Problem

The unsafe module maintains a slot-based registry of raw byte buffers that Vigil scripts manage via `unsafe.alloc/free/get/set`. However, this registry was **private to unsafe.c** — plugins like the SDL GPU bindings couldn't resolve a Vigil buffer handle to a raw `void*` pointer for passing to C APIs like `SDL_UploadToGPUBuffer`, `SDL_CreateGPUShader` (shader bytecode), or `SDL_PushGPUVertexUniformData`.

## Solution

New public header: `include/vigil/unsafe_buffer.h`

```c
// Resolve handle → raw pointer (NULL if invalid)
void *vigil_unsafe_buffer_get(int64_t slot, int32_t *out_size);

// Allocate from C, return handle for Vigil
int64_t vigil_unsafe_buffer_alloc(int32_t size);

// Free a buffer
void vigil_unsafe_buffer_free(int64_t slot);

// Register externally-allocated buffer (takes ownership)
int64_t vigil_unsafe_buffer_register(void *data, int32_t size);
```

## How it addresses the three GPU blockers

### 1. Deep Struct Nesting
Vigil scripts can now build C structs field-by-field in unsafe buffers using existing `unsafe.set_i32/set_f32/set_i64` at byte offsets, then pass the buffer handle to a plugin function that resolves it to a `void*`.

### 2. Raw Pointer / Buffer Parameters
Plugins call `vigil_unsafe_buffer_get(handle, &size)` to get a validated `(ptr, size)` pair for any C API that needs `const void*`.

### 3. Array-of-Struct Parameters
Same pattern — build an array of structs in a single unsafe buffer with calculated offsets, pass the handle.

## Safety Model

- Vigil side: buffer access requires `import "unsafe"` — explicitly opted in
- Plugin side: `vigil_unsafe_buffer_get` validates the handle and returns NULL for invalid slots — no raw pointer guessing
- Registered buffers are freed with `free()` when the slot is released

## Changes

| File | Description |
|------|-------------|
| `include/vigil/unsafe_buffer.h` | New public header (4 functions) |
| `src/stdlib/unsafe.c` | Implement the 4 public functions |
| `tests/unsafe_test.c` | Tests for alloc/get/free/register |
| `docs/plugins.md` | Usage documentation for plugin authors |

## Validation

- `make build` ✅
- `make test` — 32/32 pass ✅

Refs #307