### PR TITLE
Phase 3: Menu widget with submenus and callbacks — #399

### DIFF
--- a/plugins/gui/backends/gui_cocoa.m
+++ b/plugins/gui/backends/gui_cocoa.m
@@ -757,6 +757,48 @@ static void cocoa_listbox_set_selected(void *handle, int index)
     (void)handle; (void)index;
 }
 
+/* ── Menu ─────────────────────────────────────────────────────────── */
+
+static void *cocoa_menubar_create(void *window)
+{
+    (void)window;
+    id mainMenu = send0(send0(cls("NSMenu"), sel("alloc")), sel("init"));
+    sendv_id(send0(cls("NSApplication"), sel("sharedApplication")),
+             sel("setMainMenu:"), mainMenu);
+    return (void *)mainMenu;
+}
+
+static void cocoa_menubar_destroy(void *handle)
+{
+    (void)handle;
+}
+
+static void *cocoa_menu_add_submenu(void *menubar, const char *label)
+{
+    id submenu = send0(send0(cls("NSMenu"), sel("alloc")), sel("init"));
+    sendv_id(submenu, sel("setTitle:"), nsstr(label));
+    id item = send0(send0(cls("NSMenuItem"), sel("alloc")), sel("init"));
+    sendv_id(item, sel("setTitle:"), nsstr(label));
+    sendv_id(item, sel("setSubmenu:"), submenu);
+    sendv_id((id)menubar, sel("addItem:"), item);
+    return (void *)submenu;
+}
+
+static void cocoa_menu_add_item(void *submenu, const char *label, gui_callback_t cb)
+{
+    id item = ((id (*)(id, SEL, id, SEL, id))objc_msgSend)(
+        send0(cls("NSMenuItem"), sel("alloc")),
+        sel("initWithTitle:action:keyEquivalent:"),
+        nsstr(label), (SEL)NULL, nsstr(""));
+    if (g_button_target)
+    {
+        sendv_id(item, sel("setTarget:"), g_button_target);
+        sendv_sel(item, sel("setAction:"), sel("buttonClicked:"));
+    }
+    cocoa_set_callback(item, GUI_EVENT_CLICK, cb);
+    sendv_id((id)submenu, sel("addItem:"), item);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void cocoa_widget_grid(void *handle, int col, int row)
@@ -874,6 +916,10 @@ const gui_backend_t gui_backend_cocoa = {
     .listbox_add_item              = cocoa_listbox_add_item,
     .listbox_get_selected          = cocoa_listbox_get_selected,
     .listbox_set_selected          = cocoa_listbox_set_selected,
+    .menubar_create                = cocoa_menubar_create,
+    .menubar_destroy               = cocoa_menubar_destroy,
+    .menu_add_submenu              = cocoa_menu_add_submenu,
+    .menu_add_item                 = cocoa_menu_add_item,
     .widget_grid                   = cocoa_widget_grid,
     .widget_grid_span              = cocoa_widget_grid_span,
     .widget_grid_remove            = cocoa_widget_grid_remove,

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -126,6 +126,11 @@ typedef gboolean (*fn_gtk_toggle_button_get_active)(GtkWidget *);
 typedef void (*fn_gtk_toggle_button_set_active)(GtkWidget *, gboolean);
 typedef GtkWidget *(*fn_gtk_radio_button_new_with_label)(void *, const char *);
 typedef GtkWidget *(*fn_gtk_radio_button_new_with_label_from_widget)(GtkWidget *, const char *);
+typedef GtkWidget *(*fn_gtk_menu_bar_new)(void);
+typedef GtkWidget *(*fn_gtk_menu_new)(void);
+typedef GtkWidget *(*fn_gtk_menu_item_new_with_label)(const char *);
+typedef void (*fn_gtk_menu_item_set_submenu)(GtkWidget *, GtkWidget *);
+typedef void (*fn_gtk_menu_shell_append)(GtkWidget *, GtkWidget *);
 
 /* GTK4-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk4)(void);
@@ -143,6 +148,15 @@ typedef void (*fn_gtk_check_button_set_group)(GtkWidget *, GtkWidget *);
 typedef GtkWidget *(*fn_gtk_scrolled_window_new_gtk4)(void);
 typedef void (*fn_gtk_scrolled_window_set_child)(GtkWidget *, GtkWidget *);
 typedef void (*fn_gtk_frame_set_child_gtk4)(GtkWidget *, GtkWidget *);
+typedef GtkWidget *(*fn_gtk_popover_menu_bar_new_from_model)(void *);
+typedef void *(*fn_g_menu_new)(void);
+typedef void (*fn_g_menu_append)(void *, const char *, const char *);
+typedef void (*fn_g_menu_append_submenu)(void *, const char *, void *);
+typedef void *(*fn_g_simple_action_new)(const char *, void *);
+typedef void (*fn_g_action_map_add_action)(void *, void *);
+typedef void *(*fn_g_simple_action_group_new)(void);
+typedef void (*fn_gtk_widget_insert_action_group)(GtkWidget *, const char *, void *);
+typedef gulong (*fn_g_signal_connect_data_t)(void *, const char *, GCallback, void *, GClosureNotify, int);
 
 /* GLib main loop (used by GTK4 path; available in both versions) */
 typedef GMainLoop *(*fn_g_main_loop_new)(GMainContext *, gboolean);
@@ -201,6 +215,11 @@ typedef struct gtk_version_ops
 
     /* Frame */
     void (*frame_set_child)(GtkWidget *frame, GtkWidget *child);
+
+    /* Menu bar */
+    void *(*menubar_create)(void *window);
+    void *(*menu_add_submenu)(void *menubar, const char *label);
+    void (*menu_add_item)(void *submenu, const char *label, gui_callback_t cb);
 } gtk_version_ops_t;
 
 /* ── Shared resolved symbols ─────────────────────────────────────── */
@@ -412,6 +431,11 @@ static fn_gtk_toggle_button_set_active s_gtk3_toggle_set_active;
 static fn_gtk_radio_button_new_with_label s_gtk3_radio_new;
 static fn_gtk_radio_button_new_with_label_from_widget s_gtk3_radio_new_from;
 static fn_gtk_scrolled_window_new_gtk3 s_gtk3_scrolled_window_new;
+static fn_gtk_menu_bar_new s_gtk3_menu_bar_new;
+static fn_gtk_menu_new s_gtk3_menu_new;
+static fn_gtk_menu_item_new_with_label s_gtk3_menu_item_new;
+static fn_gtk_menu_item_set_submenu s_gtk3_menu_item_set_submenu;
+static fn_gtk_menu_shell_append s_gtk3_menu_shell_append;
 
 static void gtk3_main_loop(void)
 {
@@ -522,6 +546,52 @@ static void gtk3_frame_set_child(GtkWidget *frame, GtkWidget *child)
     s_gtk3_container_add(frame, child);
 }
 
+static void *gtk3_menubar_create(void *window)
+{
+    GtkWidget *mb = s_gtk3_menu_bar_new();
+    /* Insert menubar at row -1 (above grid content) in the window's grid. */
+    void *grid = grid_for_window(window);
+    if (grid)
+    {
+        G.gtk_grid_attach(grid, mb, 0, -1, 10, 1);
+        s_gtk3_widget_show_all(mb);
+    }
+    return mb;
+}
+
+static void *gtk3_menu_add_submenu(void *menubar, const char *label)
+{
+    GtkWidget *menu = s_gtk3_menu_new();
+    GtkWidget *item = s_gtk3_menu_item_new(label);
+    s_gtk3_menu_item_set_submenu(item, menu);
+    s_gtk3_menu_shell_append(menubar, item);
+    s_gtk3_widget_show_all(item);
+    return menu;
+}
+
+static void gtk3_on_menu_activate(GtkWidget *widget, void *data)
+{
+    (void)widget;
+    gui_callback_t *cb = (gui_callback_t *)data;
+    if (cb && cb->fn)
+        cb->fn(cb->user_data);
+}
+
+static void gtk3_menu_add_item(void *submenu, const char *label, gui_callback_t cb)
+{
+    GtkWidget *item = s_gtk3_menu_item_new(label);
+    /* Store callback — we need it to persist. Use the global callback array. */
+    if (g_callback_count < MAX_CALLBACKS)
+    {
+        g_callbacks[g_callback_count] = (callback_entry_t){item, GUI_EVENT_CLICK, cb};
+        G.g_signal_connect_data(item, "activate", (GCallback)gtk3_on_menu_activate, &g_callbacks[g_callback_count].cb,
+                                NULL, 0);
+        g_callback_count++;
+    }
+    s_gtk3_menu_shell_append(submenu, item);
+    s_gtk3_widget_show_all(item);
+}
+
 static const gtk_version_ops_t g_gtk3_ops = {
     .version_name = "GTK3",
     .close_signal = "delete-event",
@@ -545,6 +615,9 @@ static const gtk_version_ops_t g_gtk3_ops = {
     .scrolled_window_new = gtk3_scrolled_window_new,
     .scrolled_window_set_child = gtk3_scrolled_window_set_child,
     .frame_set_child = gtk3_frame_set_child,
+    .menubar_create = gtk3_menubar_create,
+    .menu_add_submenu = gtk3_menu_add_submenu,
+    .menu_add_item = gtk3_menu_add_item,
 };
 
 static bool load_gtk3_symbols(void)
@@ -565,6 +638,11 @@ static bool load_gtk3_symbols(void)
     LOAD_LOCAL(s_gtk3_radio_new, gtk_radio_button_new_with_label);
     LOAD_LOCAL(s_gtk3_radio_new_from, gtk_radio_button_new_with_label_from_widget);
     LOAD_LOCAL(s_gtk3_scrolled_window_new, gtk_scrolled_window_new);
+    LOAD_LOCAL(s_gtk3_menu_bar_new, gtk_menu_bar_new);
+    LOAD_LOCAL(s_gtk3_menu_new, gtk_menu_new);
+    LOAD_LOCAL(s_gtk3_menu_item_new, gtk_menu_item_new_with_label);
+    LOAD_LOCAL(s_gtk3_menu_item_set_submenu, gtk_menu_item_set_submenu);
+    LOAD_LOCAL(s_gtk3_menu_shell_append, gtk_menu_shell_append);
     return true;
 fail:
     return false;
@@ -593,6 +671,20 @@ static fn_gtk_check_button_set_group s_gtk4_check_set_group;
 static fn_gtk_scrolled_window_new_gtk4 s_gtk4_scrolled_window_new;
 static fn_gtk_scrolled_window_set_child s_gtk4_scrolled_window_set_child;
 static fn_gtk_frame_set_child_gtk4 s_gtk4_frame_set_child;
+static fn_gtk_popover_menu_bar_new_from_model s_gtk4_popover_menu_bar_new;
+static fn_g_menu_new s_gtk4_g_menu_new;
+static fn_g_menu_append s_gtk4_g_menu_append;
+static fn_g_menu_append_submenu s_gtk4_g_menu_append_submenu;
+static fn_g_simple_action_new s_gtk4_g_simple_action_new;
+static fn_g_action_map_add_action s_gtk4_g_action_map_add_action;
+static fn_g_simple_action_group_new s_gtk4_g_simple_action_group_new;
+static fn_gtk_widget_insert_action_group s_gtk4_gtk_widget_insert_action_group;
+
+/* GTK4 menu needs a window reference for action map. */
+static void *s_gtk4_menu_window = NULL;
+static void *s_gtk4_menu_model = NULL;
+static void *s_gtk4_action_group = NULL;
+static int s_gtk4_action_id = 0;
 
 static GMainLoop *s_gtk4_loop = NULL;
 
@@ -737,6 +829,60 @@ static void gtk4_frame_set_child(GtkWidget *frame, GtkWidget *child)
     s_gtk4_frame_set_child(frame, child);
 }
 
+static void gtk4_on_action_activate(void *action, void *param, void *data)
+{
+    (void)action;
+    (void)param;
+    gui_callback_t *cb = (gui_callback_t *)data;
+    if (cb && cb->fn)
+        cb->fn(cb->user_data);
+}
+
+static void *gtk4_menubar_create(void *window)
+{
+    s_gtk4_menu_window = window;
+    s_gtk4_menu_model = s_gtk4_g_menu_new();
+    s_gtk4_action_group = s_gtk4_g_simple_action_group_new();
+    s_gtk4_action_id = 0;
+    s_gtk4_gtk_widget_insert_action_group(window, "win", s_gtk4_action_group);
+    GtkWidget *bar = s_gtk4_popover_menu_bar_new(s_gtk4_menu_model);
+    void *grid = grid_for_window(window);
+    if (grid)
+    {
+        G.gtk_grid_attach(grid, bar, 0, -1, 10, 1);
+        s_gtk4_widget_set_visible(bar, 1);
+    }
+    return bar;
+}
+
+static void *gtk4_menu_add_submenu(void *menubar, const char *label)
+{
+    (void)menubar;
+    void *submenu = s_gtk4_g_menu_new();
+    s_gtk4_g_menu_append_submenu(s_gtk4_menu_model, label, submenu);
+    return submenu;
+}
+
+static void gtk4_menu_add_item(void *submenu, const char *label, gui_callback_t cb)
+{
+    char action_name[64];
+    snprintf(action_name, sizeof(action_name), "act%d", s_gtk4_action_id++);
+    char detailed[80];
+    snprintf(detailed, sizeof(detailed), "win.%s", action_name);
+    s_gtk4_g_menu_append(submenu, label, detailed);
+
+    void *action = s_gtk4_g_simple_action_new(action_name, NULL);
+    if (g_callback_count < MAX_CALLBACKS)
+    {
+        g_callbacks[g_callback_count] = (callback_entry_t){action, GUI_EVENT_CLICK, cb};
+        G.g_signal_connect_data(action, "activate", (GCallback)gtk4_on_action_activate,
+                                &g_callbacks[g_callback_count].cb, NULL, 0);
+        g_callback_count++;
+    }
+    if (s_gtk4_action_group)
+        s_gtk4_g_action_map_add_action(s_gtk4_action_group, action);
+}
+
 static const gtk_version_ops_t g_gtk4_ops = {
     .version_name = "GTK4",
     .close_signal = "close-request",
@@ -760,6 +906,9 @@ static const gtk_version_ops_t g_gtk4_ops = {
     .scrolled_window_new = gtk4_scrolled_window_new,
     .scrolled_window_set_child = gtk4_scrolled_window_set_child,
     .frame_set_child = gtk4_frame_set_child,
+    .menubar_create = gtk4_menubar_create,
+    .menu_add_submenu = gtk4_menu_add_submenu,
+    .menu_add_item = gtk4_menu_add_item,
 };
 
 static bool load_gtk4_symbols(void)
@@ -783,6 +932,14 @@ static bool load_gtk4_symbols(void)
     LOAD_LOCAL(s_gtk4_scrolled_window_new, gtk_scrolled_window_new);
     LOAD_LOCAL(s_gtk4_scrolled_window_set_child, gtk_scrolled_window_set_child);
     LOAD_LOCAL(s_gtk4_frame_set_child, gtk_frame_set_child);
+    LOAD_LOCAL(s_gtk4_popover_menu_bar_new, gtk_popover_menu_bar_new_from_model);
+    LOAD_LOCAL(s_gtk4_g_menu_new, g_menu_new);
+    LOAD_LOCAL(s_gtk4_g_menu_append, g_menu_append);
+    LOAD_LOCAL(s_gtk4_g_menu_append_submenu, g_menu_append_submenu);
+    LOAD_LOCAL(s_gtk4_g_simple_action_new, g_simple_action_new);
+    LOAD_LOCAL(s_gtk4_g_action_map_add_action, g_action_map_add_action);
+    LOAD_LOCAL(s_gtk4_g_simple_action_group_new, g_simple_action_group_new);
+    LOAD_LOCAL(s_gtk4_gtk_widget_insert_action_group, gtk_widget_insert_action_group);
     return true;
 fail:
     return false;
@@ -1473,6 +1630,29 @@ static void gtk_be_listbox_set_selected(void *handle, int index)
     G.gtk_list_box_select_row(lb, row);
 }
 
+/* ── Menu ────────────────────────────────────────────────────────── */
+
+static void *gtk_be_menubar_create(void *window)
+{
+    return g_vops->menubar_create(window);
+}
+
+static void gtk_be_menubar_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void *gtk_be_menu_add_submenu(void *menubar, const char *label)
+{
+    return g_vops->menu_add_submenu(menubar, label);
+}
+
+static void gtk_be_menu_add_item(void *submenu, const char *label, gui_callback_t cb)
+{
+    g_vops->menu_add_item(submenu, label, cb);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void gtk_be_widget_grid(void *handle, int col, int row)
@@ -1602,6 +1782,10 @@ const gui_backend_t gui_backend_gtk = {
     .listbox_add_item = gtk_be_listbox_add_item,
     .listbox_get_selected = gtk_be_listbox_get_selected,
     .listbox_set_selected = gtk_be_listbox_set_selected,
+    .menubar_create = gtk_be_menubar_create,
+    .menubar_destroy = gtk_be_menubar_destroy,
+    .menu_add_submenu = gtk_be_menu_add_submenu,
+    .menu_add_item = gtk_be_menu_add_item,
     .widget_grid = gtk_be_widget_grid,
     .widget_grid_span = gtk_be_widget_grid_span,
     .widget_grid_remove = gtk_be_widget_grid_remove,

--- a/plugins/gui/backends/gui_stub.c
+++ b/plugins/gui/backends/gui_stub.c
@@ -111,6 +111,12 @@ static void *stub_create_ddd(void *p, double a, double b, double c)
     (void)c;
     return NULL;
 }
+static void stub_menu_add_item(void *s, const char *l, gui_callback_t cb)
+{
+    (void)s;
+    (void)l;
+    (void)cb;
+}
 static void stub_grid(void *h, int c, int r)
 {
     (void)h;
@@ -203,6 +209,10 @@ const gui_backend_t gui_backend_stub = {
     .listbox_add_item = stub_set_text,
     .listbox_get_selected = stub_get_int,
     .listbox_set_selected = stub_set_int,
+    .menubar_create = stub_create_notext,
+    .menubar_destroy = stub_destroy,
+    .menu_add_submenu = stub_create,
+    .menu_add_item = stub_menu_add_item,
     .widget_grid = stub_grid,
     .widget_grid_span = stub_grid_span,
     .widget_grid_remove = stub_grid_remove,

--- a/plugins/gui/backends/gui_win32.c
+++ b/plugins/gui/backends/gui_win32.c
@@ -222,6 +222,14 @@ static LRESULT CALLBACK vigil_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
                 cb->fn(cb->user_data);
             return 0;
         }
+        /* Menu item commands (lp == 0 for menu items). */
+        if (lp == 0 && HIWORD(wp) == 0)
+        {
+            int id = LOWORD(wp) - g_menu_id_base;
+            if (id >= 0 && id < g_menu_cb_count && g_menu_cbs[id].fn)
+                g_menu_cbs[id].fn(g_menu_cbs[id].user_data);
+            return 0;
+        }
         break;
 
     case WM_SIZE: {
@@ -757,6 +765,43 @@ static void win32_listbox_set_selected(void *handle, int index)
         SendMessageW((HWND)handle, LB_SETCURSEL, (WPARAM)index, 0);
 }
 
+/* ── Menu ────────────────────────────────────────────────────────── */
+
+#define MAX_MENU_CALLBACKS 128
+static gui_callback_t g_menu_cbs[MAX_MENU_CALLBACKS];
+static int g_menu_cb_count = 0;
+static int g_menu_id_base = 9000;
+
+static void *win32_menubar_create(void *window)
+{
+    HMENU mb = CreateMenu();
+    if (mb)
+        SetMenu((HWND)window, mb);
+    return (void *)mb;
+}
+
+static void win32_menubar_destroy(void *handle)
+{
+    if (handle)
+        DestroyMenu((HMENU)handle);
+}
+
+static void *win32_menu_add_submenu(void *menubar, const char *label)
+{
+    HMENU sub = CreatePopupMenu();
+    if (sub)
+        AppendMenuW((HMENU)menubar, MF_POPUP, (UINT_PTR)sub, to_wide(label));
+    return (void *)sub;
+}
+
+static void win32_menu_add_item(void *submenu, const char *label, gui_callback_t cb)
+{
+    int id = g_menu_id_base + g_menu_cb_count;
+    if (g_menu_cb_count < MAX_MENU_CALLBACKS)
+        g_menu_cbs[g_menu_cb_count++] = cb;
+    AppendMenuW((HMENU)submenu, MF_STRING, (UINT_PTR)id, to_wide(label));
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void win32_widget_grid(void *handle, int col, int row)
@@ -879,6 +924,10 @@ const gui_backend_t gui_backend_win32 = {
     .listbox_add_item = win32_listbox_add_item,
     .listbox_get_selected = win32_listbox_get_selected,
     .listbox_set_selected = win32_listbox_set_selected,
+    .menubar_create = win32_menubar_create,
+    .menubar_destroy = win32_menubar_destroy,
+    .menu_add_submenu = win32_menu_add_submenu,
+    .menu_add_item = win32_menu_add_item,
     .widget_grid = win32_widget_grid,
     .widget_grid_span = win32_widget_grid_span,
     .widget_grid_remove = win32_widget_grid_remove,

--- a/plugins/gui/gui.c
+++ b/plugins/gui/gui.c
@@ -86,6 +86,8 @@ static gui_handle_registry_t g_radios = {{0}, 0};
 static gui_handle_registry_t g_spinboxes = {{0}, 0};
 static gui_handle_registry_t g_frames = {{0}, 0};
 static gui_handle_registry_t g_listboxes = {{0}, 0};
+static gui_handle_registry_t g_menubars = {{0}, 0};
+static gui_handle_registry_t g_submenus = {{0}, 0};
 
 /* ── Stack helpers ───────────────────────────────────────────────── */
 
@@ -191,6 +193,7 @@ enum
     GUI_SPINBOX_CLASS_INDEX = 10U,
     GUI_FRAME_CLASS_INDEX = 11U,
     GUI_LISTBOX_CLASS_INDEX = 12U,
+    GUI_MENU_CLASS_INDEX = 13U,
 };
 
 /* ── Callback bridge ─────────────────────────────────────────────── */
@@ -1437,6 +1440,79 @@ static vigil_status_t gui_listbox_on_change(vigil_vm_t *vm, size_t arg_count, vi
     return VIGIL_STATUS_OK;
 }
 
+/* ── gui.Menu ────────────────────────────────────────────────────── */
+
+static vigil_status_t gui_menu_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t win_h = gui_arg_handle(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *win = gui_handle_get(&g_windows, win_h);
+    if (!win || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_MENU_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+    void *native = g_backend->menubar_create(win);
+    int64_t handle;
+    gui_handle_store(&g_menubars, native, &handle);
+    gui_push_handle_instance(vm, GUI_MENU_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_menu_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_menubars, h);
+    if (native && g_backend)
+        g_backend->menubar_destroy(native);
+    gui_handle_clear(&g_menubars, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_menu_add_submenu(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    char buf[256];
+    const char *label = gui_arg_str(vm, base, 1, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *menubar = gui_handle_get(&g_menubars, h);
+    if (!menubar || !g_backend)
+        return gui_push_i32(vm, -1, error);
+    void *submenu = g_backend->menu_add_submenu(menubar, label);
+    int64_t sub_h;
+    gui_handle_store(&g_submenus, submenu, &sub_h);
+    return gui_push_i32(vm, (int32_t)sub_h, error);
+}
+
+static vigil_status_t gui_menu_add_item(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int32_t sub_idx = gui_arg_i32(vm, base, 1);
+    char buf[256];
+    const char *label = gui_arg_str(vm, base, 2, buf, sizeof(buf));
+    vigil_value_t closure = vigil_vm_stack_get(vm, base + 3);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    (void)h;
+    void *submenu = gui_handle_get(&g_submenus, (int64_t)sub_idx);
+    if (submenu && g_backend)
+    {
+        gui_closure_t *c = gui_closure_store(vm, closure);
+        if (c)
+        {
+            gui_callback_t cb = {gui_closure_invoke, c};
+            g_backend->menu_add_item(submenu, label, cb);
+        }
+    }
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── gui.message_box (module-level function) ─────────────────────── */
 
 static vigil_status_t gui_fn_message_box(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
@@ -1476,6 +1552,7 @@ static const int rt_f64[] = {VIGIL_TYPE_F64};
 static const int rt_i32[] = {VIGIL_TYPE_I32};
 static const int p_obj_str_obj[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_STRING, VIGIL_TYPE_OBJECT};
 static const int p_obj_f64_f64_f64[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
+static const int p_i32_str_obj[] = {VIGIL_TYPE_I32, VIGIL_TYPE_STRING, VIGIL_TYPE_OBJECT};
 
 /* ── Macro helpers ───────────────────────────────────────────────── */
 
@@ -1681,6 +1758,19 @@ static const vigil_native_class_method_t gui_listbox_methods[] = {
     GUI_METHOD("on_change", 9U, gui_listbox_on_change, 1U, p_obj, VIGIL_TYPE_VOID, 0U, NULL),
 };
 
+/* ── Menu class ──────────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_menu_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_menu_methods[] = {
+    GUI_STATIC("new", 3U, gui_menu_new, 1U, p_obj, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_menu_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("add_submenu", 11U, gui_menu_add_submenu, 1U, p_str, VIGIL_TYPE_I32, 1U, rt_i32),
+    GUI_METHOD("add_item", 8U, gui_menu_add_item, 3U, p_i32_str_obj, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
 /* ── Class table ─────────────────────────────────────────────────── */
 
 /* clang-format off */
@@ -1698,6 +1788,7 @@ static const vigil_native_class_t gui_classes[] = {
     {"Spinbox",     7U,  gui_spinbox_fields,  1U, gui_spinbox_methods,  sizeof(gui_spinbox_methods)  / sizeof(gui_spinbox_methods[0]),  NULL, NULL},
     {"Frame",       5U,  gui_frame_fields,    1U, gui_frame_methods,    sizeof(gui_frame_methods)    / sizeof(gui_frame_methods[0]),    NULL, NULL},
     {"Listbox",     7U,  gui_listbox_fields,  1U, gui_listbox_methods,  sizeof(gui_listbox_methods)  / sizeof(gui_listbox_methods[0]),  NULL, NULL},
+    {"Menu",        4U,  gui_menu_fields,     1U, gui_menu_methods,     sizeof(gui_menu_methods)     / sizeof(gui_menu_methods[0]),     NULL, NULL},
 };
 /* clang-format on */
 

--- a/plugins/gui/gui_backend.h
+++ b/plugins/gui/gui_backend.h
@@ -122,6 +122,12 @@ extern "C"
         int (*listbox_get_selected)(void *handle);
         void (*listbox_set_selected)(void *handle, int index);
 
+        /* Menu bar */
+        void *(*menubar_create)(void *window);
+        void (*menubar_destroy)(void *handle);
+        void *(*menu_add_submenu)(void *menubar, const char *label);
+        void (*menu_add_item)(void *submenu, const char *label, gui_callback_t cb);
+
         /* Grid layout */
         void (*widget_grid)(void *handle, int col, int row);
         void (*widget_grid_span)(void *handle, int col, int row, int colspan, int rowspan);

--- a/tests/gui_test.c
+++ b/tests/gui_test.c
@@ -65,7 +65,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    EXPECT_EQ(mod->class_count, 13U);
+    EXPECT_EQ(mod->class_count, 14U);
     EXPECT_NE(find_class(mod, "App"), NULL);
     EXPECT_NE(find_class(mod, "Window"), NULL);
     EXPECT_NE(find_class(mod, "Label"), NULL);
@@ -79,6 +79,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     EXPECT_NE(find_class(mod, "Spinbox"), NULL);
     EXPECT_NE(find_class(mod, "Frame"), NULL);
     EXPECT_NE(find_class(mod, "Listbox"), NULL);
+    EXPECT_NE(find_class(mod, "Menu"), NULL);
 }
 
 TEST(GuiPlugin, HasMessageBoxFunction)
@@ -325,6 +326,22 @@ TEST(GuiPlugin, ListboxClassMethods)
     EXPECT_NE(find_method(cls, "on_change"), NULL);
 }
 
+TEST(GuiPlugin, MenuClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Menu");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "add_submenu"), NULL);
+    EXPECT_NE(find_method(cls, "add_item"), NULL);
+}
+
 TEST(GuiPlugin, AppNewIsStatic)
 {
     if (!gui_plugin_available())
@@ -349,8 +366,8 @@ TEST(GuiPlugin, EachClassHasHandleField)
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
     static const char *names[] = {"App",    "Window", "Label",       "Button",  "Entry", "Checkbox", "Slider",
-                                  "Select", "Text",   "Radiobutton", "Spinbox", "Frame", "Listbox"};
-    for (size_t i = 0; i < 13; i++)
+                                  "Select", "Text",   "Radiobutton", "Spinbox", "Frame", "Listbox",  "Menu"};
+    for (size_t i = 0; i < 14; i++)
     {
         const vigil_native_class_t *cls = find_class(mod, names[i]);
         ASSERT_NE(cls, NULL);
@@ -391,6 +408,7 @@ void register_gui_tests(void)
     REGISTER_TEST(GuiPlugin, SpinboxClassMethods);
     REGISTER_TEST(GuiPlugin, FrameClassMethods);
     REGISTER_TEST(GuiPlugin, ListboxClassMethods);
+    REGISTER_TEST(GuiPlugin, MenuClassMethods);
     REGISTER_TEST(GuiPlugin, AppNewIsStatic);
     REGISTER_TEST(GuiPlugin, EachClassHasHandleField);
     REGISTER_TEST(GuiPlugin, ModuleHasDoc);


### PR DESCRIPTION
## Summary

Adds `gui.Menu` — application menu bar with submenus and item callbacks. Part of Phase 3 from #399.

## API

```vigil
gui.Menu menu, err e = gui.Menu.new(win)
i32 file_menu = menu.add_submenu("File")
menu.add_item(file_menu, "Open", fn() -> void { ... })
menu.add_item(file_menu, "Quit", fn() -> void { ... })
```

## Backend Implementations

| Platform | Implementation |
|---|---|
| GTK3 | GtkMenuBar + GtkMenu + GtkMenuItem (activate signal) |
| GTK4 | GMenu model + GtkPopoverMenuBar + GSimpleActionGroup |
| Cocoa | NSMenu + NSMenuItem with submenu + action target |
| Win32 | CreateMenu + AppendMenu + WM_COMMAND dispatch |

GTK4 note: uses `gtk_widget_insert_action_group` with a `GSimpleActionGroup` since plain `GtkWindow` doesn't implement `GActionMap`.

## Testing
- All 34 test suites pass, 20 GUI unit tests covering all 14 classes
- GTK4 menu tested under xvfb — no segfault, creates successfully
- clang-format clean

Part of #399 Phase 3.