### PR TITLE
Add compile-time portability assertions to NaN-boxing header

### DIFF
--- a/src/internal/vigil_nanbox.h
+++ b/src/internal/vigil_nanbox.h
@@ -40,8 +40,15 @@
 #ifndef VIGIL_NANBOX_H
 #define VIGIL_NANBOX_H
 
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
+
+/* ── Portability assertions ──────────────────────────────────────── */
+
+_Static_assert(CHAR_BIT == 8, "VIGIL requires 8-bit bytes");
+_Static_assert(sizeof(double) == 8, "VIGIL requires IEEE 754 binary64 doubles");
+_Static_assert(sizeof(void *) <= 8, "VIGIL NaN-boxing requires pointer width <= 64 bits");
 
 /* ── Bit constants ───────────────────────────────────────────────── */
 


### PR DESCRIPTION
Adds three `_Static_assert` checks to `vigil_nanbox.h` so that the implicit assumptions underpinning the value representation fail at compile time on unsupported targets:

- `CHAR_BIT == 8` — bytecode format and NaN-boxing assume 8-bit bytes
- `sizeof(double) == 8` — NaN-boxing requires IEEE 754 binary64
- `sizeof(void *) <= 8` — pointers are packed into a 48-bit payload

These pass on every platform in CI today (x86-64, AArch64, ARM32, wasm32, MSVC, GCC, Clang, Emscripten). The assertions cost nothing and turn silent corruption into immediate build failures on exotic targets.

Only adds `<limits.h>` (C11 standard) as a new include.