### PR TITLE
Phase 2: Slider and Select widgets for gui plugin — #399

### DIFF
--- a/plugins/gui/backends/gui_cocoa.m
+++ b/plugins/gui/backends/gui_cocoa.m
@@ -503,6 +503,72 @@ static void cocoa_checkbox_set_checked(void *handle, bool checked)
     if (handle) sendv_long((id)handle, sel("setState:"), checked ? 1 : 0);
 }
 
+/* ── Slider ───────────────────────────────────────────────────────── */
+
+static void *cocoa_slider_create(void *parent, double min_val, double max_val)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id slider = send_rect(send0(cls("NSSlider"), sel("alloc")),
+                          sel("initWithFrame:"), CGRectMake_(0, 0, 200, 24));
+    ((void (*)(id, SEL, double))objc_msgSend)(slider, sel("setMinValue:"), min_val);
+    ((void (*)(id, SEL, double))objc_msgSend)(slider, sel("setMaxValue:"), max_val);
+    ((void (*)(id, SEL, double))objc_msgSend)(slider, sel("setDoubleValue:"), min_val);
+    sendv_id(cv, sel("addSubview:"), slider);
+    register_widget_parent(slider, cv);
+    return (void *)slider;
+}
+
+static void cocoa_slider_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static double cocoa_slider_get_value(void *handle)
+{
+    if (!handle) return 0.0;
+    return ((double (*)(id, SEL))objc_msgSend)((id)handle, sel("doubleValue"));
+}
+
+static void cocoa_slider_set_value(void *handle, double value)
+{
+    if (handle) ((void (*)(id, SEL, double))objc_msgSend)((id)handle, sel("setDoubleValue:"), value);
+}
+
+/* ── Select ───────────────────────────────────────────────────────── */
+
+static void *cocoa_select_create(void *parent)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id popup = send_rect(send0(cls("NSPopUpButton"), sel("alloc")),
+                         sel("initWithFrame:"), CGRectMake_(0, 0, 200, 24));
+    sendv_id(cv, sel("addSubview:"), popup);
+    register_widget_parent(popup, cv);
+    return (void *)popup;
+}
+
+static void cocoa_select_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static void cocoa_select_add_item(void *handle, const char *text)
+{
+    if (handle) sendv_id((id)handle, sel("addItemWithTitle:"), nsstr(text));
+}
+
+static int cocoa_select_get_index(void *handle)
+{
+    if (!handle) return -1;
+    return (int)((long (*)(id, SEL))objc_msgSend)((id)handle, sel("indexOfSelectedItem"));
+}
+
+static void cocoa_select_set_index(void *handle, int index)
+{
+    if (handle) sendv_long((id)handle, sel("selectItemAtIndex:"), (long)index);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void cocoa_widget_grid(void *handle, int col, int row)
@@ -582,6 +648,15 @@ const gui_backend_t gui_backend_cocoa = {
     .checkbox_set_text             = cocoa_checkbox_set_text,
     .checkbox_get_checked          = cocoa_checkbox_get_checked,
     .checkbox_set_checked          = cocoa_checkbox_set_checked,
+    .slider_create                 = cocoa_slider_create,
+    .slider_destroy                = cocoa_slider_destroy,
+    .slider_get_value              = cocoa_slider_get_value,
+    .slider_set_value              = cocoa_slider_set_value,
+    .select_create                 = cocoa_select_create,
+    .select_destroy                = cocoa_select_destroy,
+    .select_add_item               = cocoa_select_add_item,
+    .select_get_index              = cocoa_select_get_index,
+    .select_set_index              = cocoa_select_set_index,
     .widget_grid                   = cocoa_widget_grid,
     .widget_grid_remove            = cocoa_widget_grid_remove,
     .container_grid_columnconfigure = cocoa_container_grid_columnconfigure,

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -84,6 +84,13 @@ typedef void (*fn_gtk_widget_set_vexpand)(GtkWidget *, gboolean);
 typedef gulong (*fn_g_signal_connect_data)(void *, const char *, GCallback, void *, GClosureNotify, int);
 typedef GtkWidget *(*fn_gtk_entry_new)(void);
 typedef GtkWidget *(*fn_gtk_check_button_new_with_label)(const char *);
+typedef GtkWidget *(*fn_gtk_scale_new_with_range)(int, double, double, double);
+typedef GtkWidget *(*fn_gtk_combo_box_text_new)(void);
+typedef void (*fn_gtk_combo_box_text_append_text)(GtkWidget *, const char *);
+typedef gint (*fn_gtk_combo_box_get_active)(GtkWidget *);
+typedef void (*fn_gtk_combo_box_set_active)(GtkWidget *, gint);
+typedef double (*fn_gtk_range_get_value)(GtkWidget *);
+typedef void (*fn_gtk_range_set_value)(GtkWidget *, double);
 
 /* GTK3-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk3)(int type);
@@ -180,6 +187,13 @@ static struct
     fn_g_signal_connect_data g_signal_connect_data;
     fn_gtk_entry_new gtk_entry_new;
     fn_gtk_check_button_new_with_label gtk_check_button_new_with_label;
+    fn_gtk_scale_new_with_range gtk_scale_new_with_range;
+    fn_gtk_combo_box_text_new gtk_combo_box_text_new;
+    fn_gtk_combo_box_text_append_text gtk_combo_box_text_append_text;
+    fn_gtk_combo_box_get_active gtk_combo_box_get_active;
+    fn_gtk_combo_box_set_active gtk_combo_box_set_active;
+    fn_gtk_range_get_value gtk_range_get_value;
+    fn_gtk_range_set_value gtk_range_set_value;
 } G;
 
 static const gtk_version_ops_t *g_vops = NULL;
@@ -661,6 +675,13 @@ static bool load_shared_symbols(void)
     LOAD_SHARED(g_signal_connect_data);
     LOAD_SHARED(gtk_entry_new);
     LOAD_SHARED(gtk_check_button_new_with_label);
+    LOAD_SHARED(gtk_scale_new_with_range);
+    LOAD_SHARED(gtk_combo_box_text_new);
+    LOAD_SHARED(gtk_combo_box_text_append_text);
+    LOAD_SHARED(gtk_combo_box_get_active);
+    LOAD_SHARED(gtk_combo_box_set_active);
+    LOAD_SHARED(gtk_range_get_value);
+    LOAD_SHARED(gtk_range_set_value);
     return true;
 fail:
     return false;
@@ -933,6 +954,96 @@ static void gtk_be_checkbox_set_checked(void *handle, bool checked)
         g_vops->checkbox_set_active(handle, checked ? 1 : 0);
 }
 
+/* ── Slider ───────────────────────────────────────────────────────── */
+
+static void on_slider_changed(GtkWidget *widget, void *data)
+{
+    (void)data;
+    gui_callback_t *cb = find_callback(widget, GUI_EVENT_CHANGE);
+    if (cb && cb->fn)
+        cb->fn(cb->user_data);
+}
+
+static void *gtk_be_slider_create(void *parent, double min_val, double max_val)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    GtkWidget *scale = G.gtk_scale_new_with_range(0, min_val, max_val, 1.0);
+    G.g_signal_connect_data(scale, "value-changed", (GCallback)on_slider_changed, NULL, NULL, 0);
+    register_widget_parent(scale, grid);
+    return scale;
+}
+
+static void gtk_be_slider_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static double gtk_be_slider_get_value(void *handle)
+{
+    if (!handle)
+        return 0.0;
+    return G.gtk_range_get_value(handle);
+}
+
+static void gtk_be_slider_set_value(void *handle, double value)
+{
+    if (handle)
+        G.gtk_range_set_value(handle, value);
+}
+
+/* ── Select ───────────────────────────────────────────────────────── */
+
+static void on_select_changed(GtkWidget *widget, void *data)
+{
+    (void)data;
+    gui_callback_t *cb = find_callback(widget, GUI_EVENT_CHANGE);
+    if (cb && cb->fn)
+        cb->fn(cb->user_data);
+}
+
+static void *gtk_be_select_create(void *parent)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    GtkWidget *combo = G.gtk_combo_box_text_new();
+    G.g_signal_connect_data(combo, "changed", (GCallback)on_select_changed, NULL, NULL, 0);
+    register_widget_parent(combo, grid);
+    return combo;
+}
+
+static void gtk_be_select_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void gtk_be_select_add_item(void *handle, const char *text)
+{
+    if (handle)
+        G.gtk_combo_box_text_append_text(handle, text);
+}
+
+static int gtk_be_select_get_index(void *handle)
+{
+    if (!handle)
+        return -1;
+    return G.gtk_combo_box_get_active(handle);
+}
+
+static void gtk_be_select_set_index(void *handle, int index)
+{
+    if (handle)
+        G.gtk_combo_box_set_active(handle, index);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void gtk_be_widget_grid(void *handle, int col, int row)
@@ -1023,6 +1134,15 @@ const gui_backend_t gui_backend_gtk = {
     .checkbox_set_text = gtk_be_checkbox_set_text,
     .checkbox_get_checked = gtk_be_checkbox_get_checked,
     .checkbox_set_checked = gtk_be_checkbox_set_checked,
+    .slider_create = gtk_be_slider_create,
+    .slider_destroy = gtk_be_slider_destroy,
+    .slider_get_value = gtk_be_slider_get_value,
+    .slider_set_value = gtk_be_slider_set_value,
+    .select_create = gtk_be_select_create,
+    .select_destroy = gtk_be_select_destroy,
+    .select_add_item = gtk_be_select_add_item,
+    .select_get_index = gtk_be_select_get_index,
+    .select_set_index = gtk_be_select_set_index,
     .widget_grid = gtk_be_widget_grid,
     .widget_grid_remove = gtk_be_widget_grid_remove,
     .container_grid_columnconfigure = gtk_be_container_grid_columnconfigure,

--- a/plugins/gui/backends/gui_stub.c
+++ b/plugins/gui/backends/gui_stub.c
@@ -69,6 +69,33 @@ static void stub_set_bool(void *h, bool v)
     (void)h;
     (void)v;
 }
+static void *stub_create_dd(void *p, double a, double b)
+{
+    (void)p;
+    (void)a;
+    (void)b;
+    return NULL;
+}
+static double stub_get_double(void *h)
+{
+    (void)h;
+    return 0.0;
+}
+static void stub_set_double(void *h, double v)
+{
+    (void)h;
+    (void)v;
+}
+static int stub_get_int(void *h)
+{
+    (void)h;
+    return -1;
+}
+static void stub_set_int(void *h, int v)
+{
+    (void)h;
+    (void)v;
+}
 static void stub_grid(void *h, int c, int r)
 {
     (void)h;
@@ -123,6 +150,15 @@ const gui_backend_t gui_backend_stub = {
     .checkbox_set_text = stub_set_text,
     .checkbox_get_checked = stub_get_bool,
     .checkbox_set_checked = stub_set_bool,
+    .slider_create = stub_create_dd,
+    .slider_destroy = stub_destroy,
+    .slider_get_value = stub_get_double,
+    .slider_set_value = stub_set_double,
+    .select_create = stub_create_notext,
+    .select_destroy = stub_destroy,
+    .select_add_item = stub_set_text,
+    .select_get_index = stub_get_int,
+    .select_set_index = stub_set_int,
     .widget_grid = stub_grid,
     .widget_grid_remove = stub_grid_remove,
     .container_grid_columnconfigure = stub_grid_configure,

--- a/plugins/gui/backends/gui_win32.c
+++ b/plugins/gui/backends/gui_win32.c
@@ -21,6 +21,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#include <commctrl.h>
 #include <windows.h>
 
 /* ── Grid layout engine ──────────────────────────────────────────── */
@@ -477,6 +478,80 @@ static void win32_checkbox_set_checked(void *handle, bool checked)
         SendMessageW((HWND)handle, BM_SETCHECK, checked ? BST_CHECKED : BST_UNCHECKED, 0);
 }
 
+/* ── Slider ──────────────────────────────────────────────────────── */
+
+static void *win32_slider_create(void *parent, double min_val, double max_val)
+{
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(0, TRACKBAR_CLASSW, L"", WS_CHILD | WS_VISIBLE | TBS_HORZ | TBS_AUTOTICKS, 0, 0, 200,
+                                30, (HWND)parent, (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+    {
+        SendMessageW(hwnd, TBM_SETRANGEMIN, 0, (LPARAM)(int)min_val);
+        SendMessageW(hwnd, TBM_SETRANGEMAX, 0, (LPARAM)(int)max_val);
+        register_widget_parent(hwnd, (HWND)parent);
+    }
+    return (void *)hwnd;
+}
+
+static void win32_slider_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static double win32_slider_get_value(void *handle)
+{
+    if (!handle)
+        return 0.0;
+    return (double)SendMessageW((HWND)handle, TBM_GETPOS, 0, 0);
+}
+
+static void win32_slider_set_value(void *handle, double value)
+{
+    if (handle)
+        SendMessageW((HWND)handle, TBM_SETPOS, 1, (LPARAM)(int)value);
+}
+
+/* ── Select ──────────────────────────────────────────────────────── */
+
+static void *win32_select_create(void *parent)
+{
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(0, L"COMBOBOX", L"", WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | CBS_HASSTRINGS, 0, 0,
+                                200, 200, (HWND)parent, (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+        register_widget_parent(hwnd, (HWND)parent);
+    return (void *)hwnd;
+}
+
+static void win32_select_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static void win32_select_add_item(void *handle, const char *text)
+{
+    if (handle)
+        SendMessageW((HWND)handle, CB_ADDSTRING, 0, (LPARAM)to_wide(text));
+}
+
+static int win32_select_get_index(void *handle)
+{
+    if (!handle)
+        return -1;
+    return (int)SendMessageW((HWND)handle, CB_GETCURSEL, 0, 0);
+}
+
+static void win32_select_set_index(void *handle, int index)
+{
+    if (handle)
+        SendMessageW((HWND)handle, CB_SETCURSEL, (WPARAM)index, 0);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void win32_widget_grid(void *handle, int col, int row)
@@ -559,6 +634,15 @@ const gui_backend_t gui_backend_win32 = {
     .checkbox_set_text = win32_checkbox_set_text,
     .checkbox_get_checked = win32_checkbox_get_checked,
     .checkbox_set_checked = win32_checkbox_set_checked,
+    .slider_create = win32_slider_create,
+    .slider_destroy = win32_slider_destroy,
+    .slider_get_value = win32_slider_get_value,
+    .slider_set_value = win32_slider_set_value,
+    .select_create = win32_select_create,
+    .select_destroy = win32_select_destroy,
+    .select_add_item = win32_select_add_item,
+    .select_get_index = win32_select_get_index,
+    .select_set_index = win32_select_set_index,
     .widget_grid = win32_widget_grid,
     .widget_grid_remove = win32_widget_grid_remove,
     .container_grid_columnconfigure = win32_container_grid_columnconfigure,

--- a/plugins/gui/gui.c
+++ b/plugins/gui/gui.c
@@ -79,12 +79,19 @@ static gui_handle_registry_t g_labels = {{0}, 0};
 static gui_handle_registry_t g_buttons = {{0}, 0};
 static gui_handle_registry_t g_entries = {{0}, 0};
 static gui_handle_registry_t g_checkboxes = {{0}, 0};
+static gui_handle_registry_t g_sliders = {{0}, 0};
+static gui_handle_registry_t g_selects = {{0}, 0};
 
 /* ── Stack helpers ───────────────────────────────────────────────── */
 
 static int32_t gui_arg_i32(vigil_vm_t *vm, size_t base, size_t idx)
 {
     return vigil_nanbox_decode_i32(vigil_vm_stack_get(vm, base + idx));
+}
+
+static double gui_arg_f64(vigil_vm_t *vm, size_t base, size_t idx)
+{
+    return vigil_nanbox_decode_double(vigil_vm_stack_get(vm, base + idx));
 }
 
 static const char *gui_arg_str(vigil_vm_t *vm, size_t base, size_t idx, char *buf, size_t bufsz)
@@ -172,6 +179,8 @@ enum
     GUI_BUTTON_CLASS_INDEX = 3U,
     GUI_ENTRY_CLASS_INDEX = 4U,
     GUI_CHECKBOX_CLASS_INDEX = 5U,
+    GUI_SLIDER_CLASS_INDEX = 6U,
+    GUI_SELECT_CLASS_INDEX = 7U,
 };
 
 /* ── Callback bridge ─────────────────────────────────────────────── */
@@ -753,6 +762,211 @@ static vigil_status_t gui_checkbox_on_change(vigil_vm_t *vm, size_t arg_count, v
     return VIGIL_STATUS_OK;
 }
 
+/* ── gui.Slider ──────────────────────────────────────────────────── */
+
+static vigil_status_t gui_slider_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    double min_val = gui_arg_f64(vm, base, 2);
+    double max_val = gui_arg_f64(vm, base, 3);
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_SLIDER_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+
+    void *native = g_backend->slider_create(parent, min_val, max_val);
+    int64_t handle;
+    gui_handle_store(&g_sliders, native, &handle);
+    gui_push_handle_instance(vm, GUI_SLIDER_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_slider_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_sliders, h);
+    if (native && g_backend)
+        g_backend->slider_destroy(native);
+    gui_handle_clear(&g_sliders, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_slider_get(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    double val = 0.0;
+    void *native = gui_handle_get(&g_sliders, h);
+    if (native && g_backend)
+        val = g_backend->slider_get_value(native);
+    vigil_value_t v = vigil_nanbox_encode_double(val);
+    return vigil_vm_stack_push(vm, &v, error);
+}
+
+static vigil_status_t gui_slider_set(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    double val = gui_arg_f64(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_sliders, h);
+    if (native && g_backend)
+        g_backend->slider_set_value(native, val);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_slider_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_sliders, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_slider_on_change(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_value_t closure = vigil_vm_stack_get(vm, base + 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_sliders, h);
+    if (native && g_backend)
+    {
+        gui_closure_t *c = gui_closure_store(vm, closure);
+        if (c)
+        {
+            gui_callback_t cb = {gui_closure_invoke, c};
+            g_backend->set_callback(native, GUI_EVENT_CHANGE, cb);
+        }
+    }
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+/* ── gui.Select ──────────────────────────────────────────────────── */
+
+static vigil_status_t gui_select_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_SELECT_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+
+    void *native = g_backend->select_create(parent);
+    int64_t handle;
+    gui_handle_store(&g_selects, native, &handle);
+    gui_push_handle_instance(vm, GUI_SELECT_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_select_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+        g_backend->select_destroy(native);
+    gui_handle_clear(&g_selects, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_select_add_item(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    char buf[256];
+    const char *text = gui_arg_str(vm, base, 1, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+        g_backend->select_add_item(native, text);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_select_get(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    int idx = -1;
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+        idx = g_backend->select_get_index(native);
+    return gui_push_i32(vm, (int32_t)idx, error);
+}
+
+static vigil_status_t gui_select_set(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int idx = gui_arg_i32(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+        g_backend->select_set_index(native, idx);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_select_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_select_on_change(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_value_t closure = vigil_vm_stack_get(vm, base + 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_selects, h);
+    if (native && g_backend)
+    {
+        gui_closure_t *c = gui_closure_store(vm, closure);
+        if (c)
+        {
+            gui_callback_t cb = {gui_closure_invoke, c};
+            g_backend->set_callback(native, GUI_EVENT_CHANGE, cb);
+        }
+    }
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── gui.message_box (module-level function) ─────────────────────── */
 
 static vigil_status_t gui_fn_message_box(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
@@ -785,6 +999,11 @@ static const int rt_i32_i32[] = {VIGIL_TYPE_I32, VIGIL_TYPE_I32};
 static const int rt_str[] = {VIGIL_TYPE_STRING};
 static const int rt_bool[] = {VIGIL_TYPE_BOOL};
 static const int p_bool[] = {VIGIL_TYPE_BOOL};
+static const int p_obj_f64_f64[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
+static const int p_f64[] = {VIGIL_TYPE_F64};
+static const int p_i32[] = {VIGIL_TYPE_I32};
+static const int rt_f64[] = {VIGIL_TYPE_F64};
+static const int rt_i32[] = {VIGIL_TYPE_I32};
 
 /* ── Macro helpers ───────────────────────────────────────────────── */
 
@@ -885,6 +1104,37 @@ static const vigil_native_class_method_t gui_checkbox_methods[] = {
     GUI_METHOD("on_change", 9U, gui_checkbox_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
 };
 
+/* ── Slider class ────────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_slider_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_slider_methods[] = {
+    GUI_STATIC("new", 3U, gui_slider_new, 3U, p_obj_f64_f64, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_slider_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("get", 3U, gui_slider_get, 0U, NULL, VIGIL_TYPE_F64, 1U, rt_f64),
+    GUI_METHOD("set", 3U, gui_slider_set, 1U, p_f64, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_slider_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("on_change", 9U, gui_slider_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
+/* ── Select class ────────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_select_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_select_methods[] = {
+    GUI_STATIC("new", 3U, gui_select_new, 1U, p_obj, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_select_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("add_item", 8U, gui_select_add_item, 1U, p_str, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("get", 3U, gui_select_get, 0U, NULL, VIGIL_TYPE_I32, 1U, rt_i32),
+    GUI_METHOD("set", 3U, gui_select_set, 1U, p_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_select_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("on_change", 9U, gui_select_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
 /* ── Class table ─────────────────────────────────────────────────── */
 
 /* clang-format off */
@@ -895,6 +1145,8 @@ static const vigil_native_class_t gui_classes[] = {
     {"Button",   6U, gui_button_fields,   1U, gui_button_methods,   sizeof(gui_button_methods)   / sizeof(gui_button_methods[0]),   NULL, NULL},
     {"Entry",    5U, gui_entry_fields,    1U, gui_entry_methods,    sizeof(gui_entry_methods)    / sizeof(gui_entry_methods[0]),    NULL, NULL},
     {"Checkbox", 8U, gui_checkbox_fields, 1U, gui_checkbox_methods, sizeof(gui_checkbox_methods) / sizeof(gui_checkbox_methods[0]), NULL, NULL},
+    {"Slider",   6U, gui_slider_fields,   1U, gui_slider_methods,   sizeof(gui_slider_methods)   / sizeof(gui_slider_methods[0]),   NULL, NULL},
+    {"Select",   6U, gui_select_fields,   1U, gui_select_methods,   sizeof(gui_select_methods)   / sizeof(gui_select_methods[0]),   NULL, NULL},
 };
 /* clang-format on */
 

--- a/plugins/gui/gui_backend.h
+++ b/plugins/gui/gui_backend.h
@@ -78,6 +78,19 @@ extern "C"
         bool (*checkbox_get_checked)(void *handle);
         void (*checkbox_set_checked)(void *handle, bool checked);
 
+        /* Slider (horizontal scale) */
+        void *(*slider_create)(void *parent, double min_val, double max_val);
+        void (*slider_destroy)(void *handle);
+        double (*slider_get_value)(void *handle);
+        void (*slider_set_value)(void *handle, double value);
+
+        /* Select (drop-down / combo box) */
+        void *(*select_create)(void *parent);
+        void (*select_destroy)(void *handle);
+        void (*select_add_item)(void *handle, const char *text);
+        int (*select_get_index)(void *handle);
+        void (*select_set_index)(void *handle, int index);
+
         /* Grid layout */
         void (*widget_grid)(void *handle, int col, int row);
         void (*widget_grid_remove)(void *handle);

--- a/tests/gui_test.c
+++ b/tests/gui_test.c
@@ -57,7 +57,7 @@ TEST(GuiPlugin, ModuleRegisters)
     EXPECT_STREQ(mod->name, "gui");
 }
 
-TEST(GuiPlugin, HasSixClasses)
+TEST(GuiPlugin, HasEightClasses)
 {
     if (!gui_plugin_available())
         return;
@@ -65,13 +65,15 @@ TEST(GuiPlugin, HasSixClasses)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    EXPECT_EQ(mod->class_count, 6U);
+    EXPECT_EQ(mod->class_count, 8U);
     EXPECT_NE(find_class(mod, "App"), NULL);
     EXPECT_NE(find_class(mod, "Window"), NULL);
     EXPECT_NE(find_class(mod, "Label"), NULL);
     EXPECT_NE(find_class(mod, "Button"), NULL);
     EXPECT_NE(find_class(mod, "Entry"), NULL);
     EXPECT_NE(find_class(mod, "Checkbox"), NULL);
+    EXPECT_NE(find_class(mod, "Slider"), NULL);
+    EXPECT_NE(find_class(mod, "Select"), NULL);
 }
 
 TEST(GuiPlugin, HasMessageBoxFunction)
@@ -192,6 +194,43 @@ TEST(GuiPlugin, CheckboxClassMethods)
     EXPECT_NE(find_method(cls, "on_change"), NULL);
 }
 
+TEST(GuiPlugin, SliderClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Slider");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "get"), NULL);
+    EXPECT_NE(find_method(cls, "set"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+    EXPECT_NE(find_method(cls, "on_change"), NULL);
+}
+
+TEST(GuiPlugin, SelectClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Select");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "add_item"), NULL);
+    EXPECT_NE(find_method(cls, "get"), NULL);
+    EXPECT_NE(find_method(cls, "set"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+    EXPECT_NE(find_method(cls, "on_change"), NULL);
+}
+
 TEST(GuiPlugin, AppNewIsStatic)
 {
     if (!gui_plugin_available())
@@ -215,8 +254,8 @@ TEST(GuiPlugin, EachClassHasHandleField)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    static const char *names[] = {"App", "Window", "Label", "Button", "Entry", "Checkbox"};
-    for (size_t i = 0; i < 6; i++)
+    static const char *names[] = {"App", "Window", "Label", "Button", "Entry", "Checkbox", "Slider", "Select"};
+    for (size_t i = 0; i < 8; i++)
     {
         const vigil_native_class_t *cls = find_class(mod, names[i]);
         ASSERT_NE(cls, NULL);
@@ -242,7 +281,7 @@ TEST(GuiPlugin, ModuleHasDoc)
 void register_gui_tests(void)
 {
     REGISTER_TEST(GuiPlugin, ModuleRegisters);
-    REGISTER_TEST(GuiPlugin, HasSixClasses);
+    REGISTER_TEST(GuiPlugin, HasEightClasses);
     REGISTER_TEST(GuiPlugin, HasMessageBoxFunction);
     REGISTER_TEST(GuiPlugin, AppClassMethods);
     REGISTER_TEST(GuiPlugin, WindowClassMethods);
@@ -250,6 +289,8 @@ void register_gui_tests(void)
     REGISTER_TEST(GuiPlugin, ButtonClassMethods);
     REGISTER_TEST(GuiPlugin, EntryClassMethods);
     REGISTER_TEST(GuiPlugin, CheckboxClassMethods);
+    REGISTER_TEST(GuiPlugin, SliderClassMethods);
+    REGISTER_TEST(GuiPlugin, SelectClassMethods);
     REGISTER_TEST(GuiPlugin, AppNewIsStatic);
     REGISTER_TEST(GuiPlugin, EachClassHasHandleField);
     REGISTER_TEST(GuiPlugin, ModuleHasDoc);


### PR DESCRIPTION
## Summary

Adds `gui.Slider` (horizontal scale/trackbar) and `gui.Select` (drop-down combo box) to the gui plugin. Part of Phase 2 from #399.

## New Widget APIs

### gui.Slider
- `Slider.new(parent, min, max) -> Slider, err`
- `slider.get() -> f64`
- `slider.set(value)`
- `slider.grid(col, row)`
- `slider.on_change(callback)`

### gui.Select
- `Select.new(parent) -> Select, err`
- `select.add_item(text)`
- `select.get() -> i32` (selected index, -1 if none)
- `select.set(index)`
- `select.grid(col, row)`
- `select.on_change(callback)`

## Backend Implementations

| Widget | GTK | Cocoa | Win32 |
|---|---|---|---|
| Slider | GtkScale + value-changed | NSSlider | msctls_trackbar32 |
| Select | GtkComboBoxText + changed | NSPopUpButton | COMBOBOX/CBS_DROPDOWNLIST |

## Testing

- All 34 test suites pass locally
- 14 GUI unit tests (class count, method verification for all 8 classes)
- Type-check and runtime test pass under xvfb (GTK4)
- clang-format clean

Part of #399 Phase 2.