### PR TITLE
feat: add vigil_platform_exec_streaming for live subprocess output

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -132,6 +132,40 @@ extern "C"
                                                  char **out_stdout, char **out_stderr, int *out_exit_code,
                                                  vigil_error_t *error);
 
+    /**
+     * Execute a child process with stdio inherited from the parent (live output).
+     * The child's stdout and stderr flow directly to the terminal.
+     * Returns the child's exit code via *out_exit_code.
+     * Use this for long-running build tools (gradle, xcodebuild, emcc, adb logcat).
+     * Returns VIGIL_STATUS_UNSUPPORTED on stub/embedded platforms.
+     */
+    VIGIL_API vigil_status_t vigil_platform_exec_streaming(const char *const *argv, int *out_exit_code,
+                                                           vigil_error_t *error);
+
+    /** Opaque handle to a running child process. */
+    typedef struct vigil_process vigil_process_t;
+
+    /**
+     * Start a child process with inherited stdio (non-blocking).
+     * Returns a process handle that must be cleaned up with _wait or _kill.
+     */
+    VIGIL_API vigil_status_t vigil_platform_process_start(const char *const *argv, vigil_process_t **out_process,
+                                                          vigil_error_t *error);
+
+    /**
+     * Wait for a child process to exit and retrieve its exit code.
+     * Frees the process handle. *out_process is set to NULL.
+     */
+    VIGIL_API vigil_status_t vigil_platform_process_wait(vigil_process_t **process, int *out_exit_code,
+                                                         vigil_error_t *error);
+
+    /**
+     * Send a termination signal to a child process, wait for it to exit,
+     * and free the handle. *out_process is set to NULL.
+     * Uses SIGTERM on POSIX, TerminateProcess on Windows.
+     */
+    VIGIL_API vigil_status_t vigil_platform_process_kill(vigil_process_t **process, vigil_error_t *error);
+
     /* ── Dynamic library loading ─────────────────────────────────────── */
 
     /**

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #ifndef __EMSCRIPTEN__
+#include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/resource.h>
 #endif
@@ -645,6 +646,91 @@ VIGIL_API vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator,
         *out_exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
     }
     return VIGIL_STATUS_OK;
+}
+
+/* ── Process handle (non-blocking child management) ──────────────── */
+
+struct vigil_process
+{
+    pid_t pid;
+};
+
+VIGIL_API vigil_status_t vigil_platform_process_start(const char *const *argv, vigil_process_t **out_process,
+                                                      vigil_error_t *error)
+{
+    if (!argv || !argv[0] || !out_process)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "fork failed");
+        return VIGIL_STATUS_INTERNAL;
+    }
+
+    if (pid == 0)
+    {
+        execvp(argv[0], (char *const *)argv);
+        _exit(127);
+    }
+
+    vigil_process_t *proc = (vigil_process_t *)malloc(sizeof(*proc));
+    proc->pid = pid;
+    *out_process = proc;
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_wait(vigil_process_t **process, int *out_exit_code,
+                                                     vigil_error_t *error)
+{
+    if (!process || !*process || !out_exit_code)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    int status = 0;
+    waitpid((*process)->pid, &status, 0);
+    *out_exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+    free(*process);
+    *process = NULL;
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_kill(vigil_process_t **process, vigil_error_t *error)
+{
+    if (!process || !*process)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    kill((*process)->pid, SIGTERM);
+    int status = 0;
+    waitpid((*process)->pid, &status, 0);
+    free(*process);
+    *process = NULL;
+    return VIGIL_STATUS_OK;
+}
+
+/* exec_streaming is now a convenience wrapper over start + wait. */
+VIGIL_API vigil_status_t vigil_platform_exec_streaming(const char *const *argv, int *out_exit_code,
+                                                       vigil_error_t *error)
+{
+    if (!argv || !argv[0] || !out_exit_code)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    vigil_process_t *proc = NULL;
+    vigil_status_t s = vigil_platform_process_start(argv, &proc, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
+    return vigil_platform_process_wait(&proc, out_exit_code, error);
 }
 
 /* ── Dynamic library loading ─────────────────────────────────────── */
@@ -2350,6 +2436,45 @@ VIGIL_API vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator,
     (void)out_stdout;
     (void)out_stderr;
     (void)out_exit_code;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "exec unsupported on Emscripten");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+VIGIL_API vigil_status_t vigil_platform_exec_streaming(const char *const *argv, int *out_exit_code,
+                                                       vigil_error_t *error)
+{
+    (void)argv;
+    (void)out_exit_code;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "exec unsupported on Emscripten");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+struct vigil_process
+{
+    int dummy;
+};
+
+VIGIL_API vigil_status_t vigil_platform_process_start(const char *const *argv, vigil_process_t **out_process,
+                                                      vigil_error_t *error)
+{
+    (void)argv;
+    (void)out_process;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "exec unsupported on Emscripten");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_wait(vigil_process_t **process, int *out_exit_code,
+                                                     vigil_error_t *error)
+{
+    (void)process;
+    (void)out_exit_code;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "exec unsupported on Emscripten");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_kill(vigil_process_t **process, vigil_error_t *error)
+{
+    (void)process;
     vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "exec unsupported on Emscripten");
     return VIGIL_STATUS_UNSUPPORTED;
 }

--- a/src/platform/platform_stub.c
+++ b/src/platform/platform_stub.c
@@ -217,6 +217,38 @@ vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator, const cha
     return VIGIL_STATUS_UNSUPPORTED;
 }
 
+vigil_status_t vigil_platform_exec_streaming(const char *const *argv, int *out_exit_code, vigil_error_t *error)
+{
+    (void)argv;
+    (void)out_exit_code;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+vigil_status_t vigil_platform_process_start(const char *const *argv, vigil_process_t **out_process,
+                                            vigil_error_t *error)
+{
+    (void)argv;
+    (void)out_process;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+vigil_status_t vigil_platform_process_wait(vigil_process_t **process, int *out_exit_code, vigil_error_t *error)
+{
+    (void)process;
+    (void)out_exit_code;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+vigil_status_t vigil_platform_process_kill(vigil_process_t **process, vigil_error_t *error)
+{
+    (void)process;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
 vigil_status_t vigil_platform_dlopen(const char *path, void **out_handle, vigil_error_t *error)
 {
     (void)path;

--- a/src/platform/platform_win32.c
+++ b/src/platform/platform_win32.c
@@ -632,6 +632,114 @@ VIGIL_API vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator,
     return VIGIL_STATUS_OK;
 }
 
+VIGIL_API vigil_status_t vigil_platform_exec_streaming(const char *const *argv, int *out_exit_code,
+                                                       vigil_error_t *error)
+{
+    if (!argv || !argv[0] || !out_exit_code)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    vigil_process_t *proc = NULL;
+    vigil_status_t s = vigil_platform_process_start(argv, &proc, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
+    return vigil_platform_process_wait(&proc, out_exit_code, error);
+}
+
+/* ── Process handle (non-blocking child management) ──────────────── */
+
+struct vigil_process
+{
+    HANDLE hProcess;
+};
+
+static int win32_build_cmdline(const char *const *argv, char *cmdline, size_t cmdline_size)
+{
+    size_t pos = 0;
+    for (int i = 0; argv[i]; i++)
+    {
+        if (i > 0 && pos < cmdline_size - 1)
+            cmdline[pos++] = ' ';
+        size_t len = strlen(argv[i]);
+        if (pos + len < cmdline_size - 1)
+        {
+            memcpy(cmdline + pos, argv[i], len);
+            pos += len;
+        }
+    }
+    cmdline[pos] = '\0';
+    return 1;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_start(const char *const *argv, vigil_process_t **out_process,
+                                                      vigil_error_t *error)
+{
+    PROCESS_INFORMATION pi;
+    STARTUPINFOA si;
+    char cmdline[32768];
+
+    if (!argv || !argv[0] || !out_process)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    win32_build_cmdline(argv, cmdline, sizeof(cmdline));
+
+    memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
+    memset(&pi, 0, sizeof(pi));
+
+    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi))
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "CreateProcess failed");
+        return VIGIL_STATUS_INTERNAL;
+    }
+
+    CloseHandle(pi.hThread);
+    vigil_process_t *proc = (vigil_process_t *)malloc(sizeof(*proc));
+    proc->hProcess = pi.hProcess;
+    *out_process = proc;
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_wait(vigil_process_t **process, int *out_exit_code,
+                                                     vigil_error_t *error)
+{
+    if (!process || !*process || !out_exit_code)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    DWORD exit_code;
+    WaitForSingleObject((*process)->hProcess, INFINITE);
+    GetExitCodeProcess((*process)->hProcess, &exit_code);
+    *out_exit_code = (int)exit_code;
+    CloseHandle((*process)->hProcess);
+    free(*process);
+    *process = NULL;
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_process_kill(vigil_process_t **process, vigil_error_t *error)
+{
+    if (!process || !*process)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "null argument");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+
+    TerminateProcess((*process)->hProcess, 1);
+    WaitForSingleObject((*process)->hProcess, INFINITE);
+    CloseHandle((*process)->hProcess);
+    free(*process);
+    *process = NULL;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── Dynamic library loading ─────────────────────────────────────── */
 
 VIGIL_API vigil_status_t vigil_platform_dlopen(const char *path, void **out_handle, vigil_error_t *error)

--- a/tests/platform_test.c
+++ b/tests/platform_test.c
@@ -450,6 +450,75 @@ TEST_F(PlatformTest, FileExistsReturnsValidStatus)
     EXPECT_EQ(exists, 1); /* "." always exists */
 }
 
+#ifdef VIGIL_HAS_DESKTOP_PLATFORM
+TEST_F(PlatformTest, ExecStreamingRunsChild)
+{
+    int exit_code = -1;
+#ifdef _WIN32
+    const char *argv[] = {"cmd", "/c", "echo", "hello", NULL};
+#else
+    const char *argv[] = {"echo", "hello", NULL};
+#endif
+    vigil_status_t s = vigil_platform_exec_streaming(argv, &exit_code, &FIXTURE(PlatformTest)->error);
+    EXPECT_EQ(s, VIGIL_STATUS_OK);
+    EXPECT_EQ(exit_code, 0);
+}
+
+TEST_F(PlatformTest, ExecStreamingBadCommandFails)
+{
+    int exit_code = -1;
+    const char *argv[] = {"vigil_nonexistent_command_xyz", NULL};
+    vigil_platform_exec_streaming(argv, &exit_code, &FIXTURE(PlatformTest)->error);
+    EXPECT_NE(exit_code, 0);
+}
+
+TEST_F(PlatformTest, ExecStreamingNullArgvFails)
+{
+    int exit_code = 0;
+    vigil_status_t s = vigil_platform_exec_streaming(NULL, &exit_code, &FIXTURE(PlatformTest)->error);
+    EXPECT_EQ(s, VIGIL_STATUS_INVALID_ARGUMENT);
+}
+
+TEST_F(PlatformTest, ProcessStartAndWait)
+{
+#ifdef _WIN32
+    const char *argv[] = {"cmd", "/c", "echo", "hello", NULL};
+#else
+    const char *argv[] = {"echo", "hello", NULL};
+#endif
+    vigil_process_t *proc = NULL;
+    int exit_code = -1;
+    ASSERT_EQ(vigil_platform_process_start(argv, &proc, &FIXTURE(PlatformTest)->error), VIGIL_STATUS_OK);
+    ASSERT_EQ(vigil_platform_process_wait(&proc, &exit_code, &FIXTURE(PlatformTest)->error), VIGIL_STATUS_OK);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(proc, NULL);
+}
+
+TEST_F(PlatformTest, ProcessStartAndKill)
+{
+#ifdef _WIN32
+    const char *argv[] = {"cmd", "/c", "ping", "-n", "60", "127.0.0.1", NULL};
+#else
+    const char *argv[] = {"sleep", "60", NULL};
+#endif
+    vigil_process_t *proc = NULL;
+    vigil_status_t s = vigil_platform_process_start(argv, &proc, &FIXTURE(PlatformTest)->error);
+    EXPECT_EQ(s, VIGIL_STATUS_OK);
+    ASSERT_NE(proc, NULL);
+
+    s = vigil_platform_process_kill(&proc, &FIXTURE(PlatformTest)->error);
+    EXPECT_EQ(s, VIGIL_STATUS_OK);
+    EXPECT_EQ(proc, NULL);
+}
+
+TEST_F(PlatformTest, ProcessStartNullArgvFails)
+{
+    vigil_process_t *proc = NULL;
+    vigil_status_t s = vigil_platform_process_start(NULL, &proc, &FIXTURE(PlatformTest)->error);
+    EXPECT_EQ(s, VIGIL_STATUS_INVALID_ARGUMENT);
+}
+#endif /* VIGIL_HAS_DESKTOP_PLATFORM */
+
 void register_platform_tests(void)
 {
     REGISTER_TEST_F(PlatformTest, WriteAndReadFile);
@@ -471,4 +540,12 @@ void register_platform_tests(void)
     REGISTER_TEST_F(PlatformTest, LineEditorReadlineFallbackEofFails);
     REGISTER_TEST_F(PlatformTest, FileExistsReturnsValidStatus);
     REGISTER_TEST_F(PlatformTest, EnumerateTlsCasCallback);
+#ifdef VIGIL_HAS_DESKTOP_PLATFORM
+    REGISTER_TEST_F(PlatformTest, ExecStreamingRunsChild);
+    REGISTER_TEST_F(PlatformTest, ExecStreamingBadCommandFails);
+    REGISTER_TEST_F(PlatformTest, ExecStreamingNullArgvFails);
+    REGISTER_TEST_F(PlatformTest, ProcessStartAndWait);
+    REGISTER_TEST_F(PlatformTest, ProcessStartAndKill);
+    REGISTER_TEST_F(PlatformTest, ProcessStartNullArgvFails);
+#endif
 }


### PR DESCRIPTION
## Summary

Closes #439. Adds subprocess management to the platform layer: both a blocking convenience function for simple build tool invocation, and a non-blocking process handle API for background processes and cancellation.

## API

### Blocking (convenience)
```c
vigil_status_t vigil_platform_exec_streaming(const char *const *argv,
                                              int *out_exit_code,
                                              vigil_error_t *error);
```

### Non-blocking (process handle)
```c
vigil_status_t vigil_platform_process_start(const char *const *argv,
                                             vigil_process_t **out_process,
                                             vigil_error_t *error);

vigil_status_t vigil_platform_process_wait(vigil_process_t **process,
                                            int *out_exit_code,
                                            vigil_error_t *error);

vigil_status_t vigil_platform_process_kill(vigil_process_t **process,
                                            vigil_error_t *error);
```

`exec_streaming` is implemented as `process_start` + `process_wait`.

## Use cases

- `gradle assembleDebug` → `exec_streaming` (blocking, live output)
- `adb logcat` → `process_start` + later `process_kill` (background, cancellable)
- `flutter run` hot-reload loop → `process_start` + `process_kill` on restart

## Implementations

| Platform | start | wait | kill |
|----------|-------|------|------|
| POSIX | fork + execvp | waitpid | kill(SIGTERM) + waitpid |
| Win32 | CreateProcessA | WaitForSingleObject | TerminateProcess + wait |
| Stub/Emscripten | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |

## Tests (7 total, desktop-only)

- ExecStreamingRunsChild, ExecStreamingBadCommandFails, ExecStreamingNullArgvFails
- ProcessStartAndWait, ProcessStartAndKill, ProcessStartNullArgvFails
