### PR TITLE
Allow discarding multi-return values from bare function/method calls

### DIFF
--- a/integration_tests/test_regression.py
+++ b/integration_tests/test_regression.py
@@ -586,6 +586,20 @@ class ErrorFlowTest(unittest.TestCase):
             }
         """, 42)
 
+    def test_discard_multi_return_bare_call(self) -> None:
+        self._run("""
+            fn two() -> (i32, i32) { return 1, 2; }
+            fn three() -> (i32, i32, i32) { return 10, 20, 30; }
+            fn main() -> i32 {
+                two();
+                three();
+                i32 a, i32 b = two();
+                if a != 1 { return 1; }
+                if b != 2 { return 2; }
+                return 0;
+            }
+        """, 0)
+
     def test_standalone_err_variable(self) -> None:
         self._run("""
             fn main() -> i32 {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -12915,14 +12915,6 @@ static vigil_status_t vigil_parser_parse_expression_statement_internal(vigil_par
     {
         return status;
     }
-    if (expression_result.type_count > 1U)
-    {
-        return vigil_parser_report(state,
-                                   vigil_parser_previous(state) == NULL ? vigil_parser_fallback_span(state)
-                                                                        : vigil_parser_previous(state)->span,
-                                   "multi-value expressions must be bound explicitly");
-    }
-
     last_token = vigil_parser_previous(state);
     if (expect_semicolon)
     {
@@ -12933,7 +12925,19 @@ static vigil_status_t vigil_parser_parse_expression_statement_internal(vigil_par
         }
     }
 
-    if (!vigil_parser_type_is_void(expression_result.type))
+    if (expression_result.type_count > 1U)
+    {
+        vigil_source_span_t span = last_token == NULL ? vigil_parser_fallback_span(state) : last_token->span;
+        for (size_t i = 0; i < expression_result.type_count; i++)
+        {
+            status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_POP, span);
+            if (status != VIGIL_STATUS_OK)
+            {
+                return status;
+            }
+        }
+    }
+    else if (!vigil_parser_type_is_void(expression_result.type))
     {
         status = vigil_parser_emit_opcode(state, VIGIL_OPCODE_POP,
                                           last_token == NULL ? vigil_parser_fallback_span(state) : last_token->span);


### PR DESCRIPTION
When a function or method returns multiple values, calling it as a bare statement (without binding the results) now compiles successfully. The compiler emits a POP instruction for each return value instead of rejecting the expression with 'multi-value expressions must be bound explicitly'.

Single-return discard behavior is unchanged.

Closes #375

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
