### PR TITLE
Close all remaining gui limitations — #399

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -225,6 +225,4 @@ If a feature isn't supported on your platform, implement it as a no-op (return N
 
 ## Known Limitations
 
-- **GTK4 file dialogs**: Stubbed because GTK4 removed all synchronous dialog APIs
-- **SDL text rendering**: Uses SDL3's built-in 8×8 debug font; `vigil_font.h` (stb_truetype) integration planned
-- **SDL menus**: Menu bar is a no-op in the SDL backend
+- **SDL text rendering**: Uses SDL3's built-in 8×8 debug font. Functional but compact. TTF font integration via `vigil_font.h` (stb_truetype) is a future enhancement for higher-quality text.

--- a/plugins/gui/backends/gui_gtk.c
+++ b/plugins/gui/backends/gui_gtk.c
@@ -163,6 +163,10 @@ typedef gboolean (*fn_gtk_check_button_get_active)(GtkWidget *);
 typedef void (*fn_gtk_check_button_set_active)(GtkWidget *, gboolean);
 typedef void (*fn_gtk_check_button_set_label)(GtkWidget *, const char *);
 typedef void (*fn_gtk_check_button_set_group)(GtkWidget *, GtkWidget *);
+typedef GtkWidget *(*fn_gtk_file_chooser_dialog_new_gtk4)(const char *, GtkWindow *, int, const char *, ...);
+typedef void *(*fn_gtk_file_chooser_get_file)(GtkWidget *);
+typedef char *(*fn_g_file_get_path)(void *);
+typedef void (*fn_g_free)(void *);
 typedef GtkWidget *(*fn_gtk_scrolled_window_new_gtk4)(void);
 typedef void (*fn_gtk_scrolled_window_set_child)(GtkWidget *, GtkWidget *);
 typedef void (*fn_gtk_frame_set_child_gtk4)(GtkWidget *, GtkWidget *);
@@ -782,6 +786,10 @@ static fn_gtk_check_button_get_active s_gtk4_check_get_active;
 static fn_gtk_check_button_set_active s_gtk4_check_set_active;
 static fn_gtk_check_button_set_label s_gtk4_check_set_label;
 static fn_gtk_check_button_set_group s_gtk4_check_set_group;
+static fn_gtk_file_chooser_dialog_new_gtk4 s_gtk4_file_chooser_new;
+static fn_gtk_file_chooser_get_file s_gtk4_file_chooser_get_file;
+static fn_g_file_get_path s_gtk4_g_file_get_path;
+static fn_g_free s_gtk4_g_free;
 static fn_gtk_scrolled_window_new_gtk4 s_gtk4_scrolled_window_new;
 static fn_gtk_scrolled_window_set_child s_gtk4_scrolled_window_set_child;
 static fn_gtk_frame_set_child_gtk4 s_gtk4_frame_set_child;
@@ -892,18 +900,66 @@ static void gtk4_message_box(void *parent, const char *title, const char *msg)
     s_gtk4_g_main_loop_unref(loop);
 }
 
+static int s_gtk4_dlg_response_code = -6;
+
+static void gtk4_on_dialog_response(GtkWidget *dlg, int response, void *data)
+{
+    (void)dlg;
+    s_gtk4_dlg_response_code = response;
+    s_gtk4_g_main_loop_quit((GMainLoop *)data);
+}
+
 static const char *gtk4_file_dialog(void *parent, const char *title, int action, char *buf, size_t bufsz)
 {
-    /* GTK4 removed gtk_dialog_run. Use GtkFileChooserDialog with a
-       nested GMainLoop, responding to the "response" signal. */
-    (void)parent;
-    (void)title;
-    (void)action;
     buf[0] = '\0';
-    /* Simplified: return empty for now. Full async file dialog
-       requires significant additional infrastructure. */
-    (void)bufsz;
+    GtkWidget *dlg = s_gtk4_file_chooser_new(title, parent, action, "Cancel", -6, "OK", -3, NULL);
+    if (!dlg)
+        return buf;
+
+    GMainLoop *loop = s_gtk4_g_main_loop_new(NULL, 0);
+    s_gtk4_dlg_response_code = -6;
+    G.g_signal_connect_data(dlg, "response", (GCallback)gtk4_on_dialog_response, loop, NULL, 0);
+
+    s_gtk4_widget_set_visible(dlg, 1);
+    s_gtk4_g_main_loop_run(loop);
+
+    if (s_gtk4_dlg_response_code == -3) /* GTK_RESPONSE_ACCEPT */
+    {
+        void *gfile = s_gtk4_file_chooser_get_file(dlg);
+        if (gfile)
+        {
+            char *path = s_gtk4_g_file_get_path(gfile);
+            if (path)
+            {
+                size_t len = strlen(path);
+                if (len >= bufsz)
+                    len = bufsz - 1;
+                memcpy(buf, path, len);
+                buf[len] = '\0';
+                s_gtk4_g_free(path);
+            }
+        }
+    }
+
+    s_gtk4_window_destroy(dlg);
+    s_gtk4_g_main_loop_unref(loop);
     return buf;
+}
+
+static bool s_gtk4_yesno_result = false;
+
+static void gtk4_yesno_yes_clicked(GtkWidget *w, void *data)
+{
+    (void)w;
+    s_gtk4_yesno_result = true;
+    s_gtk4_g_main_loop_quit((GMainLoop *)data);
+}
+
+static void gtk4_yesno_no_clicked(GtkWidget *w, void *data)
+{
+    (void)w;
+    s_gtk4_yesno_result = false;
+    s_gtk4_g_main_loop_quit((GMainLoop *)data);
 }
 
 static bool gtk4_yes_no_dialog(void *parent, const char *title, const char *msg)
@@ -922,34 +978,22 @@ static bool gtk4_yes_no_dialog(void *parent, const char *title, const char *msg)
     G.gtk_widget_set_vexpand(label, 1);
     G.gtk_grid_attach(grid, label, 0, 0, 2, 1);
 
-    /* Use a shared variable to capture the result. */
-
     GtkWidget *yes_btn = G.gtk_button_new_with_label("Yes");
     GtkWidget *no_btn = G.gtk_button_new_with_label("No");
     G.gtk_grid_attach(grid, yes_btn, 0, 1, 1, 1);
     G.gtk_grid_attach(grid, no_btn, 1, 1, 1, 1);
 
-    G.g_signal_connect_data(yes_btn, "clicked", (GCallback)s_gtk4_g_main_loop_quit, loop, NULL, 1);
-    G.g_signal_connect_data(no_btn, "clicked", (GCallback)s_gtk4_g_main_loop_quit, loop, NULL, 1);
+    s_gtk4_yesno_result = false;
+    G.g_signal_connect_data(yes_btn, "clicked", (GCallback)gtk4_yesno_yes_clicked, loop, NULL, 0);
+    G.g_signal_connect_data(no_btn, "clicked", (GCallback)gtk4_yesno_no_clicked, loop, NULL, 0);
     G.g_signal_connect_data(win, "close-request", (GCallback)s_gtk4_g_main_loop_quit, loop, NULL, 1);
-
-    /* Track which button was clicked via the callback system. */
-    if (g_callback_count + 1 < MAX_CALLBACKS)
-    {
-        gui_callback_t yes_cb = {NULL, (void *)1};
-        gui_callback_t no_cb = {NULL, (void *)0};
-        g_callbacks[g_callback_count++] = (callback_entry_t){yes_btn, GUI_EVENT_CLICK, yes_cb};
-        g_callbacks[g_callback_count++] = (callback_entry_t){no_btn, GUI_EVENT_CLICK, no_cb};
-    }
 
     s_gtk4_widget_set_visible(win, 1);
     s_gtk4_g_main_loop_run(loop);
 
-    /* Check which button has focus / was last clicked. Simplified:
-       check if yes_btn was the source. For now, default to false. */
     s_gtk4_window_destroy(win);
     s_gtk4_g_main_loop_unref(loop);
-    return false; /* GTK4 yes/no needs more infrastructure; placeholder */
+    return s_gtk4_yesno_result;
 }
 
 static const char *gtk4_entry_get_text(GtkWidget *entry)
@@ -1127,6 +1171,10 @@ static bool load_gtk4_symbols(void)
     LOAD_LOCAL(s_gtk4_check_set_active, gtk_check_button_set_active);
     LOAD_LOCAL(s_gtk4_check_set_label, gtk_check_button_set_label);
     LOAD_LOCAL(s_gtk4_check_set_group, gtk_check_button_set_group);
+    LOAD_LOCAL(s_gtk4_file_chooser_new, gtk_file_chooser_dialog_new);
+    LOAD_LOCAL(s_gtk4_file_chooser_get_file, gtk_file_chooser_get_file);
+    LOAD_LOCAL(s_gtk4_g_file_get_path, g_file_get_path);
+    LOAD_LOCAL(s_gtk4_g_free, g_free);
     LOAD_LOCAL(s_gtk4_scrolled_window_new, gtk_scrolled_window_new);
     LOAD_LOCAL(s_gtk4_scrolled_window_set_child, gtk_scrolled_window_set_child);
     LOAD_LOCAL(s_gtk4_frame_set_child, gtk_frame_set_child);

--- a/plugins/gui/backends/gui_sdl.c
+++ b/plugins/gui/backends/gui_sdl.c
@@ -387,6 +387,10 @@ static void handle_focus(float mx, float my)
     SDL_StopTextInput(g_sdl_window);
 }
 
+/* Forward declarations for menu rendering (defined in Menu section). */
+static void sdl_render_menubar(void);
+static void sdl_handle_menubar_click(float mx, float my);
+
 static bool sdl_init(const char *app_name)
 {
     (void)app_name;
@@ -442,6 +446,7 @@ static void sdl_main_loop(void)
                 if (ev.button.button == SDL_BUTTON_LEFT)
                 {
                     handle_focus(ev.button.x, ev.button.y);
+                    sdl_handle_menubar_click(ev.button.x, ev.button.y);
                     handle_mouse_click(ev.button.x, ev.button.y);
                 }
                 break;
@@ -483,6 +488,7 @@ static void sdl_main_loop(void)
         for (int i = 0; i < g_widget_count; i++)
             if (g_widgets[i].type != SW_WINDOW)
                 render_widget(&g_widgets[i]);
+        sdl_render_menubar();
         SDL_RenderPresent(g_sdl_renderer);
         SDL_Delay(16); /* ~60 fps */
     }
@@ -842,28 +848,81 @@ static void sdl_listbox_set(void *h, int i)
     sdl_select_set(h, i);
 }
 
-/* ── Menu (simplified) ───────────────────────────────────────────── */
+/* ── Menu (flat bar with clickable items) ─────────────────────────── */
+
+#define SDL_MAX_MENU_ITEMS 64
+
+typedef struct
+{
+    char label[64];
+    gui_callback_t cb;
+    float x, w;
+} sdl_menu_item_t;
+
+static sdl_menu_item_t g_sdl_menu_items[SDL_MAX_MENU_ITEMS];
+static int g_sdl_menu_item_count = 0;
+static bool g_sdl_has_menubar = false;
+
+static void sdl_render_menubar(void)
+{
+    if (!g_sdl_has_menubar)
+        return;
+    SDL_FRect bar = {0, 0, (float)g_win_w, 20};
+    draw_rect_fill(&bar, COL_BTN_R, COL_BTN_G, COL_BTN_B);
+    for (int i = 0; i < g_sdl_menu_item_count; i++)
+        draw_text(g_sdl_menu_items[i].x + 4, 6, g_sdl_menu_items[i].label);
+}
+
+static void sdl_handle_menubar_click(float mx, float my)
+{
+    if (!g_sdl_has_menubar || my > 20)
+        return;
+    for (int i = 0; i < g_sdl_menu_item_count; i++)
+    {
+        if (mx >= g_sdl_menu_items[i].x && mx < g_sdl_menu_items[i].x + g_sdl_menu_items[i].w)
+        {
+            if (g_sdl_menu_items[i].cb.fn)
+                g_sdl_menu_items[i].cb.fn(g_sdl_menu_items[i].cb.user_data);
+            return;
+        }
+    }
+}
 
 static void *sdl_menubar_create(void *win)
 {
     (void)win;
+    g_sdl_has_menubar = true;
+    g_sdl_menu_item_count = 0;
     return sw_handle(0);
 }
+
 static void sdl_menubar_destroy(void *h)
 {
     (void)h;
+    g_sdl_has_menubar = false;
 }
+
 static void *sdl_menu_add_submenu(void *mb, const char *l)
 {
     (void)mb;
     (void)l;
     return sw_handle(0);
 }
+
 static void sdl_menu_add_item(void *sm, const char *l, gui_callback_t cb)
 {
     (void)sm;
-    (void)l;
-    (void)cb;
+    if (g_sdl_menu_item_count >= SDL_MAX_MENU_ITEMS)
+        return;
+    sdl_menu_item_t *item = &g_sdl_menu_items[g_sdl_menu_item_count];
+    snprintf(item->label, sizeof(item->label), "%s", l);
+    item->cb = cb;
+    float x = 4;
+    for (int i = 0; i < g_sdl_menu_item_count; i++)
+        x += g_sdl_menu_items[i].w;
+    item->x = x;
+    item->w = (float)(strlen(l) * 8 + 16);
+    g_sdl_menu_item_count++;
 }
 
 /* ── PanedWindow ─────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Resolves the final 3 known limitations from the gui plugin docs.

### GTK4 file dialogs ✅
`GtkFileChooserDialog` with nested `GMainLoop` and `response` signal handler. Extracts path via `gtk_file_chooser_get_file` + `g_file_get_path`. Supports open, save, and choose_directory.

### GTK4 ask_yes_no ✅
Proper Yes/No button callbacks with static result flag. Previously always returned false.

### SDL menus ✅
Flat menu bar rendered at top of window (20px). Clickable items with callback dispatch, auto-positioned by text width.

## Limitation Status

| Limitation | Status |
|---|---|
| ~~Cocoa Canvas~~ | ✅ Fixed in #412 |
| ~~Win32 Canvas~~ | ✅ Fixed in #412 |
| ~~Win32 choose_directory~~ | ✅ Fixed in #412 |
| ~~SDL text input~~ | ✅ Fixed in #412 |
| ~~GTK4 file dialogs~~ | ✅ This PR |
| ~~GTK4 ask_yes_no~~ | ✅ This PR |
| ~~SDL menus~~ | ✅ This PR |
| SDL debug font | Cosmetic only — functional, just compact |

**All functional limitations are now resolved.**

## Testing
- All 34 test suites pass
- clang-format clean

Part of #399.