### PR TITLE
CLI: Add missing editor, profile, complexity commands to help output

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -3680,6 +3680,9 @@ static void register_cli_commands(vigil_cli_t *cli, parsed_args_t *args)
     (void)vigil_cli_add_command(cli, "embed", "Embed files as VIGIL source code");
     (void)vigil_cli_add_command(cli, "test", "Run tests");
     (void)vigil_cli_add_command(cli, "get", "Manage dependencies");
+    (void)vigil_cli_add_command(cli, "editor", "Manage editor integrations");
+    (void)vigil_cli_add_command(cli, "profile", "Print compile/runtime timing and memory stats");
+    (void)vigil_cli_add_command(cli, "complexity", "Analyze cyclomatic complexity in Vigil code");
 
     cmd = vigil_cli_add_command(cli, "package", "Package a VIGIL program as a standalone binary");
     vigil_cli_add_positional(cmd, "entry", "Entry script or project directory", &args->pkg_entry);


### PR DESCRIPTION
Three commands were registered in the early dispatch table but not in the CLI parser's command list, so they worked when invoked but didn't appear in `vigil -h`:

- `editor` — Manage editor integrations
- `profile` — Print compile/runtime timing and memory stats  
- `complexity` — Analyze cyclomatic complexity in Vigil code

Now all 16 commands appear in help, matching the README.

```
Commands:
  run                  Run a VIGIL script
  check                Type-check a VIGIL script
  new                  Create a new VIGIL project
  debug                Debug a VIGIL script
  doc                  Show documentation for modules, builtins, or source files
  fmt                  Format VIGIL source files
  repl                 Start interactive REPL
  lsp                  Start Language Server Protocol server
  version              Print version information
  embed                Embed files as VIGIL source code
  test                 Run tests
  get                  Manage dependencies
  editor               Manage editor integrations
  profile              Print compile/runtime timing and memory stats
  complexity           Analyze cyclomatic complexity in Vigil code
  package              Package a VIGIL program as a standalone binary
```

32/32 tests pass.