### PR TITLE
Phase 4: Canvas widget with drawing primitives — #399

### DIFF
--- a/plugins/gui/backends/gui_cocoa.m
+++ b/plugins/gui/backends/gui_cocoa.m
@@ -834,6 +834,38 @@ static void cocoa_paned_set_position(void *handle, int pos)
         (id)handle, sel("setPosition:ofDividerAtIndex:"), (double)pos, 0L);
 }
 
+/* ── Canvas ───────────────────────────────────────────────────────── */
+/* Cocoa canvas uses an NSView. Drawing is deferred — commands are
+   stored but actual rendering requires setNeedsDisplay + drawRect
+   override, which needs a runtime-created subclass. For now, provide
+   a basic NSView that can be extended later. */
+
+static void *cocoa_canvas_create(void *parent, int width, int height)
+{
+    if (!parent) return NULL;
+    id cv = send0((id)parent, sel("contentView"));
+    id view = send_rect(send0(cls("NSView"), sel("alloc")),
+                        sel("initWithFrame:"), CGRectMake_(0, 0, width, height));
+    sendv_id(cv, sel("addSubview:"), view);
+    register_widget_parent(view, cv);
+    return (void *)view;
+}
+
+static void cocoa_canvas_destroy(void *handle)
+{
+    if (handle) sendv((id)handle, sel("removeFromSuperview"));
+}
+
+static void cocoa_canvas_clear(void *handle) { (void)handle; }
+static void cocoa_canvas_draw_line(void *h, double x1, double y1, double x2, double y2)
+{ (void)h; (void)x1; (void)y1; (void)x2; (void)y2; }
+static void cocoa_canvas_draw_rect(void *h, double x, double y, double w, double ht)
+{ (void)h; (void)x; (void)y; (void)w; (void)ht; }
+static void cocoa_canvas_draw_oval(void *h, double x, double y, double w, double ht)
+{ (void)h; (void)x; (void)y; (void)w; (void)ht; }
+static void cocoa_canvas_draw_text(void *h, double x, double y, const char *t)
+{ (void)h; (void)x; (void)y; (void)t; }
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void cocoa_widget_grid(void *handle, int col, int row)
@@ -1021,6 +1053,13 @@ const gui_backend_t gui_backend_cocoa = {
     .paned_set_start               = cocoa_paned_set_start,
     .paned_set_end                 = cocoa_paned_set_end,
     .paned_set_position            = cocoa_paned_set_position,
+    .canvas_create                 = cocoa_canvas_create,
+    .canvas_destroy                = cocoa_canvas_destroy,
+    .canvas_clear                  = cocoa_canvas_clear,
+    .canvas_draw_line              = cocoa_canvas_draw_line,
+    .canvas_draw_rect              = cocoa_canvas_draw_rect,
+    .canvas_draw_oval              = cocoa_canvas_draw_oval,
+    .canvas_draw_text              = cocoa_canvas_draw_text,
     .widget_grid                   = cocoa_widget_grid,
     .widget_grid_span              = cocoa_widget_grid_span,
     .widget_grid_remove            = cocoa_widget_grid_remove,

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -111,6 +111,18 @@ typedef void (*fn_gtk_list_box_select_row)(GtkWidget *, void *);
 typedef void *(*fn_gtk_list_box_get_row_at_index)(GtkWidget *, gint);
 typedef GtkWidget *(*fn_gtk_paned_new)(int);
 typedef void (*fn_gtk_paned_set_position)(GtkWidget *, gint);
+typedef GtkWidget *(*fn_gtk_drawing_area_new)(void);
+typedef void (*fn_gtk_widget_queue_draw)(GtkWidget *);
+typedef void (*fn_cairo_set_source_rgb)(void *, double, double, double);
+typedef void (*fn_cairo_set_line_width)(void *, double);
+typedef void (*fn_cairo_move_to)(void *, double, double);
+typedef void (*fn_cairo_line_to)(void *, double, double);
+typedef void (*fn_cairo_stroke)(void *);
+typedef void (*fn_cairo_rectangle)(void *, double, double, double, double);
+typedef void (*fn_cairo_fill)(void *);
+typedef void (*fn_cairo_arc)(void *, double, double, double, double, double);
+typedef void (*fn_cairo_show_text)(void *, const char *);
+typedef void (*fn_cairo_paint)(void *);
 
 /* GTK3-only function pointer types */
 typedef GtkWidget *(*fn_gtk_window_new_gtk3)(int type);
@@ -164,6 +176,7 @@ typedef void *(*fn_g_simple_action_group_new)(void);
 typedef void (*fn_gtk_widget_insert_action_group)(GtkWidget *, const char *, void *);
 typedef void (*fn_gtk_paned_set_start_child)(GtkWidget *, GtkWidget *);
 typedef void (*fn_gtk_paned_set_end_child)(GtkWidget *, GtkWidget *);
+typedef void (*fn_gtk_drawing_area_set_draw_func)(GtkWidget *, GCallback, void *, void *);
 typedef gulong (*fn_g_signal_connect_data_t)(void *, const char *, GCallback, void *, GClosureNotify, int);
 
 /* GLib main loop (used by GTK4 path; available in both versions) */
@@ -234,6 +247,9 @@ typedef struct gtk_version_ops
     /* PanedWindow */
     void (*paned_set_start)(GtkWidget *paned, GtkWidget *child);
     void (*paned_set_end)(GtkWidget *paned, GtkWidget *child);
+
+    /* Canvas */
+    void (*canvas_setup_draw)(GtkWidget *da, void *canvas_data);
 } gtk_version_ops_t;
 
 /* ── Shared resolved symbols ─────────────────────────────────────── */
@@ -281,6 +297,18 @@ static struct
     fn_gtk_list_box_get_row_at_index gtk_list_box_get_row_at_index;
     fn_gtk_paned_new gtk_paned_new;
     fn_gtk_paned_set_position gtk_paned_set_position;
+    fn_gtk_drawing_area_new gtk_drawing_area_new;
+    fn_gtk_widget_queue_draw gtk_widget_queue_draw;
+    fn_cairo_set_source_rgb cairo_set_source_rgb;
+    fn_cairo_set_line_width cairo_set_line_width;
+    fn_cairo_move_to cairo_move_to;
+    fn_cairo_line_to cairo_line_to;
+    fn_cairo_stroke cairo_stroke;
+    fn_cairo_rectangle cairo_rectangle;
+    fn_cairo_fill cairo_fill;
+    fn_cairo_arc cairo_arc;
+    fn_cairo_show_text cairo_show_text;
+    fn_cairo_paint cairo_paint;
 } G;
 
 static const gtk_version_ops_t *g_vops = NULL;
@@ -426,6 +454,10 @@ static gboolean on_window_close_gtk4(GtkWidget *widget, void *data)
     g_vops->main_quit();
     return 0;
 }
+
+/* Forward declarations for canvas draw callbacks (defined in Canvas section). */
+static gboolean gtk3_canvas_draw(GtkWidget *widget, void *cr, void *data);
+static void gtk4_canvas_draw_func(GtkWidget *da, void *cr, int w, int h, void *data);
 
 /* ════════════════════════════════════════════════════════════════════
  * GTK3 version ops
@@ -659,6 +691,12 @@ static void gtk3_paned_set_end(GtkWidget *paned, GtkWidget *child)
     s_gtk3_paned_pack2(paned, child, 1, 0);
 }
 
+static void gtk3_canvas_setup_draw(GtkWidget *da, void *data)
+{
+    (void)data;
+    G.g_signal_connect_data(da, "draw", (GCallback)gtk3_canvas_draw, NULL, NULL, 0);
+}
+
 static const gtk_version_ops_t g_gtk3_ops = {
     .version_name = "GTK3",
     .close_signal = "delete-event",
@@ -689,6 +727,7 @@ static const gtk_version_ops_t g_gtk3_ops = {
     .menu_add_item = gtk3_menu_add_item,
     .paned_set_start = gtk3_paned_set_start,
     .paned_set_end = gtk3_paned_set_end,
+    .canvas_setup_draw = gtk3_canvas_setup_draw,
 };
 
 static bool load_gtk3_symbols(void)
@@ -756,6 +795,7 @@ static fn_g_simple_action_group_new s_gtk4_g_simple_action_group_new;
 static fn_gtk_widget_insert_action_group s_gtk4_gtk_widget_insert_action_group;
 static fn_gtk_paned_set_start_child s_gtk4_paned_set_start;
 static fn_gtk_paned_set_end_child s_gtk4_paned_set_end;
+static fn_gtk_drawing_area_set_draw_func s_gtk4_set_draw_func;
 
 /* GTK4 menu needs a window reference for action map. */
 static void *s_gtk4_menu_window = NULL;
@@ -1030,6 +1070,12 @@ static void gtk4_paned_set_end_wrap(GtkWidget *paned, GtkWidget *child)
     s_gtk4_paned_set_end(paned, child);
 }
 
+static void gtk4_canvas_setup_draw(GtkWidget *da, void *data)
+{
+    (void)data;
+    s_gtk4_set_draw_func(da, (GCallback)gtk4_canvas_draw_func, NULL, NULL);
+}
+
 static const gtk_version_ops_t g_gtk4_ops = {
     .version_name = "GTK4",
     .close_signal = "close-request",
@@ -1060,6 +1106,7 @@ static const gtk_version_ops_t g_gtk4_ops = {
     .menu_add_item = gtk4_menu_add_item,
     .paned_set_start = gtk4_paned_set_start_wrap,
     .paned_set_end = gtk4_paned_set_end_wrap,
+    .canvas_setup_draw = gtk4_canvas_setup_draw,
 };
 
 static bool load_gtk4_symbols(void)
@@ -1093,6 +1140,7 @@ static bool load_gtk4_symbols(void)
     LOAD_LOCAL(s_gtk4_gtk_widget_insert_action_group, gtk_widget_insert_action_group);
     LOAD_LOCAL(s_gtk4_paned_set_start, gtk_paned_set_start_child);
     LOAD_LOCAL(s_gtk4_paned_set_end, gtk_paned_set_end_child);
+    LOAD_LOCAL(s_gtk4_set_draw_func, gtk_drawing_area_set_draw_func);
     return true;
 fail:
     return false;
@@ -1144,6 +1192,18 @@ static bool load_shared_symbols(void)
     LOAD_SHARED(gtk_list_box_get_row_at_index);
     LOAD_SHARED(gtk_paned_new);
     LOAD_SHARED(gtk_paned_set_position);
+    LOAD_SHARED(gtk_drawing_area_new);
+    LOAD_SHARED(gtk_widget_queue_draw);
+    LOAD_SHARED(cairo_set_source_rgb);
+    LOAD_SHARED(cairo_set_line_width);
+    LOAD_SHARED(cairo_move_to);
+    LOAD_SHARED(cairo_line_to);
+    LOAD_SHARED(cairo_stroke);
+    LOAD_SHARED(cairo_rectangle);
+    LOAD_SHARED(cairo_fill);
+    LOAD_SHARED(cairo_arc);
+    LOAD_SHARED(cairo_show_text);
+    LOAD_SHARED(cairo_paint);
     return true;
 fail:
     return false;
@@ -1849,6 +1909,184 @@ static void gtk_be_paned_set_position(void *handle, int pos)
         G.gtk_paned_set_position(handle, pos);
 }
 
+/* ── Canvas ──────────────────────────────────────────────────────── */
+
+enum
+{
+    DRAW_LINE = 0,
+    DRAW_RECT,
+    DRAW_OVAL,
+    DRAW_TEXT
+};
+
+typedef struct
+{
+    int type;
+    double x1, y1, x2, y2;
+    char text[128];
+} draw_cmd_t;
+
+#define MAX_CANVAS 32
+#define MAX_DRAW_CMDS 512
+
+typedef struct
+{
+    GtkWidget *da;
+    draw_cmd_t cmds[MAX_DRAW_CMDS];
+    int cmd_count;
+} canvas_data_t;
+
+static canvas_data_t g_canvas_data[MAX_CANVAS];
+static int g_canvas_count = 0;
+
+static canvas_data_t *canvas_for_da(void *da)
+{
+    for (int i = 0; i < g_canvas_count; i++)
+        if (g_canvas_data[i].da == da)
+            return &g_canvas_data[i];
+    return NULL;
+}
+
+static void canvas_replay(void *cr, canvas_data_t *cd)
+{
+    /* White background. */
+    G.cairo_set_source_rgb(cr, 1.0, 1.0, 1.0);
+    G.cairo_paint(cr);
+    /* Draw commands in black. */
+    G.cairo_set_source_rgb(cr, 0.0, 0.0, 0.0);
+    G.cairo_set_line_width(cr, 1.0);
+    for (int i = 0; i < cd->cmd_count; i++)
+    {
+        draw_cmd_t *c = &cd->cmds[i];
+        switch (c->type)
+        {
+        case DRAW_LINE:
+            G.cairo_move_to(cr, c->x1, c->y1);
+            G.cairo_line_to(cr, c->x2, c->y2);
+            G.cairo_stroke(cr);
+            break;
+        case DRAW_RECT:
+            G.cairo_rectangle(cr, c->x1, c->y1, c->x2, c->y2);
+            G.cairo_stroke(cr);
+            break;
+        case DRAW_OVAL:
+            G.cairo_arc(cr, c->x1 + c->x2 / 2, c->y1 + c->y2 / 2, (c->x2 < c->y2 ? c->x2 : c->y2) / 2, 0, 6.283185);
+            G.cairo_stroke(cr);
+            break;
+        case DRAW_TEXT:
+            G.cairo_move_to(cr, c->x1, c->y1);
+            G.cairo_show_text(cr, c->text);
+            break;
+        }
+    }
+}
+
+/* GTK3 draw callback: gboolean (*)(GtkWidget*, cairo_t*, gpointer) */
+static gboolean gtk3_canvas_draw(GtkWidget *widget, void *cr, void *data)
+{
+    (void)data;
+    canvas_data_t *cd = canvas_for_da(widget);
+    if (cd)
+        canvas_replay(cr, cd);
+    return 0;
+}
+
+/* GTK4 draw func: void (*)(GtkDrawingArea*, cairo_t*, int, int, gpointer) */
+static void gtk4_canvas_draw_func(GtkWidget *da, void *cr, int w, int h, void *data)
+{
+    (void)w;
+    (void)h;
+    (void)data;
+    canvas_data_t *cd = canvas_for_da(da);
+    if (cd)
+        canvas_replay(cr, cd);
+}
+
+static void *gtk_be_canvas_create(void *parent, int width, int height)
+{
+    if (!parent)
+        return NULL;
+    void *grid = grid_for_window(parent);
+    if (!grid)
+        return NULL;
+    GtkWidget *da = G.gtk_drawing_area_new();
+    G.gtk_widget_set_hexpand(da, 1);
+    G.gtk_widget_set_vexpand(da, 1);
+    (void)width;
+    (void)height;
+    if (g_canvas_count < MAX_CANVAS)
+    {
+        canvas_data_t *cd = &g_canvas_data[g_canvas_count++];
+        memset(cd, 0, sizeof(*cd));
+        cd->da = da;
+    }
+    g_vops->canvas_setup_draw(da, NULL);
+    register_widget_parent(da, grid);
+    return da;
+}
+
+static void gtk_be_canvas_destroy(void *handle)
+{
+    if (handle)
+        g_vops->widget_destroy(handle);
+}
+
+static void gtk_be_canvas_clear(void *handle)
+{
+    canvas_data_t *cd = canvas_for_da(handle);
+    if (cd)
+    {
+        cd->cmd_count = 0;
+        G.gtk_widget_queue_draw(handle);
+    }
+}
+
+static void gtk_be_canvas_draw_line(void *handle, double x1, double y1, double x2, double y2)
+{
+    canvas_data_t *cd = canvas_for_da(handle);
+    if (cd && cd->cmd_count < MAX_DRAW_CMDS)
+    {
+        cd->cmds[cd->cmd_count++] = (draw_cmd_t){DRAW_LINE, x1, y1, x2, y2, {0}};
+        G.gtk_widget_queue_draw(handle);
+    }
+}
+
+static void gtk_be_canvas_draw_rect(void *handle, double x, double y, double w, double h)
+{
+    canvas_data_t *cd = canvas_for_da(handle);
+    if (cd && cd->cmd_count < MAX_DRAW_CMDS)
+    {
+        cd->cmds[cd->cmd_count++] = (draw_cmd_t){DRAW_RECT, x, y, w, h, {0}};
+        G.gtk_widget_queue_draw(handle);
+    }
+}
+
+static void gtk_be_canvas_draw_oval(void *handle, double x, double y, double w, double h)
+{
+    canvas_data_t *cd = canvas_for_da(handle);
+    if (cd && cd->cmd_count < MAX_DRAW_CMDS)
+    {
+        cd->cmds[cd->cmd_count++] = (draw_cmd_t){DRAW_OVAL, x, y, w, h, {0}};
+        G.gtk_widget_queue_draw(handle);
+    }
+}
+
+static void gtk_be_canvas_draw_text(void *handle, double x, double y, const char *text)
+{
+    canvas_data_t *cd = canvas_for_da(handle);
+    if (cd && cd->cmd_count < MAX_DRAW_CMDS)
+    {
+        draw_cmd_t cmd = {DRAW_TEXT, x, y, 0, 0, {0}};
+        size_t len = strlen(text);
+        if (len >= sizeof(cmd.text))
+            len = sizeof(cmd.text) - 1;
+        memcpy(cmd.text, text, len);
+        cmd.text[len] = '\0';
+        cd->cmds[cd->cmd_count++] = cmd;
+        G.gtk_widget_queue_draw(handle);
+    }
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void gtk_be_widget_grid(void *handle, int col, int row)
@@ -2007,6 +2245,13 @@ const gui_backend_t gui_backend_gtk = {
     .paned_set_start = gtk_be_paned_set_start,
     .paned_set_end = gtk_be_paned_set_end,
     .paned_set_position = gtk_be_paned_set_position,
+    .canvas_create = gtk_be_canvas_create,
+    .canvas_destroy = gtk_be_canvas_destroy,
+    .canvas_clear = gtk_be_canvas_clear,
+    .canvas_draw_line = gtk_be_canvas_draw_line,
+    .canvas_draw_rect = gtk_be_canvas_draw_rect,
+    .canvas_draw_oval = gtk_be_canvas_draw_oval,
+    .canvas_draw_text = gtk_be_canvas_draw_text,
     .widget_grid = gtk_be_widget_grid,
     .widget_grid_span = gtk_be_widget_grid_span,
     .widget_grid_remove = gtk_be_widget_grid_remove,

--- a/plugins/gui/backends/gui_stub.c
+++ b/plugins/gui/backends/gui_stub.c
@@ -171,6 +171,28 @@ static bool stub_ask(void *p, const char *t, const char *m)
     (void)m;
     return false;
 }
+static void *stub_canvas_create(void *p, int w, int h)
+{
+    (void)p;
+    (void)w;
+    (void)h;
+    return NULL;
+}
+static void stub_canvas_draw(void *h, double a, double b, double c, double d)
+{
+    (void)h;
+    (void)a;
+    (void)b;
+    (void)c;
+    (void)d;
+}
+static void stub_canvas_text(void *h, double a, double b, const char *t)
+{
+    (void)h;
+    (void)a;
+    (void)b;
+    (void)t;
+}
 
 const gui_backend_t gui_backend_stub = {
     .name = "stub",
@@ -247,4 +269,11 @@ const gui_backend_t gui_backend_stub = {
     .save_file_dialog = stub_get_text,
     .choose_directory = stub_get_text,
     .ask_yes_no = stub_ask,
+    .canvas_create = stub_canvas_create,
+    .canvas_destroy = stub_destroy,
+    .canvas_clear = stub_destroy,
+    .canvas_draw_line = stub_canvas_draw,
+    .canvas_draw_rect = stub_canvas_draw,
+    .canvas_draw_oval = stub_canvas_draw,
+    .canvas_draw_text = stub_canvas_text,
 };

--- a/plugins/gui/backends/gui_win32.c
+++ b/plugins/gui/backends/gui_win32.c
@@ -847,6 +847,63 @@ static void win32_paned_set_position(void *handle, int pos)
     (void)pos;
 }
 
+/* ── Canvas ──────────────────────────────────────────────────────── */
+/* Win32 canvas: simplified stub using a STATIC control.
+   Full GDI drawing requires a custom window class with WM_PAINT. */
+
+static void *win32_canvas_create(void *parent, int width, int height)
+{
+    if (!parent)
+        return NULL;
+    HWND hwnd = CreateWindowExW(WS_EX_CLIENTEDGE, L"STATIC", L"", WS_CHILD | WS_VISIBLE | SS_OWNERDRAW, 0, 0, width,
+                                height, (HWND)parent, (HMENU)(intptr_t)g_next_ctrl_id++, g_hinstance, NULL);
+    if (hwnd)
+        register_widget_parent(hwnd, (HWND)parent);
+    return (void *)hwnd;
+}
+
+static void win32_canvas_destroy(void *handle)
+{
+    if (handle)
+        DestroyWindow((HWND)handle);
+}
+
+static void win32_canvas_clear(void *handle)
+{
+    (void)handle;
+}
+static void win32_canvas_draw_line(void *h, double x1, double y1, double x2, double y2)
+{
+    (void)h;
+    (void)x1;
+    (void)y1;
+    (void)x2;
+    (void)y2;
+}
+static void win32_canvas_draw_rect(void *h, double x, double y, double w, double ht)
+{
+    (void)h;
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)ht;
+}
+static void win32_canvas_draw_oval(void *h, double x, double y, double w, double ht)
+{
+    (void)h;
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)ht;
+}
+static void win32_canvas_draw_text(void *h, double x, double y, const char *t)
+{
+    (void)h;
+    (void)x;
+    (void)y;
+    (void)t;
+}
+
 /* ── Grid layout ─────────────────────────────────────────────────── */
 
 static void win32_widget_grid(void *handle, int col, int row)
@@ -1030,6 +1087,13 @@ const gui_backend_t gui_backend_win32 = {
     .paned_set_start = win32_paned_set_start,
     .paned_set_end = win32_paned_set_end,
     .paned_set_position = win32_paned_set_position,
+    .canvas_create = win32_canvas_create,
+    .canvas_destroy = win32_canvas_destroy,
+    .canvas_clear = win32_canvas_clear,
+    .canvas_draw_line = win32_canvas_draw_line,
+    .canvas_draw_rect = win32_canvas_draw_rect,
+    .canvas_draw_oval = win32_canvas_draw_oval,
+    .canvas_draw_text = win32_canvas_draw_text,
     .widget_grid = win32_widget_grid,
     .widget_grid_span = win32_widget_grid_span,
     .widget_grid_remove = win32_widget_grid_remove,

--- a/plugins/gui/gui.c
+++ b/plugins/gui/gui.c
@@ -89,6 +89,7 @@ static gui_handle_registry_t g_listboxes = {{0}, 0};
 static gui_handle_registry_t g_menubars = {{0}, 0};
 static gui_handle_registry_t g_submenus = {{0}, 0};
 static gui_handle_registry_t g_paneds = {{0}, 0};
+static gui_handle_registry_t g_canvases = {{0}, 0};
 
 /* ── Stack helpers ───────────────────────────────────────────────── */
 
@@ -196,6 +197,7 @@ enum
     GUI_LISTBOX_CLASS_INDEX = 12U,
     GUI_MENU_CLASS_INDEX = 13U,
     GUI_PANED_CLASS_INDEX = 14U,
+    GUI_CANVAS_CLASS_INDEX = 15U,
 };
 
 /* ── Callback bridge ─────────────────────────────────────────────── */
@@ -1576,6 +1578,131 @@ static vigil_status_t gui_paned_grid(vigil_vm_t *vm, size_t arg_count, vigil_err
     return VIGIL_STATUS_OK;
 }
 
+/* ── gui.Canvas ──────────────────────────────────────────────────── */
+
+static vigil_status_t gui_canvas_new(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t parent_h = gui_arg_handle(vm, base, 1);
+    int w = gui_arg_i32(vm, base, 2);
+    int h = gui_arg_i32(vm, base, 3);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *parent = gui_handle_get(&g_windows, parent_h);
+    if (!parent || !g_backend)
+    {
+        gui_push_handle_instance(vm, GUI_CANVAS_CLASS_INDEX, -1, error);
+        return gui_push_fail_err(vm, "gui: invalid parent window", error);
+    }
+    void *native = g_backend->canvas_create(parent, w, h);
+    int64_t handle;
+    gui_handle_store(&g_canvases, native, &handle);
+    gui_push_handle_instance(vm, GUI_CANVAS_CLASS_INDEX, handle, error);
+    return gui_push_ok_err(vm, error);
+}
+
+static vigil_status_t gui_canvas_destroy(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_destroy(native);
+    gui_handle_clear(&g_canvases, h);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_clear(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_clear(native);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_draw_line(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    double x1 = gui_arg_f64(vm, base, 1);
+    double y1 = gui_arg_f64(vm, base, 2);
+    double x2 = gui_arg_f64(vm, base, 3);
+    double y2 = gui_arg_f64(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_draw_line(native, x1, y1, x2, y2);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_draw_rect(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    double x = gui_arg_f64(vm, base, 1);
+    double y = gui_arg_f64(vm, base, 2);
+    double w = gui_arg_f64(vm, base, 3);
+    double ht = gui_arg_f64(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_draw_rect(native, x, y, w, ht);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_draw_oval(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    double x = gui_arg_f64(vm, base, 1);
+    double y = gui_arg_f64(vm, base, 2);
+    double w = gui_arg_f64(vm, base, 3);
+    double ht = gui_arg_f64(vm, base, 4);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_draw_oval(native, x, y, w, ht);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_draw_text(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    double x = gui_arg_f64(vm, base, 1);
+    double y = gui_arg_f64(vm, base, 2);
+    char buf[1024];
+    const char *text = gui_arg_str(vm, base, 3, buf, sizeof(buf));
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->canvas_draw_text(native, x, y, text);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
+static vigil_status_t gui_canvas_grid(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    int64_t h = gui_self_handle(vm, base);
+    int col = gui_arg_i32(vm, base, 1);
+    int row = gui_arg_i32(vm, base, 2);
+    vigil_vm_stack_pop_n(vm, arg_count);
+    void *native = gui_handle_get(&g_canvases, h);
+    if (native && g_backend)
+        g_backend->widget_grid(native, col, row);
+    (void)error;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── gui.message_box (module-level function) ─────────────────────── */
 
 static vigil_status_t gui_fn_message_box(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
@@ -1690,6 +1817,9 @@ static const int p_obj_str_obj[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_STRING, VIGIL_
 static const int p_obj_f64_f64_f64[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
 static const int p_i32_str_obj[] = {VIGIL_TYPE_I32, VIGIL_TYPE_STRING, VIGIL_TYPE_OBJECT};
 static const int p_obj_bool[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_BOOL};
+static const int p_f64_f64_f64_f64[] = {VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_F64};
+static const int p_f64_f64_str[] = {VIGIL_TYPE_F64, VIGIL_TYPE_F64, VIGIL_TYPE_STRING};
+static const int p_obj_i32_i32[] = {VIGIL_TYPE_OBJECT, VIGIL_TYPE_I32, VIGIL_TYPE_I32};
 
 /* ── Macro helpers ───────────────────────────────────────────────── */
 
@@ -1921,6 +2051,23 @@ static const vigil_native_class_method_t gui_paned_methods[] = {
     GUI_METHOD("grid", 4U, gui_paned_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
 };
 
+/* ── Canvas class ────────────────────────────────────────────────── */
+
+static const vigil_native_class_field_t gui_canvas_fields[] = {
+    GUI_PFIELD("handle", 6U, VIGIL_TYPE_I64),
+};
+
+static const vigil_native_class_method_t gui_canvas_methods[] = {
+    GUI_STATIC("new", 3U, gui_canvas_new, 3U, p_obj_i32_i32, VIGIL_TYPE_OBJECT, 2U, rt_obj_err),
+    GUI_METHOD("destroy", 7U, gui_canvas_destroy, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("clear", 5U, gui_canvas_clear, 0U, NULL, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("draw_line", 9U, gui_canvas_draw_line, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("draw_rect", 9U, gui_canvas_draw_rect, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("draw_oval", 9U, gui_canvas_draw_oval, 4U, p_f64_f64_f64_f64, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("draw_text", 9U, gui_canvas_draw_text, 3U, p_f64_f64_str, VIGIL_TYPE_VOID, 0U, NULL),
+    GUI_METHOD("grid", 4U, gui_canvas_grid, 2U, p_i32_i32, VIGIL_TYPE_VOID, 0U, NULL),
+};
+
 /* ── Class table ─────────────────────────────────────────────────── */
 
 /* clang-format off */
@@ -1940,6 +2087,7 @@ static const vigil_native_class_t gui_classes[] = {
     {"Listbox",     7U,  gui_listbox_fields,  1U, gui_listbox_methods,  sizeof(gui_listbox_methods)  / sizeof(gui_listbox_methods[0]),  NULL, NULL},
     {"Menu",        4U,  gui_menu_fields,     1U, gui_menu_methods,     sizeof(gui_menu_methods)     / sizeof(gui_menu_methods[0]),     NULL, NULL},
     {"PanedWindow", 11U, gui_paned_fields,    1U, gui_paned_methods,    sizeof(gui_paned_methods)    / sizeof(gui_paned_methods[0]),    NULL, NULL},
+    {"Canvas",      6U,  gui_canvas_fields,   1U, gui_canvas_methods,   sizeof(gui_canvas_methods)   / sizeof(gui_canvas_methods[0]),   NULL, NULL},
 };
 /* clang-format on */
 

--- a/plugins/gui/gui_backend.h
+++ b/plugins/gui/gui_backend.h
@@ -151,6 +151,15 @@ extern "C"
         const char *(*save_file_dialog)(void *parent, const char *title, char *buf, size_t bufsz);
         const char *(*choose_directory)(void *parent, const char *title, char *buf, size_t bufsz);
         bool (*ask_yes_no)(void *parent, const char *title, const char *message);
+
+        /* Canvas (drawing surface) */
+        void *(*canvas_create)(void *parent, int width, int height);
+        void (*canvas_destroy)(void *handle);
+        void (*canvas_clear)(void *handle);
+        void (*canvas_draw_line)(void *handle, double x1, double y1, double x2, double y2);
+        void (*canvas_draw_rect)(void *handle, double x, double y, double w, double h);
+        void (*canvas_draw_oval)(void *handle, double x, double y, double w, double h);
+        void (*canvas_draw_text)(void *handle, double x, double y, const char *text);
     } gui_backend_t;
 
     /* ── Backend selection ───────────────────────────────────────────── */

--- a/tests/gui_test.c
+++ b/tests/gui_test.c
@@ -65,7 +65,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    EXPECT_EQ(mod->class_count, 15U);
+    EXPECT_EQ(mod->class_count, 16U);
     EXPECT_NE(find_class(mod, "App"), NULL);
     EXPECT_NE(find_class(mod, "Window"), NULL);
     EXPECT_NE(find_class(mod, "Label"), NULL);
@@ -81,6 +81,7 @@ TEST(GuiPlugin, HasThirteenClasses)
     EXPECT_NE(find_class(mod, "Listbox"), NULL);
     EXPECT_NE(find_class(mod, "Menu"), NULL);
     EXPECT_NE(find_class(mod, "PanedWindow"), NULL);
+    EXPECT_NE(find_class(mod, "Canvas"), NULL);
 }
 
 TEST(GuiPlugin, HasDialogFunctions)
@@ -363,6 +364,26 @@ TEST(GuiPlugin, PanedWindowClassMethods)
     EXPECT_NE(find_method(cls, "grid"), NULL);
 }
 
+TEST(GuiPlugin, CanvasClassMethods)
+{
+    if (!gui_plugin_available())
+        return;
+    vigil_native_registry_t natives;
+    vigil_error_t error;
+    const vigil_native_module_t *mod = get_gui_module(&natives, &error);
+    ASSERT_NE(mod, NULL);
+    const vigil_native_class_t *cls = find_class(mod, "Canvas");
+    ASSERT_NE(cls, NULL);
+    EXPECT_NE(find_method(cls, "new"), NULL);
+    EXPECT_NE(find_method(cls, "destroy"), NULL);
+    EXPECT_NE(find_method(cls, "clear"), NULL);
+    EXPECT_NE(find_method(cls, "draw_line"), NULL);
+    EXPECT_NE(find_method(cls, "draw_rect"), NULL);
+    EXPECT_NE(find_method(cls, "draw_oval"), NULL);
+    EXPECT_NE(find_method(cls, "draw_text"), NULL);
+    EXPECT_NE(find_method(cls, "grid"), NULL);
+}
+
 TEST(GuiPlugin, AppNewIsStatic)
 {
     if (!gui_plugin_available())
@@ -386,10 +407,10 @@ TEST(GuiPlugin, EachClassHasHandleField)
     vigil_error_t error;
     const vigil_native_module_t *mod = get_gui_module(&natives, &error);
     ASSERT_NE(mod, NULL);
-    static const char *names[] = {"App",      "Window", "Label",   "Button", "Entry",
-                                  "Checkbox", "Slider", "Select",  "Text",   "Radiobutton",
-                                  "Spinbox",  "Frame",  "Listbox", "Menu",   "PanedWindow"};
-    for (size_t i = 0; i < 15; i++)
+    static const char *names[] = {"App",     "Window", "Label",       "Button",      "Entry",   "Checkbox",
+                                  "Slider",  "Select", "Text",        "Radiobutton", "Spinbox", "Frame",
+                                  "Listbox", "Menu",   "PanedWindow", "Canvas"};
+    for (size_t i = 0; i < 16; i++)
     {
         const vigil_native_class_t *cls = find_class(mod, names[i]);
         ASSERT_NE(cls, NULL);
@@ -432,6 +453,7 @@ void register_gui_tests(void)
     REGISTER_TEST(GuiPlugin, ListboxClassMethods);
     REGISTER_TEST(GuiPlugin, MenuClassMethods);
     REGISTER_TEST(GuiPlugin, PanedWindowClassMethods);
+    REGISTER_TEST(GuiPlugin, CanvasClassMethods);
     REGISTER_TEST(GuiPlugin, AppNewIsStatic);
     REGISTER_TEST(GuiPlugin, EachClassHasHandleField);
     REGISTER_TEST(GuiPlugin, ModuleHasDoc);


### PR DESCRIPTION
## Summary

Adds `gui.Canvas` — a 2D drawing surface with line, rect, oval, and text primitives. Completes Phase 4 from #399.

## API

```vigil
gui.Canvas c, err e = gui.Canvas.new(win, 400, 300)
c.grid(0, 0)
c.draw_rect(10.0, 10.0, 100.0, 80.0)
c.draw_line(10.0, 10.0, 110.0, 90.0)
c.draw_oval(150.0, 30.0, 80.0, 60.0)
c.draw_text(10.0, 120.0, "Hello Canvas!")
c.clear()
```

## GTK Backend (fully functional)

Uses GtkDrawingArea with Cairo rendering:
- Draw commands queued in a command buffer (up to 512 commands)
- Replayed on each paint event via cairo_t
- GTK3: `g_signal_connect("draw")` callback
- GTK4: `gtk_drawing_area_set_draw_func`
- White background, black stroke for all primitives

## Cocoa / Win32

Canvas widget created (NSView / STATIC control), drawing primitives stubbed for future Core Graphics / GDI implementation.

## Testing
- All 34 test suites pass, 22 GUI unit tests covering all 16 classes
- Canvas tested under xvfb with GTK4 — draw commands execute without error
- clang-format clean

Completes Phase 4 for #399.