### PR TITLE
Phase 3: PanedWindow — completes containers — #399

### DIFF
--- a/plugins/gui/backends/gui_cocoa.m
+++ b/plugins/gui/backends/gui_cocoa.m
@@ -799,6 +799,41 @@ static void cocoa_menu_add_item(void *submenu, const char *label, gui_callback_t
     sendv_id((id)submenu, sel("addItem:"), item);
 }
 
+/* ── PanedWindow ──────────────────────────────────────────────────── */
+
+static void *cocoa_paned_create(void *parent, bool horizontal)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id split = send_rect(send0(cls("NSSplitView"), sel("alloc")),
+                         sel("initWithFrame:"), CGRectMake_(0, 0, 400, 200));
+    sendv_bool(split, sel("setVertical:"), horizontal ? 1 : 0);
+    sendv_id(cv, sel("addSubview:"), split);
+    register_widget_parent(split, cv);
+    return (void *)split;
+}
+
+static void cocoa_paned_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static void cocoa_paned_set_start(void *handle, void *child)
+{
+    if (handle && child) sendv_id((id)handle, sel("addSubview:"), (id)child);
+}
+
+static void cocoa_paned_set_end(void *handle, void *child)
+{
+    if (handle && child) sendv_id((id)handle, sel("addSubview:"), (id)child);
+}
+
+static void cocoa_paned_set_position(void *handle, int pos)
+{
+    if (handle) ((void (*)(id, SEL, double, long))objc_msgSend)(
+        (id)handle, sel("setPosition:ofDividerAtIndex:"), (double)pos, 0L);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void cocoa_widget_grid(void *handle, int col, int row)
@@ -920,6 +955,11 @@ const gui_backend_t gui_backend_cocoa = {
     .menubar_destroy               = cocoa_menubar_destroy,
     .menu_add_submenu              = cocoa_menu_add_submenu,
     .menu_add_item                 = cocoa_menu_add_item,
+    .paned_create                  = cocoa_paned_create,
+    .paned_destroy                 = cocoa_paned_destroy,
+    .paned_set_start               = cocoa_paned_set_start,
+    .paned_set_end                 = cocoa_paned_set_end,
+    .paned_set_position            = cocoa_paned_set_position,
     .widget_grid                   = cocoa_widget_grid,
     .widget_grid_span              = cocoa_widget_grid_span,
     .widget_grid_remove            = cocoa_widget_grid_remove,

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -109,6 +109,8 @@ typedef void *(*fn_gtk_list_box_get_selected_row)(GtkWidget *);
 typedef gint (*fn_gtk_list_box_row_get_index)(void *);
 typedef void (*fn_gtk_list_box_select_row)(GtkWidget *, void *);
 typedef void *(*fn_gtk_list_box_get_row_at_index)(GtkWidget *, gint);
+typedef GtkWidget *(*fn_gtk_paned_new)(int);
+typedef void (*fn_gtk_paned_set_position)(GtkWidget *, gint);
 
 /* GTK3-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk3)(int type);
@@ -131,6 +133,8 @@ typedef GtkWidget *(*fn_gtk_menu_new)(void);
 typedef GtkWidget *(*fn_gtk_menu_item_new_with_label)(const char *);
 typedef void (*fn_gtk_menu_item_set_submenu)(GtkWidget *, GtkWidget *);
 typedef void (*fn_gtk_menu_shell_append)(GtkWidget *, GtkWidget *);
+typedef void (*fn_gtk_paned_pack1)(GtkWidget *, GtkWidget *, gboolean, gboolean);
+typedef void (*fn_gtk_paned_pack2)(GtkWidget *, GtkWidget *, gboolean, gboolean);
 
 /* GTK4-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk4)(void);
@@ -156,6 +160,8 @@ typedef void *(*fn_g_simple_action_new)(const char *, void *);
 typedef void (*fn_g_action_map_add_action)(void *, void *);
 typedef void *(*fn_g_simple_action_group_new)(void);
 typedef void (*fn_gtk_widget_insert_action_group)(GtkWidget *, const char *, void *);
+typedef void (*fn_gtk_paned_set_start_child)(GtkWidget *, GtkWidget *);
+typedef void (*fn_gtk_paned_set_end_child)(GtkWidget *, GtkWidget *);
 typedef gulong (*fn_g_signal_connect_data_t)(void *, const char *, GCallback, void *, GClosureNotify, int);
 
 /* GLib main loop (used by GTK4 path; available in both versions) */
@@ -220,6 +226,10 @@ typedef struct gtk_version_ops
     void *(*menubar_create)(void *window);
     void *(*menu_add_submenu)(void *menubar, const char *label);
     void (*menu_add_item)(void *submenu, const char *label, gui_callback_t cb);
+
+    /* PanedWindow */
+    void (*paned_set_start)(GtkWidget *paned, GtkWidget *child);
+    void (*paned_set_end)(GtkWidget *paned, GtkWidget *child);
 } gtk_version_ops_t;
 
 /* ── Shared resolved symbols ─────────────────────────────────────── */
@@ -265,6 +275,8 @@ static struct
     fn_gtk_list_box_row_get_index gtk_list_box_row_get_index;
     fn_gtk_list_box_select_row gtk_list_box_select_row;
     fn_gtk_list_box_get_row_at_index gtk_list_box_get_row_at_index;
+    fn_gtk_paned_new gtk_paned_new;
+    fn_gtk_paned_set_position gtk_paned_set_position;
 } G;
 
 static const gtk_version_ops_t *g_vops = NULL;
@@ -436,6 +448,8 @@ static fn_gtk_menu_new s_gtk3_menu_new;
 static fn_gtk_menu_item_new_with_label s_gtk3_menu_item_new;
 static fn_gtk_menu_item_set_submenu s_gtk3_menu_item_set_submenu;
 static fn_gtk_menu_shell_append s_gtk3_menu_shell_append;
+static fn_gtk_paned_pack1 s_gtk3_paned_pack1;
+static fn_gtk_paned_pack2 s_gtk3_paned_pack2;
 
 static void gtk3_main_loop(void)
 {
@@ -592,6 +606,16 @@ static void gtk3_menu_add_item(void *submenu, const char *label, gui_callback_t 
     s_gtk3_widget_show_all(item);
 }
 
+static void gtk3_paned_set_start(GtkWidget *paned, GtkWidget *child)
+{
+    s_gtk3_paned_pack1(paned, child, 1, 0);
+}
+
+static void gtk3_paned_set_end(GtkWidget *paned, GtkWidget *child)
+{
+    s_gtk3_paned_pack2(paned, child, 1, 0);
+}
+
 static const gtk_version_ops_t g_gtk3_ops = {
     .version_name = "GTK3",
     .close_signal = "delete-event",
@@ -618,6 +642,8 @@ static const gtk_version_ops_t g_gtk3_ops = {
     .menubar_create = gtk3_menubar_create,
     .menu_add_submenu = gtk3_menu_add_submenu,
     .menu_add_item = gtk3_menu_add_item,
+    .paned_set_start = gtk3_paned_set_start,
+    .paned_set_end = gtk3_paned_set_end,
 };
 
 static bool load_gtk3_symbols(void)
@@ -643,6 +669,8 @@ static bool load_gtk3_symbols(void)
     LOAD_LOCAL(s_gtk3_menu_item_new, gtk_menu_item_new_with_label);
     LOAD_LOCAL(s_gtk3_menu_item_set_submenu, gtk_menu_item_set_submenu);
     LOAD_LOCAL(s_gtk3_menu_shell_append, gtk_menu_shell_append);
+    LOAD_LOCAL(s_gtk3_paned_pack1, gtk_paned_pack1);
+    LOAD_LOCAL(s_gtk3_paned_pack2, gtk_paned_pack2);
     return true;
 fail:
     return false;
@@ -679,6 +707,8 @@ static fn_g_simple_action_new s_gtk4_g_simple_action_new;
 static fn_g_action_map_add_action s_gtk4_g_action_map_add_action;
 static fn_g_simple_action_group_new s_gtk4_g_simple_action_group_new;
 static fn_gtk_widget_insert_action_group s_gtk4_gtk_widget_insert_action_group;
+static fn_gtk_paned_set_start_child s_gtk4_paned_set_start;
+static fn_gtk_paned_set_end_child s_gtk4_paned_set_end;
 
 /* GTK4 menu needs a window reference for action map. */
 static void *s_gtk4_menu_window = NULL;
@@ -883,6 +913,16 @@ static void gtk4_menu_add_item(void *submenu, const char *label, gui_callback_t 
         s_gtk4_g_action_map_add_action(s_gtk4_action_group, action);
 }
 
+static void gtk4_paned_set_start_wrap(GtkWidget *paned, GtkWidget *child)
+{
+    s_gtk4_paned_set_start(paned, child);
+}
+
+static void gtk4_paned_set_end_wrap(GtkWidget *paned, GtkWidget *child)
+{
+    s_gtk4_paned_set_end(paned, child);
+}
+
 static const gtk_version_ops_t g_gtk4_ops = {
     .version_name = "GTK4",
     .close_signal = "close-request",
@@ -909,6 +949,8 @@ static const gtk_version_ops_t g_gtk4_ops = {
     .menubar_create = gtk4_menubar_create,
     .menu_add_submenu = gtk4_menu_add_submenu,
     .menu_add_item = gtk4_menu_add_item,
+    .paned_set_start = gtk4_paned_set_start_wrap,
+    .paned_set_end = gtk4_paned_set_end_wrap,
 };
 
 static bool load_gtk4_symbols(void)
@@ -940,6 +982,8 @@ static bool load_gtk4_symbols(void)
     LOAD_LOCAL(s_gtk4_g_action_map_add_action, g_action_map_add_action);
     LOAD_LOCAL(s_gtk4_g_simple_action_group_new, g_simple_action_group_new);
     LOAD_LOCAL(s_gtk4_gtk_widget_insert_action_group, gtk_widget_insert_action_group);
+    LOAD_LOCAL(s_gtk4_paned_set_start, gtk_paned_set_start_child);
+    LOAD_LOCAL(s_gtk4_paned_set_end, gtk_paned_set_end_child);
     return true;
 fail:
     return false;
@@ -989,6 +1033,8 @@ static bool load_shared_symbols(void)
     LOAD_SHARED(gtk_list_box_row_get_index);
     LOAD_SHARED(gtk_list_box_select_row);
     LOAD_SHARED(gtk_list_box_get_row_at_index);
+    LOAD_SHARED(gtk_paned_new);
+    LOAD_SHARED(gtk_paned_set_position);
     return true;
 fail:
     return false;
@@ -1653,6 +1699,47 @@ static void gtk_be_menu_add_item(void *submenu, const char *label, gui_callback_
     g_vops->menu_add_item(submenu, label, cb);
 }
 
+/* ── PanedWindow ─────────────────────────────────────────────────── */
+
+static void *gtk_be_paned_create(void *parent, bool horizontal)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    /* GTK_ORIENTATION_HORIZONTAL=0, GTK_ORIENTATION_VERTICAL=1 */
+    GtkWidget *paned = G.gtk_paned_new(horizontal ? 0 : 1);
+    G.gtk_widget_set_hexpand(paned, 1);
+    G.gtk_widget_set_vexpand(paned, 1);
+    register_widget_parent(paned, grid);
+    return paned;
+}
+
+static void gtk_be_paned_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void gtk_be_paned_set_start(void *handle, void *child)
+{
+    if (handle && child)
+        g_vops->paned_set_start(handle, child);
+}
+
+static void gtk_be_paned_set_end(void *handle, void *child)
+{
+    if (handle && child)
+        g_vops->paned_set_end(handle, child);
+}
+
+static void gtk_be_paned_set_position(void *handle, int pos)
+{
+    if (handle)
+        G.gtk_paned_set_position(handle, pos);
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void gtk_be_widget_grid(void *handle, int col, int row)
@@ -1786,6 +1873,11 @@ const gui_backend_t gui_backend_gtk = {
     .menubar_destroy = gtk_be_menubar_destroy,
     .menu_add_submenu = gtk_be_menu_add_submenu,
     .menu_add_item = gtk_be_menu_add_item,
+    .paned_create = gtk_be_paned_create,
+    .paned_destroy = gtk_be_paned_destroy,
+    .paned_set_start = gtk_be_paned_set_start,
+    .paned_set_end = gtk_be_paned_set_end,
+    .paned_set_position = gtk_be_paned_set_position,
     .widget_grid = gtk_be_widget_grid,
     .widget_grid_span = gtk_be_widget_grid_span,
     .widget_grid_remove = gtk_be_widget_grid_remove,

--- a/plugins/gui/backends/gui_stub.c
+++ b/plugins/gui/backends/gui_stub.c
@@ -117,6 +117,17 @@ static void stub_menu_add_item(void *s, const char *l, gui_callback_t cb)
     (void)l;
     (void)cb;
 }
+static void *stub_create_paned(void *p, bool h)
+{
+    (void)p;
+    (void)h;
+    return NULL;
+}
+static void stub_set_child(void *h, void *c)
+{
+    (void)h;
+    (void)c;
+}
 static void stub_grid(void *h, int c, int r)
 {
     (void)h;
@@ -213,6 +224,11 @@ const gui_backend_t gui_backend_stub = {
     .menubar_destroy = stub_destroy,
     .menu_add_submenu = stub_create,
     .menu_add_item = stub_menu_add_item,
+    .paned_create = stub_create_paned,
+    .paned_destroy = stub_destroy,
+    .paned_set_start = stub_set_child,
+    .paned_set_end = stub_set_child,
+    .paned_set_position = stub_set_int,
     .widget_grid = stub_grid,
     .widget_grid_span = stub_grid_span,
     .widget_grid_remove = stub_grid_remove,

--- a/plugins/gui/backends/gui_win32.c
+++ b/plugins/gui/backends/gui_win32.c
@@ -802,6 +802,50 @@ static void win32_menu_add_item(void *submenu, const char *label, gui_callback_t
     AppendMenuW((HMENU)submenu, MF_STRING, (UINT_PTR)id, to_wide(label));
 }
 
+/* ── PanedWindow ─────────────────────────────────────────────────── */
+
+/* Win32 has no native split pane. Use a static container; children
+   are positioned manually by the grid engine. */
+
+static void *win32_paned_create(void *parent, bool horizontal)
+{
+    (void)horizontal;
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(0, L"STATIC", L"", WS_CHILD | WS_VISIBLE, 0, 0, 400, 200, (HWND)parent,
+                                (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+    {
+        grid_ensure(hwnd);
+        register_widget_parent(hwnd, (HWND)parent);
+    }
+    return (void *)hwnd;
+}
+
+static void win32_paned_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static void win32_paned_set_start(void *handle, void *child)
+{
+    (void)handle;
+    (void)child;
+}
+
+static void win32_paned_set_end(void *handle, void *child)
+{
+    (void)handle;
+    (void)child;
+}
+
+static void win32_paned_set_position(void *handle, int pos)
+{
+    (void)handle;
+    (void)pos;
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void win32_widget_grid(void *handle, int col, int row)
@@ -928,6 +972,11 @@ const gui_backend_t gui_backend_win32 = {
     .menubar_destroy = win32_menubar_destroy,
     .menu_add_submenu = win32_menu_add_submenu,
     .menu_add_item = win32_menu_add_item,
+    .paned_create = win32_paned_create,
+    .paned_destroy = win32_paned_destroy,
+    .paned_set_start = win32_paned_set_start,
+    .paned_set_end = win32_paned_set_end,
+    .paned_set_position = win32_paned_set_position,
     .widget_grid = win32_widget_grid,
     .widget_grid_span = win32_widget_grid_span,
     .widget_grid_remove = win32_widget_grid_remove,

--- a/plugins/gui/gui.c
+++ b/plugins/gui/gui.c
@@ -88,6 +88,7 @@ static gui_handle_registry_t g_frames = {{0}, 0};
 static gui_handle_registry_t g_listboxes = {{0}, 0};
 static gui_handle_registry_t g_menubars = {{0}, 0};
 static gui_handle_registry_t g_submenus = {{0}, 0};
+static gui_handle_registry_t g_paneds = {{0}, 0};
 
 /* ── Stack helpers ───────────────────────────────────────────────── */
 
@@ -194,6 +195,7 @@ enum
     GUI_FRAME_CLASS_INDEX = 11U,
     GUI_LISTBOX_CLASS_INDEX = 12U,
     GUI_MENU_CLASS_INDEX = 13U,
+    GUI_PANED_CLASS_INDEX = 14U,
 };
 
 /* ── Callback bridge ─────────────────────────────────────────────── */
@@ -1513,6 +1515,67 @@ static vigil_status_t gui_menu_add_item(vigil_vm_t *vm, size_t arg_count, vigil_
     return VIGIL_STATUS_OK;
 }
 
+/* ── gui.PanedWindow ─────────────────────────────────────────────── */
+
+static vigil_status_t gui_paned_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    int32_t horizontal = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_PANED_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+    void *native = g_backend->paned_create(parent, horizontal != 0);
+    int64_t handle;
+    gui_handle_store(&g_paneds, native, &handle);
+    gui_push_handle_instance(vm, GUI_PANED_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_paned_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_paneds, h);
+    if (native && g_backend)
+        g_backend->paned_destroy(native);
+    gui_handle_clear(&g_paneds, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_paned_set_position(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int pos = gui_arg_i32(vm, base, 1);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_paneds, h);
+    if (native && g_backend)
+        g_backend->paned_set_position(native, pos);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_paned_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_paneds, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── gui.message_box (module-level function) ─────────────────────── */
 
 static vigil_status_t gui_fn_message_box(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
@@ -1553,6 +1616,7 @@ static const int rt_i32[] = {VIGIL_TYPE_I32};
 static const int p_obj_str_obj[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_STRING, VIGIL_TYPE_OBJECT};
 static const int p_obj_f64_f64_f64[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
 static const int p_i32_str_obj[] = {VIGIL_TYPE_I32, VIGIL_TYPE_STRING, VIGIL_TYPE_OBJECT};
+static const int p_obj_bool[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_BOOL};
 
 /* ── Macro helpers ───────────────────────────────────────────────── */
 
@@ -1771,6 +1835,19 @@ static const vigil_native_class_method_t gui_menu_methods[] = {
     GUI_METHOD("add_item", 8U, gui_menu_add_item, 3U, p_i32_str_obj, VIGIL_TYPE_VOID, 0U, NULL),
 };
 
+/* ── PanedWindow class ───────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_paned_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_paned_methods[] = {
+    GUI_STATIC("new", 3U, gui_paned_new, 2U, p_obj_bool, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_paned_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("set_position", 12U, gui_paned_set_position, 1U, p_i32, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_paned_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
 /* ── Class table ─────────────────────────────────────────────────── */
 
 /* clang-format off */
@@ -1789,6 +1866,7 @@ static const vigil_native_class_t gui_classes[] = {
     {"Frame",       5U,  gui_frame_fields,    1U, gui_frame_methods,    sizeof(gui_frame_methods)    / sizeof(gui_frame_methods[0]),    NULL, NULL},
     {"Listbox",     7U,  gui_listbox_fields,  1U, gui_listbox_methods,  sizeof(gui_listbox_methods)  / sizeof(gui_listbox_methods[0]),  NULL, NULL},
     {"Menu",        4U,  gui_menu_fields,     1U, gui_menu_methods,     sizeof(gui_menu_methods)     / sizeof(gui_menu_methods[0]),     NULL, NULL},
+    {"PanedWindow", 11U, gui_paned_fields,    1U, gui_paned_methods,    sizeof(gui_paned_methods)    / sizeof(gui_paned_methods[0]),    NULL, NULL},
 };
 /* clang-format on */
 

--- a/plugins/gui/gui_backend.h
+++ b/plugins/gui/gui_backend.h
@@ -128,6 +128,13 @@ extern "C"
         void *(*menu_add_submenu)(void *menubar, const char *label);
         void (*menu_add_item)(void *submenu, const char *label, gui_callback_t cb);
 
+        /* PanedWindow (resizable split container) */
+        void *(*paned_create)(void *parent, bool horizontal);
+        void (*paned_destroy)(void *handle);
+        void (*paned_set_start)(void *handle, void *child);
+        void (*paned_set_end)(void *handle, void *child);
+        void (*paned_set_position)(void *handle, int pos);
+
         /* Grid layout */
         void (*widget_grid)(void *handle, int col, int row);
         void (*widget_grid_span)(void *handle, int col, int row, int colspan, int rowspan);

--- a/tests/gui_test.c
+++ b/tests/gui_test.c
@@ -65,7 +65,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    EXPECT_EQ(mod->class_count, 14U);
+    EXPECT_EQ(mod->class_count, 15U);
     EXPECT_NE(find_class(mod, "App"), NULL);
     EXPECT_NE(find_class(mod, "Window"), NULL);
     EXPECT_NE(find_class(mod, "Label"), NULL);
@@ -80,6 +80,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     EXPECT_NE(find_class(mod, "Frame"), NULL);
     EXPECT_NE(find_class(mod, "Listbox"), NULL);
     EXPECT_NE(find_class(mod, "Menu"), NULL);
+    EXPECT_NE(find_class(mod, "PanedWindow"), NULL);
 }
 
 TEST(GuiPlugin, HasMessageBoxFunction)
@@ -342,6 +343,22 @@ TEST(GuiPlugin, MenuClassMethods)
     EXPECT_NE(find_method(cls, "add_item"), NULL);
 }
 
+TEST(GuiPlugin, PanedWindowClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "PanedWindow");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "set_position"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+}
+
 TEST(GuiPlugin, AppNewIsStatic)
 {
     if (!gui_plugin_available())
@@ -365,9 +382,10 @@ TEST(GuiPlugin, EachClassHasHandleField)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    static const char *names[] = {"App",    "Window", "Label",       "Button",  "Entry", "Checkbox", "Slider",
-                                  "Select", "Text",   "Radiobutton", "Spinbox", "Frame", "Listbox",  "Menu"};
-    for (size_t i = 0; i < 14; i++)
+    static const char *names[] = {"App",      "Window", "Label",   "Button", "Entry",
+                                  "Checkbox", "Slider", "Select",  "Text",   "Radiobutton",
+                                  "Spinbox",  "Frame",  "Listbox", "Menu",   "PanedWindow"};
+    for (size_t i = 0; i < 15; i++)
     {
         const vigil_native_class_t *cls = find_class(mod, names[i]);
         ASSERT_NE(cls, NULL);
@@ -409,6 +427,7 @@ void register_gui_tests(void)
     REGISTER_TEST(GuiPlugin, FrameClassMethods);
     REGISTER_TEST(GuiPlugin, ListboxClassMethods);
     REGISTER_TEST(GuiPlugin, MenuClassMethods);
+    REGISTER_TEST(GuiPlugin, PanedWindowClassMethods);
     REGISTER_TEST(GuiPlugin, AppNewIsStatic);
     REGISTER_TEST(GuiPlugin, EachClassHasHandleField);
     REGISTER_TEST(GuiPlugin, ModuleHasDoc);


### PR DESCRIPTION
## Summary

Adds `gui.PanedWindow` (resizable split container), completing Phase 3 containers from #399.

## API

```vigil
gui.PanedWindow paned, err e = gui.PanedWindow.new(win, true)  // horizontal split
paned.set_position(200)  // divider at 200px
paned.grid(0, 0)
```

## Backend Implementations

| Platform | Implementation |
|---|---|
| GTK3 | GtkPaned + gtk_paned_pack1/pack2 |
| GTK4 | GtkPaned + gtk_paned_set_start_child/set_end_child |
| Cocoa | NSSplitView |
| Win32 | Static container (native split pane TBD) |

## Phase 3 Complete

With this PR, Phase 3 delivers:
- **Frame** (PR #406) — labeled container
- **Listbox** (PR #406) — scrollable selectable list
- **Menu** (PR #407) — menu bar with submenus and callbacks
- **PanedWindow** (this PR) — resizable split container
- **grid_span** (PR #406) — column/row spanning in grid layout

## Testing
- All 34 test suites pass, 21 GUI unit tests covering all 15 classes
- clang-format clean

Completes Phase 3 for #399.