### PR TITLE
Add struct type — plain data classes

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -635,6 +635,39 @@ switch e.kind() {
 }
 ```
 
+## Structs
+
+Structs are plain data types — all fields are public, no methods, no `init()`:
+
+```
+struct Point {
+    f64 x
+    f64 y
+}
+
+struct Color {
+    i32 r
+    i32 g
+    i32 b
+    i32 a
+}
+```
+
+Construct with positional arguments:
+
+```
+Point p = Point(1.0, 2.0)
+Color red = Color(255, 0, 0, 255)
+```
+
+Fields are mutable:
+
+```
+p.x = 10.0
+```
+
+Use `class` instead of `struct` when you need methods, `init()`, interfaces, or visibility control.
+
 ## Classes
 
 ```

--- a/include/vigil/token.h
+++ b/include/vigil/token.h
@@ -88,7 +88,8 @@ extern "C"
         VIGIL_TOKEN_SHIFT_LEFT = 70,
         VIGIL_TOKEN_SHIFT_RIGHT = 71,
         VIGIL_TOKEN_EXTERN = 72,
-        VIGIL_TOKEN_WALRUS = 73
+        VIGIL_TOKEN_WALRUS = 73,
+        VIGIL_TOKEN_STRUCT = 74
     } vigil_token_kind_t;
 
     typedef struct vigil_token

--- a/src/compiler_declarations.c
+++ b/src/compiler_declarations.c
@@ -1690,3 +1690,81 @@ vigil_status_t vigil_program_parse_class_declaration(vigil_program_state_t *prog
 
     return vigil_program_synthesize_class_constructor(program, decl);
 }
+
+/* ── Struct declarations ──────────────────────────────────────────── */
+
+vigil_status_t vigil_program_parse_struct_declaration(vigil_program_state_t *program, size_t *cursor, int is_public)
+{
+    vigil_status_t status;
+    const vigil_token_t *struct_token;
+    const vigil_token_t *name_token;
+    const vigil_token_t *type_token;
+    const char *name_text;
+    size_t name_length;
+    vigil_class_decl_t *decl;
+
+    struct_token = vigil_program_cursor_peek(program, *cursor);
+    if (struct_token == NULL || struct_token->kind != VIGIL_TOKEN_STRUCT)
+        return vigil_compile_report(
+            program, struct_token == NULL ? vigil_program_eof_span(program) : struct_token->span, "expected 'struct'");
+    vigil_program_cursor_advance(program, cursor);
+
+    name_token = vigil_program_cursor_peek(program, *cursor);
+    if (name_token == NULL || name_token->kind != VIGIL_TOKEN_IDENTIFIER)
+        return vigil_compile_report(program, struct_token->span, "expected struct name");
+    name_text = vigil_program_token_text(program, name_token, &name_length);
+
+    status = class_check_name_conflicts(program, name_token, name_text, name_length);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    status = vigil_program_grow_classes(program, program->class_count + 1U);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    decl = &program->classes[program->class_count];
+    memset(decl, 0, sizeof(*decl));
+    decl->constructor_function_index = (size_t)-1;
+    decl->source_id = program->source->id;
+    decl->name = name_text;
+    decl->name_length = name_length;
+    decl->name_span = name_token->span;
+    decl->is_public = is_public;
+    program->class_count += 1U;
+    vigil_program_cursor_advance(program, cursor);
+
+    type_token = vigil_program_cursor_peek(program, *cursor);
+    if (type_token == NULL || type_token->kind != VIGIL_TOKEN_LBRACE)
+        return vigil_compile_report(program, name_token->span, "expected '{' after struct name");
+    vigil_program_cursor_advance(program, cursor);
+
+    while (1)
+    {
+        type_token = vigil_program_cursor_peek(program, *cursor);
+        if (type_token == NULL)
+            return vigil_compile_report(program, vigil_program_eof_span(program), "expected '}' after struct body");
+        if (type_token->kind == VIGIL_TOKEN_RBRACE)
+        {
+            vigil_program_cursor_advance(program, cursor);
+            break;
+        }
+        if (type_token->kind == VIGIL_TOKEN_SEMICOLON)
+        {
+            vigil_program_cursor_advance(program, cursor);
+            continue;
+        }
+        if (type_token->kind == VIGIL_TOKEN_FN)
+            return vigil_compile_report(program, type_token->span, "structs cannot contain methods");
+        if (type_token->kind == VIGIL_TOKEN_PUB)
+            return vigil_compile_report(program, type_token->span, "struct fields are public by default; remove 'pub'");
+
+        status = class_parse_field(program, cursor, decl, name_token, 1);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+    }
+
+    if (decl->field_count == 0U)
+        return vigil_compile_report(program, name_token->span, "structs must have at least one field");
+
+    return VIGIL_STATUS_OK;
+}

--- a/src/compiler_semantics.c
+++ b/src/compiler_semantics.c
@@ -289,6 +289,8 @@ static vigil_status_t parse_one_declaration(vigil_program_state_t *program, size
         return vigil_program_parse_interface_declaration(program, cursor, is_public);
     if (token->kind == VIGIL_TOKEN_CLASS)
         return vigil_program_parse_class_declaration(program, cursor, is_public);
+    if (token->kind == VIGIL_TOKEN_STRUCT)
+        return vigil_program_parse_struct_declaration(program, cursor, is_public);
     if (vigil_program_is_global_variable_declaration_start(program, *cursor))
         return vigil_program_parse_global_variable_declaration(program, cursor, is_public);
     if (token->kind == VIGIL_TOKEN_EXTERN)
@@ -304,8 +306,8 @@ static vigil_status_t parse_one_declaration(vigil_program_state_t *program, size
     }
 
     return vigil_compile_report(program, token->span,
-                                "expected top-level 'import', 'const', 'enum', 'interface', 'class', variable "
-                                "declaration, 'extern fn', or 'fn'");
+                                "expected top-level 'import', 'const', 'enum', 'interface', 'class', 'struct', "
+                                "variable declaration, 'extern fn', or 'fn'");
 }
 
 static vigil_status_t emit_implicit_void_return(vigil_parser_state_t *state, vigil_source_span_t span)

--- a/src/fmt.c
+++ b/src/fmt.c
@@ -295,7 +295,7 @@ static const uint64_t kNoSpaceAfterBits[2] = {
 static const uint64_t kTopLevelDeclBits[2] = {
     TOK_BIT(VIGIL_TOKEN_FN) | TOK_BIT(VIGIL_TOKEN_CLASS) | TOK_BIT(VIGIL_TOKEN_INTERFACE) |
     TOK_BIT(VIGIL_TOKEN_ENUM) | TOK_BIT(VIGIL_TOKEN_CONST) | TOK_BIT(VIGIL_TOKEN_PUB),
-    0
+    TOK_BIT(VIGIL_TOKEN_STRUCT)
 };
 
 static const uint64_t kLiteralBraceOpenerBits[2] = {

--- a/src/internal/vigil_compiler_types.h
+++ b/src/internal/vigil_compiler_types.h
@@ -616,6 +616,7 @@ vigil_status_t vigil_program_parse_constant_declaration(vigil_program_state_t *p
 vigil_status_t vigil_program_parse_enum_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_interface_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_class_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
+vigil_status_t vigil_program_parse_struct_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t vigil_program_parse_extern_fn(vigil_program_state_t *program, size_t *cursor, int is_public);
 vigil_status_t parse_fn_declaration(vigil_program_state_t *program, size_t *cursor, int is_public);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -165,6 +165,7 @@ static vigil_token_kind_t vigil_lexer_keyword_kind(const char *text, size_t leng
         {"default", 7U, VIGIL_TOKEN_DEFAULT},
         {"continue", 8U, VIGIL_TOKEN_CONTINUE},
         {"interface", 9U, VIGIL_TOKEN_INTERFACE},
+        {"struct", 6U, VIGIL_TOKEN_STRUCT},
     };
     size_t i;
 

--- a/src/token.c
+++ b/src/token.c
@@ -3,7 +3,7 @@
 #include "internal/vigil_internal.h"
 #include "vigil/token.h"
 
-static const char *const kVigilTokenNames[VIGIL_TOKEN_WALRUS + 1] = {
+static const char *const kVigilTokenNames[VIGIL_TOKEN_STRUCT + 1] = {
     [VIGIL_TOKEN_EOF] = "eof",
     [VIGIL_TOKEN_IDENTIFIER] = "identifier",
     [VIGIL_TOKEN_INT_LITERAL] = "int_literal",
@@ -78,6 +78,7 @@ static const char *const kVigilTokenNames[VIGIL_TOKEN_WALRUS + 1] = {
     [VIGIL_TOKEN_SHIFT_RIGHT] = "shift_right",
     [VIGIL_TOKEN_EXTERN] = "extern",
     [VIGIL_TOKEN_WALRUS] = "walrus",
+    [VIGIL_TOKEN_STRUCT] = "struct",
 };
 
 static int vigil_token_list_validate_mutable(const vigil_token_list_t *list, vigil_error_t *error)
@@ -242,7 +243,7 @@ vigil_status_t vigil_token_list_append(vigil_token_list_t *list, vigil_token_kin
 
 const char *vigil_token_kind_name(vigil_token_kind_t kind)
 {
-    if (kind > VIGIL_TOKEN_WALRUS)
+    if (kind > VIGIL_TOKEN_STRUCT)
     {
         return "unknown";
     }

--- a/tests/compiler_test.c
+++ b/tests/compiler_test.c
@@ -3434,6 +3434,52 @@ TEST(VigilCompilerTest, RejectsWalrusWithVoidExpression)
                                    "cannot infer type from void expression");
 }
 
+TEST(VigilCompilerTest, StructDeclarationAndConstruction)
+{
+    EXPECT_EQ(CompileAndRun(vigil_test_failed_, "struct Point { f64 x; f64 y; }\n"
+                                                "fn main() -> i32 {\n"
+                                                "    Point p = Point(3.0, 4.0);\n"
+                                                "    if p.x != 3.0 { return 1; }\n"
+                                                "    if p.y != 4.0 { return 2; }\n"
+                                                "    p.x = 10.0;\n"
+                                                "    if p.x != 10.0 { return 3; }\n"
+                                                "    return 0;\n"
+                                                "}\n"),
+              0);
+}
+
+TEST(VigilCompilerTest, StructAsParameter)
+{
+    EXPECT_EQ(CompileAndRun(vigil_test_failed_, "struct Pair { i32 a; i32 b; }\n"
+                                                "fn sum(Pair p) -> i32 { return p.a + p.b; }\n"
+                                                "fn main() -> i32 { return sum(Pair(17, 25)); }\n"),
+              42);
+}
+
+TEST(VigilCompilerTest, RejectsStructWithMethods)
+{
+    ExpectSingleCompilerDiagnostic(vigil_test_failed_,
+                                   "struct Bad { i32 x; fn foo() -> void {} }\n"
+                                   "fn main() -> i32 { return 0; }\n",
+                                   "structs cannot contain methods");
+}
+
+TEST(VigilCompilerTest, RejectsEmptyStruct)
+{
+    ExpectSingleCompilerDiagnostic(vigil_test_failed_,
+                                   "struct Empty {}\n"
+                                   "fn main() -> i32 { return 0; }\n",
+                                   "structs must have at least one field");
+}
+
+TEST(VigilCompilerTest, RejectsStructWithPub)
+{
+    ExpectSingleCompilerDiagnostic(vigil_test_failed_,
+                                   "struct Bad { pub i32 x; }\n"
+                                   "fn main() -> i32 { return 0; }\n",
+                                   "struct fields are public by default; remove 'pub'");
+}
+
 static void register_compiler_defer_tests(void)
 {
     REGISTER_TEST(VigilCompilerTest, CompilesAndExecutesDeferredFunctionValues);
@@ -3579,4 +3625,9 @@ void register_compiler_tests(void)
     REGISTER_TEST(VigilCompilerTest, RejectsConstWalrusReassignment);
     REGISTER_TEST(VigilCompilerTest, RejectsParameterReassignment);
     REGISTER_TEST(VigilCompilerTest, RejectsWalrusWithVoidExpression);
+    REGISTER_TEST(VigilCompilerTest, StructDeclarationAndConstruction);
+    REGISTER_TEST(VigilCompilerTest, StructAsParameter);
+    REGISTER_TEST(VigilCompilerTest, RejectsStructWithMethods);
+    REGISTER_TEST(VigilCompilerTest, RejectsEmptyStruct);
+    REGISTER_TEST(VigilCompilerTest, RejectsStructWithPub);
 }


### PR DESCRIPTION
## Summary

Adds a `struct` keyword for declaring plain data types with all-public fields, no methods, and positional construction.

## Usage

```vigil
struct Point {
    f64 x
    f64 y
}

struct Color {
    i32 r
    i32 g
    i32 b
    i32 a
}

fn main() -> i32 {
    p := Point(1.0, 2.0)
    p.x = 10.0              // fields are mutable

    red := Color(255, 0, 0, 255)
    fmt.println(f"({red.r}, {red.g}, {red.b})")

    return 0
}
```

## Design

- All fields public — no `pub` keyword needed (or allowed)
- No methods — use `class` when you need behavior
- No `init()` — positional constructor auto-generated from field order
- No interfaces — structs are pure data
- Reference semantics — same as classes
- Works with `:=` inference: `p := Point(1.0, 2.0)`

## When to use struct vs class

| | `struct` | `class` |
|---|---|---|
| Fields | all public | `pub` opt-in |
| Methods | ❌ | ✅ |
| `init()` | ❌ (auto) | ✅ |
| Interfaces | ❌ | ✅ |
| Use case | data containers | behavior + state |

## Diagnostics

- `structs cannot contain methods` — `fn` inside struct body
- `struct fields are public by default; remove 'pub'` — explicit `pub` rejected
- `structs must have at least one field` — empty struct body

## Tests

5 new tests, 1102 total passing, 116 integration tests passing.
