### PR TITLE
Add string and byte iteration to for-in loops

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -463,7 +463,7 @@ for (i32 i = 0; i < 10; i++) {
 
 ### for-in
 
-Iterates over arrays (single binding) and maps (key-value pair):
+Iterates over arrays (single binding), maps (key-value pair), and strings (single codepoint):
 
 ```
 for val in arr {
@@ -472,6 +472,18 @@ for val in arr {
 
 for key, val in m {
     fmt.println(key + "=" + string(val));
+}
+
+for ch in "hello" {
+    fmt.println(ch);
+}
+```
+
+String iteration yields one-codepoint `string` values, walking UTF-8 codepoints in order. For byte-level iteration, use `.bytes()`:
+
+```
+for b in "hello".bytes() {
+    // b is u8
 }
 ```
 

--- a/include/vigil/chunk.h
+++ b/include/vigil/chunk.h
@@ -294,7 +294,8 @@ extern "C"
            Format: [opcode(1)][u32 dst_local]  (5 bytes) */
         VIGIL_OPCODE_ADD_F64_STORE = 186,
         VIGIL_OPCODE_SUBTRACT_F64_STORE = 187,
-        VIGIL_OPCODE_MULTIPLY_F64_STORE = 188
+        VIGIL_OPCODE_MULTIPLY_F64_STORE = 188,
+        VIGIL_OPCODE_STRING_NEXT_CHAR = 189
     } vigil_opcode_t;
 
     /* Forward-declare the register chunk for the translation cache. */

--- a/integration_tests/test_syntax_integration.py
+++ b/integration_tests/test_syntax_integration.py
@@ -388,6 +388,54 @@ class DocsConformanceTest(unittest.TestCase):
             self.assertEqual(result.returncode, 200, msg=result.stderr)
             self.assertEqual(result.stderr, "")
 
+    def test_for_in_string_iteration(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="vigil_syntax_") as tmpdir:
+            root = Path(tmpdir)
+            write_sources(root, {"main.vigil": """
+                fn main() -> i32 {
+                    // ASCII iteration
+                    i32 count = 0;
+                    for ch in "hello" {
+                        count += 1;
+                    }
+                    if count != 5 { return 1; }
+
+                    // Unicode codepoint iteration
+                    i32 ucount = 0;
+                    for ch in "héllo" {
+                        ucount += 1;
+                    }
+                    if ucount != 5 { return 2; }
+
+                    // Empty string
+                    i32 ecount = 0;
+                    for ch in "" {
+                        ecount += 1;
+                    }
+                    if ecount != 0 { return 3; }
+
+                    // Byte iteration via .bytes()
+                    i32 bcount = 0;
+                    for b in "hi".bytes() {
+                        bcount += 1;
+                    }
+                    if bcount != 2 { return 4; }
+
+                    // break in string iteration
+                    i32 bk = 0;
+                    for ch in "abcdef" {
+                        if ch == "d" { break; }
+                        bk += 1;
+                    }
+                    if bk != 3 { return 5; }
+
+                    return 0;
+                }
+            """})
+            result = run_vigil(root, "main.vigil")
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(result.stderr, "")
+
     # -- switch and enum --
 
     def test_switch_with_enum(self) -> None:

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -13,7 +13,7 @@
 #define VIGIL_REG_CACHE_STATE_BUILDING 1LL
 #define VIGIL_REG_CACHE_STATE_READY 2LL
 
-static const char *const kVigilOpcodeNames[VIGIL_OPCODE_MULTIPLY_F64_STORE + 1] = {
+static const char *const kVigilOpcodeNames[VIGIL_OPCODE_STRING_NEXT_CHAR + 1] = {
     [VIGIL_OPCODE_CONSTANT] = "CONSTANT",
     [VIGIL_OPCODE_NIL] = "NIL",
     [VIGIL_OPCODE_TRUE] = "TRUE",
@@ -203,6 +203,7 @@ static const char *const kVigilOpcodeNames[VIGIL_OPCODE_MULTIPLY_F64_STORE + 1] 
     [VIGIL_OPCODE_ADD_F64_STORE] = "ADD_F64_STORE",
     [VIGIL_OPCODE_SUBTRACT_F64_STORE] = "SUBTRACT_F64_STORE",
     [VIGIL_OPCODE_MULTIPLY_F64_STORE] = "MULTIPLY_F64_STORE",
+    [VIGIL_OPCODE_STRING_NEXT_CHAR] = "STRING_NEXT_CHAR",
 };
 
 static vigil_status_t vigil_chunk_append_text(vigil_string_t *output, const char *text, vigil_error_t *error);
@@ -666,7 +667,7 @@ static int vigil_chunk_is_forloop_opcode(vigil_opcode_t opcode)
 static int vigil_chunk_is_u32_operand_opcode(vigil_opcode_t opcode)
 {
     /* Lookup table avoids a long OR-chain that inflates cyclomatic complexity. */
-    static const uint8_t table[VIGIL_OPCODE_MULTIPLY_F64_STORE + 1] = {
+    static const uint8_t table[VIGIL_OPCODE_STRING_NEXT_CHAR + 1] = {
         [VIGIL_OPCODE_CONSTANT] = 1,
         [VIGIL_OPCODE_GET_LOCAL] = 1,
         [VIGIL_OPCODE_SET_LOCAL] = 1,
@@ -1262,7 +1263,7 @@ vigil_source_span_t vigil_chunk_span_at(const vigil_chunk_t *chunk, size_t offse
 
 const char *vigil_opcode_name(vigil_opcode_t opcode)
 {
-    if (opcode > VIGIL_OPCODE_MULTIPLY_F64_STORE)
+    if (opcode > VIGIL_OPCODE_STRING_NEXT_CHAR)
     {
         return "UNKNOWN";
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -11267,7 +11267,8 @@ static vigil_status_t vigil_parser_bind_inferred_target(vigil_parser_state_t *st
 }
 
 static vigil_status_t emit_for_in_condition(vigil_parser_state_t *state, vigil_source_span_t span, size_t index_slot,
-                                            size_t collection_slot, size_t *exit_jump, size_t *body_jump)
+                                            size_t collection_slot, vigil_parser_type_t iterable_type,
+                                            size_t *exit_jump, size_t *body_jump)
 {
     vigil_status_t status;
 
@@ -11277,7 +11278,10 @@ static vigil_status_t emit_for_in_condition(vigil_parser_state_t *state, vigil_s
     status = emit_opcode_u32(state, VIGIL_OPCODE_GET_LOCAL, (uint32_t)collection_slot, span);
     if (status != VIGIL_STATUS_OK)
         return status;
-    status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_GET_COLLECTION_SIZE, span);
+    if (vigil_parser_type_is_string(iterable_type))
+        status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_GET_STRING_SIZE, span);
+    else
+        status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_GET_COLLECTION_SIZE, span);
     if (status != VIGIL_STATUS_OK)
         return status;
     status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_LESS, span);
@@ -11337,6 +11341,27 @@ static vigil_status_t emit_for_in_bind_array(vigil_parser_state_t *state, vigil_
     if (status != VIGIL_STATUS_OK)
         return status;
     return vigil_parser_bind_inferred_target(state, name, element_type);
+}
+
+static vigil_status_t emit_for_in_bind_string(vigil_parser_state_t *state, vigil_source_span_t span,
+                                              size_t collection_slot, size_t index_slot, const vigil_token_t *name)
+{
+    vigil_status_t status;
+
+    /* STRING_NEXT_CHAR(string, byte_offset) -> (char_string, next_offset) */
+    status = emit_for_in_get_element(state, span, collection_slot, index_slot, VIGIL_OPCODE_STRING_NEXT_CHAR);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+    /* Stack: ... char_string next_offset */
+    /* Store next_offset back to the index slot. */
+    status = emit_opcode_u32(state, VIGIL_OPCODE_SET_LOCAL, (uint32_t)index_slot, span);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+    status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_POP, span);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+    /* Stack: ... char_string — bind to loop variable. */
+    return vigil_parser_bind_inferred_target(state, name, vigil_binding_type_primitive(VIGIL_TYPE_STRING));
 }
 
 typedef struct
@@ -11399,7 +11424,14 @@ static vigil_status_t validate_for_in_iterable(vigil_parser_state_t *state, cons
         types->value_type = vigil_program_map_type_value(state->program, iterable_type);
         return VIGIL_STATUS_OK;
     }
-    return vigil_parser_report(state, for_token->span, "for-in requires an array or map iterable");
+    if (vigil_parser_type_is_string(iterable_type))
+    {
+        if (second_name != NULL)
+            return vigil_parser_report(state, second_name->span, "for-in over strings requires a single loop binding");
+        types->element_type = vigil_binding_type_primitive(VIGIL_TYPE_STRING);
+        return VIGIL_STATUS_OK;
+    }
+    return vigil_parser_report(state, for_token->span, "for-in requires an array, map, or string iterable");
 }
 
 static vigil_status_t for_in_emit_scaffolding(vigil_parser_state_t *state, const vigil_token_t *for_token,
@@ -11420,13 +11452,16 @@ static vigil_status_t for_in_emit_scaffolding(vigil_parser_state_t *state, const
         return status;
 
     ls->condition_start = vigil_chunk_code_size(&state->chunk);
-    status = emit_for_in_condition(state, for_token->span, ls->index_slot, ls->collection_slot, &ls->exit_jump_offset,
-                                   &ls->body_jump_offset);
+    status = emit_for_in_condition(state, for_token->span, ls->index_slot, ls->collection_slot, iterable_type,
+                                   &ls->exit_jump_offset, &ls->body_jump_offset);
     if (status != VIGIL_STATUS_OK)
         return status;
 
     ls->increment_start = vigil_chunk_code_size(&state->chunk);
-    status = emit_for_in_increment(state, for_token->span, ls->index_slot, ls->condition_start);
+    if (vigil_parser_type_is_string(iterable_type))
+        status = vigil_parser_emit_loop(state, ls->condition_start, for_token->span);
+    else
+        status = emit_for_in_increment(state, for_token->span, ls->index_slot, ls->condition_start);
     if (status != VIGIL_STATUS_OK)
         return status;
 
@@ -11441,7 +11476,9 @@ static vigil_status_t for_in_parse_body(vigil_parser_state_t *state, const vigil
 {
     vigil_status_t status;
     vigil_parser_begin_scope(state);
-    if (vigil_parser_type_is_array(iterable_type))
+    if (vigil_parser_type_is_string(iterable_type))
+        status = emit_for_in_bind_string(state, for_token->span, ls->collection_slot, ls->index_slot, first_name);
+    else if (vigil_parser_type_is_array(iterable_type))
         status = emit_for_in_bind_array(state, for_token->span, ls->collection_slot, ls->index_slot, first_name,
                                         types->element_type);
     else

--- a/src/regvm.c
+++ b/src/regvm.c
@@ -610,6 +610,7 @@ static size_t stack_op_size(const uint8_t *code, size_t ip, size_t code_size)
     case VIGIL_OPCODE_STRING_TRIM_PREFIX:
     case VIGIL_OPCODE_STRING_TRIM_SUFFIX:
     case VIGIL_OPCODE_STRING_JOIN:
+    case VIGIL_OPCODE_STRING_NEXT_CHAR:
     case VIGIL_OPCODE_STRING_CUT:
     case VIGIL_OPCODE_STRING_FIELDS:
     case VIGIL_OPCODE_STRING_EQUAL_FOLD:
@@ -2600,6 +2601,17 @@ vigil_status_t vigil_reg_translate(const vigil_chunk_t *stack_chunk, vigil_reg_c
         }
         case VIGIL_OPCODE_STRING_CHAR_AT: {
             /* Pop 2 (str, idx), push 2 (char, err). */
+            SYNC_PACK(2);
+            uint8_t arg = vs_pop(&vs);
+            uint8_t str = vs_pop(&vs);
+            uint8_t result_base;
+            PUSH_RESULT_REGS(str, 2, result_base);
+            TR_EMIT(vigil_reg_abc(VREG_STRING_OP, result_base, arg, op));
+            ip += 1;
+            break;
+        }
+        case VIGIL_OPCODE_STRING_NEXT_CHAR: {
+            /* Pop 2 (str, offset), push 2 (char, next_offset). */
             SYNC_PACK(2);
             uint8_t arg = vs_pop(&vs);
             uint8_t str = vs_pop(&vs);
@@ -5011,6 +5023,11 @@ r_dispatch_switch_check:
             pop_count = 2;
             helper_ret_count = 2;
             status = vigil_vm_op_string_char_at(vm, frame, error);
+            break;
+        case VIGIL_OPCODE_STRING_NEXT_CHAR:
+            pop_count = 2;
+            helper_ret_count = 2;
+            status = vigil_vm_op_string_next_char(vm, frame, error);
             break;
         case VIGIL_OPCODE_STRING_TRIM:
         case VIGIL_OPCODE_STRING_TO_UPPER:

--- a/src/vm_ops_string.c
+++ b/src/vm_ops_string.c
@@ -1283,3 +1283,63 @@ vigil_status_t vigil_vm_op_string_join(vigil_vm_t *vm, vigil_vm_frame_t *frame, 
     VIGIL_VM_VALUE_RELEASE(&value);
     return status;
 }
+
+/* ── STRING_NEXT_CHAR ──────────────────────────────────────────── */
+
+vigil_status_t vigil_vm_op_string_next_char(vigil_vm_t *vm, vigil_vm_frame_t *frame, vigil_error_t *error)
+{
+    vigil_status_t status;
+    vigil_value_t str_val, offset_val, char_val, next_val;
+    const char *text;
+    size_t text_length;
+    int64_t offset;
+    size_t char_len;
+
+    frame->ip += 1U;
+    offset_val = vigil_vm_pop_or_nil(vm);
+    str_val = vigil_vm_pop_or_nil(vm);
+
+    if (!vigil_vm_get_string_parts(&str_val, &text, &text_length) || !vigil_nanbox_is_int(offset_val))
+    {
+        VIGIL_VM_VALUE_RELEASE(&str_val);
+        VIGIL_VM_VALUE_RELEASE(&offset_val);
+        return vigil_vm_fail_at_ip(vm, VIGIL_STATUS_INVALID_ARGUMENT,
+                                   "string next_char requires a string and i32 offset", error);
+    }
+
+    offset = vigil_value_as_int(&offset_val);
+    if (offset < 0 || (size_t)offset >= text_length)
+    {
+        VIGIL_VM_VALUE_RELEASE(&str_val);
+        VIGIL_VM_VALUE_RELEASE(&offset_val);
+        return vigil_vm_fail_at_ip(vm, VIGIL_STATUS_INVALID_ARGUMENT, "string next_char offset out of range", error);
+    }
+
+    {
+        unsigned char uc = (unsigned char)text[(size_t)offset];
+        if (uc < 0x80U)
+            char_len = 1U;
+        else if ((uc & 0xE0U) == 0xC0U)
+            char_len = 2U;
+        else if ((uc & 0xF0U) == 0xE0U)
+            char_len = 3U;
+        else
+            char_len = 4U;
+        if ((size_t)offset + char_len > text_length)
+            char_len = text_length - (size_t)offset;
+    }
+
+    status = vigil_vm_new_string_value(vm, text + (size_t)offset, char_len, &char_val, error);
+    VIGIL_VM_VALUE_RELEASE(&str_val);
+    VIGIL_VM_VALUE_RELEASE(&offset_val);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    vigil_value_init_int(&next_val, offset + (int64_t)char_len);
+    status = vigil_vm_push(vm, &char_val, error);
+    VIGIL_VM_VALUE_RELEASE(&char_val);
+    if (status == VIGIL_STATUS_OK)
+        status = vigil_vm_push(vm, &next_val, error);
+    VIGIL_VM_VALUE_RELEASE(&next_val);
+    return status;
+}

--- a/src/vm_ops_string.h
+++ b/src/vm_ops_string.h
@@ -34,5 +34,6 @@ vigil_status_t vigil_vm_op_string_fields(vigil_vm_t *vm, vigil_vm_frame_t *frame
 vigil_status_t vigil_vm_op_string_equal_fold(vigil_vm_t *vm, vigil_vm_frame_t *frame, vigil_error_t *error);
 vigil_status_t vigil_vm_op_string_cut(vigil_vm_t *vm, vigil_vm_frame_t *frame, vigil_error_t *error);
 vigil_status_t vigil_vm_op_string_join(vigil_vm_t *vm, vigil_vm_frame_t *frame, vigil_error_t *error);
+vigil_status_t vigil_vm_op_string_next_char(vigil_vm_t *vm, vigil_vm_frame_t *frame, vigil_error_t *error);
 
 #endif /* VIGIL_VM_OPS_STRING_H */

--- a/tests/chunk_test.c
+++ b/tests/chunk_test.c
@@ -508,7 +508,7 @@ TEST(VigilChunkTest, DisassembleRejectsTruncatedU32OperandInstructions)
 TEST(VigilChunkTest, OpcodeNameReturnsUnknownForOutOfRangeOpcode)
 {
     EXPECT_STREQ(vigil_opcode_name(VIGIL_OPCODE_RETURN), "RETURN");
-    EXPECT_STREQ(vigil_opcode_name((vigil_opcode_t)(VIGIL_OPCODE_MULTIPLY_F64_STORE + 1)), "UNKNOWN");
+    EXPECT_STREQ(vigil_opcode_name((vigil_opcode_t)(VIGIL_OPCODE_STRING_NEXT_CHAR + 1)), "UNKNOWN");
 }
 
 TEST(VigilChunkTest, UsesRuntimeAllocatorHooks)

--- a/tests/compiler_test.c
+++ b/tests/compiler_test.c
@@ -2938,7 +2938,7 @@ TEST(VigilCompilerTest, RejectsInvalidForInBindingsAndIterables)
     EXPECT_EQ(vigil_compile_source(&registry, source_id, &function, &diagnostics, &error), VIGIL_STATUS_SYNTAX_ERROR);
     ASSERT_EQ(vigil_diagnostic_list_count(&diagnostics), 1U);
     EXPECT_STREQ(vigil_string_c_str(&vigil_diagnostic_list_get(&diagnostics, 0U)->message),
-                 "for-in requires an array or map iterable");
+                 "for-in requires an array, map, or string iterable");
 
     vigil_diagnostic_list_free(&diagnostics);
     vigil_source_registry_free(&registry);


### PR DESCRIPTION
Extends `for-in` to iterate over strings by UTF-8 codepoint:

```vigil
for ch in "hello" {
    fmt.println(ch);   // "h", "e", "l", "l", "o"
}
```

Each `ch` is a one-codepoint `string`. Unicode is handled correctly — `"héllo"` yields 5 iterations, not 6.

Byte-level iteration already works via `.bytes()`:

```vigil
for b in "hello".bytes() {
    // b is u8
}
```

## Implementation

- New `STRING_NEXT_CHAR` opcode (189): takes `(string, byte_offset)`, pushes `(one-codepoint string, next_byte_offset)`. This gives O(n) iteration without codepoint-index seeking.
- Compiler `for-in` extended to accept `string` iterables. Uses byte offset as the loop counter, `GET_STRING_SIZE` as the bound, and `STRING_NEXT_CHAR` for element extraction. The byte offset is advanced by the opcode itself, so the standard `index += 1` increment is skipped.
- Opcode wired through chunk disassembler, register VM translator, and register VM dispatch.

## Tests

- Integration test covering ASCII, Unicode, empty string, byte iteration, and `break` in string loops.
- Updated existing compiler test for the new error message ("for-in requires an array, map, or string iterable").
- Updated chunk test for new opcode bounds.