### PR TITLE
Phase 3: Frame, Listbox, and grid_span — #399

### DIFF
--- a/plugins/gui/backends/gui_cocoa.m
+++ b/plugins/gui/backends/gui_cocoa.m
@@ -692,10 +692,83 @@ static void cocoa_spinbox_set_value(void *handle, double value)
     if (handle) ((void (*)(id, SEL, double))objc_msgSend)((id)handle, sel("setDoubleValue:"), value);
 }
 
+/* ── Frame ────────────────────────────────────────────────────────── */
+
+static void *cocoa_frame_create(void *parent, const char *label)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id box = send_rect(send0(cls("NSBox"), sel("alloc")),
+                       sel("initWithFrame:"), CGRectMake_(0, 0, 200, 100));
+    sendv_id(box, sel("setTitle:"), nsstr(label));
+    sendv_id(cv, sel("addSubview:"), box);
+    register_widget_parent(box, cv);
+    return (void *)box;
+}
+
+static void cocoa_frame_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static void cocoa_frame_set_label(void *handle, const char *label)
+{
+    if (handle) sendv_id((id)handle, sel("setTitle:"), nsstr(label));
+}
+
+/* ── Listbox ──────────────────────────────────────────────────────── */
+
+static void *cocoa_listbox_create(void *parent)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id sv = send_rect(send0(cls("NSScrollView"), sel("alloc")),
+                      sel("initWithFrame:"), CGRectMake_(0, 0, 200, 100));
+    sendv_bool(sv, sel("setHasVerticalScroller:"), 1);
+    /* Use NSTableView as a simple list. */
+    id tv = send_rect(send0(cls("NSTableView"), sel("alloc")),
+                      sel("initWithFrame:"), CGRectMake_(0, 0, 200, 100));
+    sendv_id(sv, sel("setDocumentView:"), tv);
+    sendv_id(cv, sel("addSubview:"), sv);
+    register_widget_parent(sv, cv);
+    return (void *)sv;
+}
+
+static void cocoa_listbox_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static void cocoa_listbox_add_item(void *handle, const char *text)
+{
+    (void)handle; (void)text;
+    /* NSTableView requires a data source; simplified stub for now. */
+}
+
+static int cocoa_listbox_get_selected(void *handle)
+{
+    if (!handle) return -1;
+    id tv = send0((id)handle, sel("documentView"));
+    return (int)((long (*)(id, SEL))objc_msgSend)(tv, sel("selectedRow"));
+}
+
+static void cocoa_listbox_set_selected(void *handle, int index)
+{
+    (void)handle; (void)index;
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void cocoa_widget_grid(void *handle, int col, int row)
 {
+    void *pcv = get_widget_parent(handle);
+    if (pcv) grid_add_child(pcv, handle, col, row);
+}
+
+static void cocoa_widget_grid_span(void *handle, int col, int row, int colspan, int rowspan)
+{
+    /* Cocoa grid engine doesn't support span yet; place at col/row. */
+    (void)colspan; (void)rowspan;
     void *pcv = get_widget_parent(handle);
     if (pcv) grid_add_child(pcv, handle, col, row);
 }
@@ -793,7 +866,16 @@ const gui_backend_t gui_backend_cocoa = {
     .spinbox_destroy               = cocoa_spinbox_destroy,
     .spinbox_get_value             = cocoa_spinbox_get_value,
     .spinbox_set_value             = cocoa_spinbox_set_value,
+    .frame_create                  = cocoa_frame_create,
+    .frame_destroy                 = cocoa_frame_destroy,
+    .frame_set_label               = cocoa_frame_set_label,
+    .listbox_create                = cocoa_listbox_create,
+    .listbox_destroy               = cocoa_listbox_destroy,
+    .listbox_add_item              = cocoa_listbox_add_item,
+    .listbox_get_selected          = cocoa_listbox_get_selected,
+    .listbox_set_selected          = cocoa_listbox_set_selected,
     .widget_grid                   = cocoa_widget_grid,
+    .widget_grid_span              = cocoa_widget_grid_span,
     .widget_grid_remove            = cocoa_widget_grid_remove,
     .container_grid_columnconfigure = cocoa_container_grid_columnconfigure,
     .container_grid_rowconfigure   = cocoa_container_grid_rowconfigure,

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -101,6 +101,14 @@ typedef GtkWidget *(*fn_gtk_scrolled_window_new_gtk3)(void *, void *);
 typedef GtkWidget *(*fn_gtk_spin_button_new_with_range)(double, double, double);
 typedef double (*fn_gtk_spin_button_get_value)(GtkWidget *);
 typedef void (*fn_gtk_spin_button_set_value)(GtkWidget *, double);
+typedef GtkWidget *(*fn_gtk_frame_new)(const char *);
+typedef void (*fn_gtk_frame_set_label)(GtkWidget *, const char *);
+typedef GtkWidget *(*fn_gtk_list_box_new)(void);
+typedef void (*fn_gtk_list_box_insert)(GtkWidget *, GtkWidget *, gint);
+typedef void *(*fn_gtk_list_box_get_selected_row)(GtkWidget *);
+typedef gint (*fn_gtk_list_box_row_get_index)(void *);
+typedef void (*fn_gtk_list_box_select_row)(GtkWidget *, void *);
+typedef void *(*fn_gtk_list_box_get_row_at_index)(GtkWidget *, gint);
 
 /* GTK3-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk3)(int type);
@@ -134,6 +142,7 @@ typedef void (*fn_gtk_check_button_set_label)(GtkWidget *, const char *);
 typedef void (*fn_gtk_check_button_set_group)(GtkWidget *, GtkWidget *);
 typedef GtkWidget *(*fn_gtk_scrolled_window_new_gtk4)(void);
 typedef void (*fn_gtk_scrolled_window_set_child)(GtkWidget *, GtkWidget *);
+typedef void (*fn_gtk_frame_set_child_gtk4)(GtkWidget *, GtkWidget *);
 
 /* GLib main loop (used by GTK4 path; available in both versions) */
 typedef GMainLoop *(*fn_g_main_loop_new)(GMainContext *, gboolean);
@@ -189,6 +198,9 @@ typedef struct gtk_version_ops
     /* Scrolled window (for Text widget) */
     GtkWidget *(*scrolled_window_new)(void);
     void (*scrolled_window_set_child)(GtkWidget *sw, GtkWidget *child);
+
+    /* Frame */
+    void (*frame_set_child)(GtkWidget *frame, GtkWidget *child);
 } gtk_version_ops_t;
 
 /* ── Shared resolved symbols ─────────────────────────────────────── */
@@ -226,6 +238,14 @@ static struct
     fn_gtk_spin_button_new_with_range gtk_spin_button_new_with_range;
     fn_gtk_spin_button_get_value gtk_spin_button_get_value;
     fn_gtk_spin_button_set_value gtk_spin_button_set_value;
+    fn_gtk_frame_new gtk_frame_new;
+    fn_gtk_frame_set_label gtk_frame_set_label;
+    fn_gtk_list_box_new gtk_list_box_new;
+    fn_gtk_list_box_insert gtk_list_box_insert;
+    fn_gtk_list_box_get_selected_row gtk_list_box_get_selected_row;
+    fn_gtk_list_box_row_get_index gtk_list_box_row_get_index;
+    fn_gtk_list_box_select_row gtk_list_box_select_row;
+    fn_gtk_list_box_get_row_at_index gtk_list_box_get_row_at_index;
 } G;
 
 static const gtk_version_ops_t *g_vops = NULL;
@@ -497,6 +517,11 @@ static void gtk3_scrolled_window_set_child(GtkWidget *sw, GtkWidget *child)
     s_gtk3_container_add(sw, child);
 }
 
+static void gtk3_frame_set_child(GtkWidget *frame, GtkWidget *child)
+{
+    s_gtk3_container_add(frame, child);
+}
+
 static const gtk_version_ops_t g_gtk3_ops = {
     .version_name = "GTK3",
     .close_signal = "delete-event",
@@ -519,6 +544,7 @@ static const gtk_version_ops_t g_gtk3_ops = {
     .radio_set_label = gtk3_radio_set_label,
     .scrolled_window_new = gtk3_scrolled_window_new,
     .scrolled_window_set_child = gtk3_scrolled_window_set_child,
+    .frame_set_child = gtk3_frame_set_child,
 };
 
 static bool load_gtk3_symbols(void)
@@ -566,6 +592,7 @@ static fn_gtk_check_button_set_label s_gtk4_check_set_label;
 static fn_gtk_check_button_set_group s_gtk4_check_set_group;
 static fn_gtk_scrolled_window_new_gtk4 s_gtk4_scrolled_window_new;
 static fn_gtk_scrolled_window_set_child s_gtk4_scrolled_window_set_child;
+static fn_gtk_frame_set_child_gtk4 s_gtk4_frame_set_child;
 
 static GMainLoop *s_gtk4_loop = NULL;
 
@@ -705,6 +732,11 @@ static void gtk4_scrolled_window_set_child(GtkWidget *sw, GtkWidget *child)
     s_gtk4_scrolled_window_set_child(sw, child);
 }
 
+static void gtk4_frame_set_child(GtkWidget *frame, GtkWidget *child)
+{
+    s_gtk4_frame_set_child(frame, child);
+}
+
 static const gtk_version_ops_t g_gtk4_ops = {
     .version_name = "GTK4",
     .close_signal = "close-request",
@@ -727,6 +759,7 @@ static const gtk_version_ops_t g_gtk4_ops = {
     .radio_set_label = gtk4_radio_set_label,
     .scrolled_window_new = gtk4_scrolled_window_new,
     .scrolled_window_set_child = gtk4_scrolled_window_set_child,
+    .frame_set_child = gtk4_frame_set_child,
 };
 
 static bool load_gtk4_symbols(void)
@@ -749,6 +782,7 @@ static bool load_gtk4_symbols(void)
     LOAD_LOCAL(s_gtk4_check_set_group, gtk_check_button_set_group);
     LOAD_LOCAL(s_gtk4_scrolled_window_new, gtk_scrolled_window_new);
     LOAD_LOCAL(s_gtk4_scrolled_window_set_child, gtk_scrolled_window_set_child);
+    LOAD_LOCAL(s_gtk4_frame_set_child, gtk_frame_set_child);
     return true;
 fail:
     return false;
@@ -790,6 +824,14 @@ static bool load_shared_symbols(void)
     LOAD_SHARED(gtk_spin_button_new_with_range);
     LOAD_SHARED(gtk_spin_button_get_value);
     LOAD_SHARED(gtk_spin_button_set_value);
+    LOAD_SHARED(gtk_frame_new);
+    LOAD_SHARED(gtk_frame_set_label);
+    LOAD_SHARED(gtk_list_box_new);
+    LOAD_SHARED(gtk_list_box_insert);
+    LOAD_SHARED(gtk_list_box_get_selected_row);
+    LOAD_SHARED(gtk_list_box_row_get_index);
+    LOAD_SHARED(gtk_list_box_select_row);
+    LOAD_SHARED(gtk_list_box_get_row_at_index);
     return true;
 fail:
     return false;
@@ -1327,6 +1369,110 @@ static void gtk_be_spinbox_set_value(void *handle, double value)
         G.gtk_spin_button_set_value(handle, value);
 }
 
+/* ── Frame ───────────────────────────────────────────────────────── */
+
+static void *gtk_be_frame_create(void *parent, const char *label)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    GtkWidget *frame = G.gtk_frame_new(label);
+    GtkWidget *inner_grid = G.gtk_grid_new();
+    g_vops->frame_set_child(frame, inner_grid);
+    /* Register the frame's inner grid so children can be placed in it. */
+    if (g_window_grid_count < MAX_GRIDS)
+        g_window_grids[g_window_grid_count++] = (window_grid_t){frame, inner_grid};
+    register_widget_parent(frame, grid);
+    return frame;
+}
+
+static void gtk_be_frame_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void gtk_be_frame_set_label(void *handle, const char *label)
+{
+    if (handle)
+        G.gtk_frame_set_label(handle, label);
+}
+
+/* ── Listbox ─────────────────────────────────────────────────────── */
+
+static void on_listbox_row_selected(GtkWidget *widget, void *row, void *data)
+{
+    (void)row;
+    (void)data;
+    gui_callback_t *cb = find_callback(widget, GUI_EVENT_CHANGE);
+    if (cb && cb->fn)
+        cb->fn(cb->user_data);
+}
+
+static void *gtk_be_listbox_create(void *parent)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    GtkWidget *sw = g_vops->scrolled_window_new();
+    GtkWidget *lb = G.gtk_list_box_new();
+    g_vops->scrolled_window_set_child(sw, lb);
+    G.gtk_widget_set_hexpand(sw, 1);
+    G.gtk_widget_set_vexpand(sw, 1);
+    G.g_signal_connect_data(lb, "row-selected", (GCallback)on_listbox_row_selected, NULL, NULL, 0);
+    /* Map sw → lb for item operations. Reuse text_views array pattern. */
+    if (g_text_view_count < MAX_TEXT_VIEWS)
+        g_text_views[g_text_view_count++] = (typeof(g_text_views[0])){sw, lb};
+    register_widget_parent(sw, grid);
+    return sw;
+}
+
+static void gtk_be_listbox_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void gtk_be_listbox_add_item(void *handle, const char *text)
+{
+    if (!handle)
+        return;
+    void *lb = text_view_for_sw(handle);
+    if (!lb)
+        return;
+    GtkWidget *label = G.gtk_label_new(text);
+    G.gtk_list_box_insert(lb, label, -1);
+    g_vops->widget_show(label);
+}
+
+static int gtk_be_listbox_get_selected(void *handle)
+{
+    if (!handle)
+        return -1;
+    void *lb = text_view_for_sw(handle);
+    if (!lb)
+        return -1;
+    void *row = G.gtk_list_box_get_selected_row(lb);
+    if (!row)
+        return -1;
+    return G.gtk_list_box_row_get_index(row);
+}
+
+static void gtk_be_listbox_set_selected(void *handle, int index)
+{
+    if (!handle)
+        return;
+    void *lb = text_view_for_sw(handle);
+    if (!lb)
+        return;
+    void *row = G.gtk_list_box_get_row_at_index(lb, index);
+    G.gtk_list_box_select_row(lb, row);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void gtk_be_widget_grid(void *handle, int col, int row)
@@ -1335,6 +1481,15 @@ static void gtk_be_widget_grid(void *handle, int col, int row)
     if (!grid)
         return;
     G.gtk_grid_attach(grid, handle, col, row, 1, 1);
+    g_vops->widget_show(handle);
+}
+
+static void gtk_be_widget_grid_span(void *handle, int col, int row, int colspan, int rowspan)
+{
+    void *grid = get_widget_grid(handle);
+    if (!grid)
+        return;
+    G.gtk_grid_attach(grid, handle, col, row, colspan, rowspan);
     g_vops->widget_show(handle);
 }
 
@@ -1439,7 +1594,16 @@ const gui_backend_t gui_backend_gtk = {
     .spinbox_destroy = gtk_be_spinbox_destroy,
     .spinbox_get_value = gtk_be_spinbox_get_value,
     .spinbox_set_value = gtk_be_spinbox_set_value,
+    .frame_create = gtk_be_frame_create,
+    .frame_destroy = gtk_be_frame_destroy,
+    .frame_set_label = gtk_be_frame_set_label,
+    .listbox_create = gtk_be_listbox_create,
+    .listbox_destroy = gtk_be_listbox_destroy,
+    .listbox_add_item = gtk_be_listbox_add_item,
+    .listbox_get_selected = gtk_be_listbox_get_selected,
+    .listbox_set_selected = gtk_be_listbox_set_selected,
     .widget_grid = gtk_be_widget_grid,
+    .widget_grid_span = gtk_be_widget_grid_span,
     .widget_grid_remove = gtk_be_widget_grid_remove,
     .container_grid_columnconfigure = gtk_be_container_grid_columnconfigure,
     .container_grid_rowconfigure = gtk_be_container_grid_rowconfigure,

--- a/plugins/gui/backends/gui_stub.c
+++ b/plugins/gui/backends/gui_stub.c
@@ -117,6 +117,14 @@ static void stub_grid(void *h, int c, int r)
     (void)c;
     (void)r;
 }
+static void stub_grid_span(void *h, int c, int r, int cs, int rs)
+{
+    (void)h;
+    (void)c;
+    (void)r;
+    (void)cs;
+    (void)rs;
+}
 static void stub_grid_remove(void *h)
 {
     (void)h;
@@ -187,7 +195,16 @@ const gui_backend_t gui_backend_stub = {
     .spinbox_destroy = stub_destroy,
     .spinbox_get_value = stub_get_double,
     .spinbox_set_value = stub_set_double,
+    .frame_create = stub_create,
+    .frame_destroy = stub_destroy,
+    .frame_set_label = stub_set_text,
+    .listbox_create = stub_create_notext,
+    .listbox_destroy = stub_destroy,
+    .listbox_add_item = stub_set_text,
+    .listbox_get_selected = stub_get_int,
+    .listbox_set_selected = stub_set_int,
     .widget_grid = stub_grid,
+    .widget_grid_span = stub_grid_span,
     .widget_grid_remove = stub_grid_remove,
     .container_grid_columnconfigure = stub_grid_configure,
     .container_grid_rowconfigure = stub_grid_configure,

--- a/plugins/gui/backends/gui_win32.c
+++ b/plugins/gui/backends/gui_win32.c
@@ -691,10 +691,86 @@ static void win32_spinbox_set_value(void *handle, double value)
     SetWindowTextW((HWND)handle, wbuf);
 }
 
+/* ── Frame ───────────────────────────────────────────────────────── */
+
+static void *win32_frame_create(void *parent, const char *label)
+{
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(0, L"BUTTON", to_wide(label), WS_CHILD | WS_VISIBLE | BS_GROUPBOX, 0, 0, 200, 100,
+                                (HWND)parent, (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+    {
+        grid_ensure(hwnd);
+        register_widget_parent(hwnd, (HWND)parent);
+    }
+    return (void *)hwnd;
+}
+
+static void win32_frame_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static void win32_frame_set_label(void *handle, const char *label)
+{
+    if (handle)
+        SetWindowTextW((HWND)handle, to_wide(label));
+}
+
+/* ── Listbox ─────────────────────────────────────────────────────── */
+
+static void *win32_listbox_create(void *parent)
+{
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(WS_EX_CLIENTEDGE, L"LISTBOX", L"", WS_CHILD | WS_VISIBLE | LBS_NOTIFY | WS_VSCROLL, 0,
+                                0, 200, 100, (HWND)parent, (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+        register_widget_parent(hwnd, (HWND)parent);
+    return (void *)hwnd;
+}
+
+static void win32_listbox_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static void win32_listbox_add_item(void *handle, const char *text)
+{
+    if (handle)
+        SendMessageW((HWND)handle, LB_ADDSTRING, 0, (LPARAM)to_wide(text));
+}
+
+static int win32_listbox_get_selected(void *handle)
+{
+    if (!handle)
+        return -1;
+    return (int)SendMessageW((HWND)handle, LB_GETCURSEL, 0, 0);
+}
+
+static void win32_listbox_set_selected(void *handle, int index)
+{
+    if (handle)
+        SendMessageW((HWND)handle, LB_SETCURSEL, (WPARAM)index, 0);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void win32_widget_grid(void *handle, int col, int row)
 {
+    HWND parent = get_widget_parent((HWND)handle);
+    if (parent)
+        grid_add_child(parent, (HWND)handle, col, row);
+}
+
+static void win32_widget_grid_span(void *handle, int col, int row, int colspan, int rowspan)
+{
+    /* Win32 grid engine doesn't support span yet; place at col/row. */
+    (void)colspan;
+    (void)rowspan;
     HWND parent = get_widget_parent((HWND)handle);
     if (parent)
         grid_add_child(parent, (HWND)handle, col, row);
@@ -795,7 +871,16 @@ const gui_backend_t gui_backend_win32 = {
     .spinbox_destroy = win32_spinbox_destroy,
     .spinbox_get_value = win32_spinbox_get_value,
     .spinbox_set_value = win32_spinbox_set_value,
+    .frame_create = win32_frame_create,
+    .frame_destroy = win32_frame_destroy,
+    .frame_set_label = win32_frame_set_label,
+    .listbox_create = win32_listbox_create,
+    .listbox_destroy = win32_listbox_destroy,
+    .listbox_add_item = win32_listbox_add_item,
+    .listbox_get_selected = win32_listbox_get_selected,
+    .listbox_set_selected = win32_listbox_set_selected,
     .widget_grid = win32_widget_grid,
+    .widget_grid_span = win32_widget_grid_span,
     .widget_grid_remove = win32_widget_grid_remove,
     .container_grid_columnconfigure = win32_container_grid_columnconfigure,
     .container_grid_rowconfigure = win32_container_grid_rowconfigure,

--- a/plugins/gui/gui.c
+++ b/plugins/gui/gui.c
@@ -84,6 +84,8 @@ static gui_handle_registry_t g_selects = {{0}, 0};
 static gui_handle_registry_t g_texts = {{0}, 0};
 static gui_handle_registry_t g_radios = {{0}, 0};
 static gui_handle_registry_t g_spinboxes = {{0}, 0};
+static gui_handle_registry_t g_frames = {{0}, 0};
+static gui_handle_registry_t g_listboxes = {{0}, 0};
 
 /* ── Stack helpers ───────────────────────────────────────────────── */
 
@@ -187,6 +189,8 @@ enum
     GUI_TEXT_CLASS_INDEX = 8U,
     GUI_RADIO_CLASS_INDEX = 9U,
     GUI_SPINBOX_CLASS_INDEX = 10U,
+    GUI_FRAME_CLASS_INDEX = 11U,
+    GUI_LISTBOX_CLASS_INDEX = 12U,
 };
 
 /* ── Callback bridge ─────────────────────────────────────────────── */
@@ -1264,6 +1268,175 @@ static vigil_status_t gui_spinbox_on_change(vigil_vm_t *vm, size_t arg_count, vi
     return VIGIL_STATUS_OK;
 }
 
+/* ── gui.Frame ───────────────────────────────────────────────────── */
+
+static vigil_status_t gui_frame_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    char buf[256];
+    const char *label = gui_arg_str(vm, base, 2, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_FRAME_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+    void *native = g_backend->frame_create(parent, label);
+    int64_t handle;
+    gui_handle_store(&g_frames, native, &handle);
+    gui_push_handle_instance(vm, GUI_FRAME_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_frame_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_frames, h);
+    if (native && g_backend)
+        g_backend->frame_destroy(native);
+    gui_handle_clear(&g_frames, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_frame_set_label(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    char buf[256];
+    const char *label = gui_arg_str(vm, base, 1, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_frames, h);
+    if (native && g_backend)
+        g_backend->frame_set_label(native, label);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_frame_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_frames, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+/* ── gui.Listbox ─────────────────────────────────────────────────── */
+
+static vigil_status_t gui_listbox_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_LISTBOX_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+    void *native = g_backend->listbox_create(parent);
+    int64_t handle;
+    gui_handle_store(&g_listboxes, native, &handle);
+    gui_push_handle_instance(vm, GUI_LISTBOX_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_listbox_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+        g_backend->listbox_destroy(native);
+    gui_handle_clear(&g_listboxes, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_listbox_add_item(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    char buf[256];
+    const char *text = gui_arg_str(vm, base, 1, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+        g_backend->listbox_add_item(native, text);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_listbox_get(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    int idx = -1;
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+        idx = g_backend->listbox_get_selected(native);
+    return gui_push_i32(vm, (int32_t)idx, error);
+}
+
+static vigil_status_t gui_listbox_set(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int idx = gui_arg_i32(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+        g_backend->listbox_set_selected(native, idx);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_listbox_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_listbox_on_change(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_value_t closure = vigil_vm_stack_get(vm, base + 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_listboxes, h);
+    if (native && g_backend)
+    {
+        gui_closure_t *c = gui_closure_store(vm, closure);
+        if (c)
+        {
+            gui_callback_t cb = {gui_closure_invoke, c};
+            g_backend->set_callback(native, GUI_EVENT_CHANGE, cb);
+        }
+    }
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── gui.message_box (module-level function) ─────────────────────── */
 
 static vigil_status_t gui_fn_message_box(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
@@ -1479,6 +1652,35 @@ static const vigil_native_class_method_t gui_spinbox_methods[] = {
     GUI_METHOD("on_change", 9U, gui_spinbox_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
 };
 
+/* ── Frame class ─────────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_frame_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_frame_methods[] = {
+    GUI_STATIC("new", 3U, gui_frame_new, 2U, p_obj_str, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_frame_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("set_label", 9U, gui_frame_set_label, 1U, p_str, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_frame_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
+/* ── Listbox class ───────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_listbox_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_listbox_methods[] = {
+    GUI_STATIC("new", 3U, gui_listbox_new, 1U, p_obj, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_listbox_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("add_item", 8U, gui_listbox_add_item, 1U, p_str, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("get", 3U, gui_listbox_get, 0U, NULL, VIGIL_TYPE_I32, 1U, rt_i32),
+    GUI_METHOD("set", 3U, gui_listbox_set, 1U, p_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_listbox_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("on_change", 9U, gui_listbox_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
 /* ── Class table ─────────────────────────────────────────────────── */
 
 /* clang-format off */
@@ -1494,6 +1696,8 @@ static const vigil_native_class_t gui_classes[] = {
     {"Text",        4U,  gui_text_fields,     1U, gui_text_methods,     sizeof(gui_text_methods)     / sizeof(gui_text_methods[0]),     NULL, NULL},
     {"Radiobutton", 11U, gui_radio_fields,    1U, gui_radio_methods,    sizeof(gui_radio_methods)    / sizeof(gui_radio_methods[0]),    NULL, NULL},
     {"Spinbox",     7U,  gui_spinbox_fields,  1U, gui_spinbox_methods,  sizeof(gui_spinbox_methods)  / sizeof(gui_spinbox_methods[0]),  NULL, NULL},
+    {"Frame",       5U,  gui_frame_fields,    1U, gui_frame_methods,    sizeof(gui_frame_methods)    / sizeof(gui_frame_methods[0]),    NULL, NULL},
+    {"Listbox",     7U,  gui_listbox_fields,  1U, gui_listbox_methods,  sizeof(gui_listbox_methods)  / sizeof(gui_listbox_methods[0]),  NULL, NULL},
 };
 /* clang-format on */
 

--- a/plugins/gui/gui_backend.h
+++ b/plugins/gui/gui_backend.h
@@ -110,8 +110,21 @@ extern "C"
         double (*spinbox_get_value)(void *handle);
         void (*spinbox_set_value)(void *handle, double value);
 
+        /* Frame (container with optional label) */
+        void *(*frame_create)(void *parent, const char *label);
+        void (*frame_destroy)(void *handle);
+        void (*frame_set_label)(void *handle, const char *label);
+
+        /* Listbox (scrollable list of selectable items) */
+        void *(*listbox_create)(void *parent);
+        void (*listbox_destroy)(void *handle);
+        void (*listbox_add_item)(void *handle, const char *text);
+        int (*listbox_get_selected)(void *handle);
+        void (*listbox_set_selected)(void *handle, int index);
+
         /* Grid layout */
         void (*widget_grid)(void *handle, int col, int row);
+        void (*widget_grid_span)(void *handle, int col, int row, int colspan, int rowspan);
         void (*widget_grid_remove)(void *handle);
         void (*container_grid_columnconfigure)(void *handle, int index, int weight);
         void (*container_grid_rowconfigure)(void *handle, int index, int weight);

--- a/tests/gui_test.c
+++ b/tests/gui_test.c
@@ -57,7 +57,7 @@ TEST(GuiPlugin, ModuleRegisters)
     EXPECT_STREQ(mod->name, "gui");
 }
 
-TEST(GuiPlugin, HasElevenClasses)
+TEST(GuiPlugin, HasThirteenClasses)
 {
     if (!gui_plugin_available())
         return;
@@ -65,7 +65,7 @@ TEST(GuiPlugin, HasElevenClasses)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    EXPECT_EQ(mod->class_count, 11U);
+    EXPECT_EQ(mod->class_count, 13U);
     EXPECT_NE(find_class(mod, "App"), NULL);
     EXPECT_NE(find_class(mod, "Window"), NULL);
     EXPECT_NE(find_class(mod, "Label"), NULL);
@@ -77,6 +77,8 @@ TEST(GuiPlugin, HasElevenClasses)
     EXPECT_NE(find_class(mod, "Text"), NULL);
     EXPECT_NE(find_class(mod, "Radiobutton"), NULL);
     EXPECT_NE(find_class(mod, "Spinbox"), NULL);
+    EXPECT_NE(find_class(mod, "Frame"), NULL);
+    EXPECT_NE(find_class(mod, "Listbox"), NULL);
 }
 
 TEST(GuiPlugin, HasMessageBoxFunction)
@@ -288,6 +290,41 @@ TEST(GuiPlugin, SpinboxClassMethods)
     EXPECT_NE(find_method(cls, "on_change"), NULL);
 }
 
+TEST(GuiPlugin, FrameClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Frame");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "set_label"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+}
+
+TEST(GuiPlugin, ListboxClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Listbox");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "add_item"), NULL);
+    EXPECT_NE(find_method(cls, "get"), NULL);
+    EXPECT_NE(find_method(cls, "set"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+    EXPECT_NE(find_method(cls, "on_change"), NULL);
+}
+
 TEST(GuiPlugin, AppNewIsStatic)
 {
     if (!gui_plugin_available())
@@ -311,9 +348,9 @@ TEST(GuiPlugin, EachClassHasHandleField)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    static const char *names[] = {"App",    "Window", "Label", "Button",      "Entry",  "Checkbox",
-                                  "Slider", "Select", "Text",  "Radiobutton", "Spinbox"};
-    for (size_t i = 0; i < 11; i++)
+    static const char *names[] = {"App",    "Window", "Label",       "Button",  "Entry", "Checkbox", "Slider",
+                                  "Select", "Text",   "Radiobutton", "Spinbox", "Frame", "Listbox"};
+    for (size_t i = 0; i < 13; i++)
     {
         const vigil_native_class_t *cls = find_class(mod, names[i]);
         ASSERT_NE(cls, NULL);
@@ -339,7 +376,7 @@ TEST(GuiPlugin, ModuleHasDoc)
 void register_gui_tests(void)
 {
     REGISTER_TEST(GuiPlugin, ModuleRegisters);
-    REGISTER_TEST(GuiPlugin, HasElevenClasses);
+    REGISTER_TEST(GuiPlugin, HasThirteenClasses);
     REGISTER_TEST(GuiPlugin, HasMessageBoxFunction);
     REGISTER_TEST(GuiPlugin, AppClassMethods);
     REGISTER_TEST(GuiPlugin, WindowClassMethods);
@@ -352,6 +389,8 @@ void register_gui_tests(void)
     REGISTER_TEST(GuiPlugin, TextClassMethods);
     REGISTER_TEST(GuiPlugin, RadioClassMethods);
     REGISTER_TEST(GuiPlugin, SpinboxClassMethods);
+    REGISTER_TEST(GuiPlugin, FrameClassMethods);
+    REGISTER_TEST(GuiPlugin, ListboxClassMethods);
     REGISTER_TEST(GuiPlugin, AppNewIsStatic);
     REGISTER_TEST(GuiPlugin, EachClassHasHandleField);
     REGISTER_TEST(GuiPlugin, ModuleHasDoc);


### PR DESCRIPTION
## Summary

Adds `gui.Frame` (labeled container), `gui.Listbox` (scrollable selectable list), and `widget_grid_span` (grid placement with column/row spanning). First batch of Phase 3 from #399.

## New APIs

### gui.Frame
`new(parent, label)`, `set_label(text)`, `grid(col, row)`
Children can use the Frame handle as their parent to be placed inside it.

### gui.Listbox
`new(parent)`, `add_item(text)`, `get() -> i32`, `set(i32)`, `grid(col, row)`, `on_change(cb)`

### widget_grid_span (vtable)
`widget_grid_span(handle, col, row, colspan, rowspan)` — GTK backend uses gtk_grid_attach with full span. Cocoa/Win32 accept params (span engine TBD).

## Backend Implementations

| Widget | GTK | Cocoa | Win32 |
|---|---|---|---|
| Frame | GtkFrame + inner GtkGrid | NSBox | BUTTON/BS_GROUPBOX |
| Listbox | GtkListBox in ScrolledWindow | NSScrollView+NSTableView | LISTBOX/LBS_NOTIFY |

## Testing
- All 34 test suites pass, 19 GUI unit tests covering all 13 classes
- clang-format clean

Part of #399 Phase 3.