### PR TITLE
feat: add os.setenv, os.unsetenv, and os.environ

### DIFF
--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -101,6 +101,15 @@ extern "C"
      */
     VIGIL_API vigil_status_t vigil_platform_setenv(const char *name, const char *value, vigil_error_t *error);
 
+    /** Remove an environment variable. */
+    VIGIL_API vigil_status_t vigil_platform_unsetenv(const char *key, vigil_error_t *error);
+
+    /**
+     * Return a snapshot of all environment variables as an array of
+     * "KEY=VALUE" strings. Caller must free each string and the array.
+     */
+    VIGIL_API vigil_status_t vigil_platform_environ(char ***out_env, size_t *out_count, vigil_error_t *error);
+
     /* ── OS information ──────────────────────────────────────────────── */
 
     /** Return a static string identifying the OS: "linux", "darwin", "windows", etc. */

--- a/src/platform/platform_posix.c
+++ b/src/platform/platform_posix.c
@@ -545,6 +545,40 @@ VIGIL_API vigil_status_t vigil_platform_hostname(const vigil_allocator_t *alloca
     return VIGIL_STATUS_OK;
 }
 
+/* ── Environment variables ───────────────────────────────────────── */
+
+VIGIL_API vigil_status_t vigil_platform_unsetenv(const char *key, vigil_error_t *error)
+{
+    if (unsetenv(key) != 0)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "unsetenv failed");
+        return VIGIL_STATUS_INTERNAL;
+    }
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_environ(char ***out_env, size_t *out_count, vigil_error_t *error)
+{
+    extern char **environ;
+    size_t count = 0;
+    if (environ)
+        while (environ[count])
+            count++;
+
+    char **env = (char **)malloc((count + 1) * sizeof(char *));
+    if (!env)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "out of memory");
+        return VIGIL_STATUS_INTERNAL;
+    }
+    for (size_t i = 0; i < count; i++)
+        env[i] = strdup(environ[i]);
+    env[count] = NULL;
+    *out_env = env;
+    *out_count = count;
+    return VIGIL_STATUS_OK;
+}
+
 #ifndef __EMSCRIPTEN__
 /* ── Process execution ───────────────────────────────────────────── */
 

--- a/src/platform/platform_stub.c
+++ b/src/platform/platform_stub.c
@@ -198,6 +198,23 @@ vigil_status_t vigil_platform_hostname(const vigil_allocator_t *allocator, char 
     return VIGIL_STATUS_UNSUPPORTED;
 }
 
+/* ── Environment variables (new) ──────────────────────────────────── */
+
+vigil_status_t vigil_platform_unsetenv(const char *key, vigil_error_t *error)
+{
+    (void)key;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
+vigil_status_t vigil_platform_environ(char ***out_env, size_t *out_count, vigil_error_t *error)
+{
+    (void)out_env;
+    (void)out_count;
+    vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "not supported");
+    return VIGIL_STATUS_UNSUPPORTED;
+}
+
 /* ── Process execution ───────────────────────────────────────────── */
 
 vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator, const char *const *argv, char **out_stdout,

--- a/src/platform/platform_win32.c
+++ b/src/platform/platform_win32.c
@@ -509,6 +509,60 @@ VIGIL_API vigil_status_t vigil_platform_hostname(const vigil_allocator_t *alloca
     return VIGIL_STATUS_OK;
 }
 
+/* ── Environment variables (new) ──────────────────────────────────── */
+
+VIGIL_API vigil_status_t vigil_platform_unsetenv(const char *key, vigil_error_t *error)
+{
+    if (!SetEnvironmentVariableA(key, NULL))
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "SetEnvironmentVariable failed");
+        return VIGIL_STATUS_INTERNAL;
+    }
+    return VIGIL_STATUS_OK;
+}
+
+VIGIL_API vigil_status_t vigil_platform_environ(char ***out_env, size_t *out_count, vigil_error_t *error)
+{
+    char *block = GetEnvironmentStringsA();
+    if (!block)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "GetEnvironmentStrings failed");
+        return VIGIL_STATUS_INTERNAL;
+    }
+
+    size_t count = 0;
+    const char *p = block;
+    while (*p)
+    {
+        if (strchr(p, '=') && p[0] != '=')
+            count++;
+        p += strlen(p) + 1;
+    }
+
+    char **env = (char **)malloc((count + 1) * sizeof(char *));
+    if (!env)
+    {
+        FreeEnvironmentStringsA(block);
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "out of memory");
+        return VIGIL_STATUS_INTERNAL;
+    }
+
+    size_t idx = 0;
+    p = block;
+    while (*p)
+    {
+        if (strchr(p, '=') && p[0] != '=')
+            env[idx++] = _strdup(p);
+        p += strlen(p) + 1;
+    }
+    env[idx] = NULL;
+    FreeEnvironmentStringsA(block);
+
+    *out_env = env;
+    *out_count = idx;
+    return VIGIL_STATUS_OK;
+}
+
 /* ── Process execution ───────────────────────────────────────────── */
 
 VIGIL_API vigil_status_t vigil_platform_exec(const vigil_allocator_t *allocator, const char *const *argv,

--- a/src/stdlib/os.c
+++ b/src/stdlib/os.c
@@ -13,7 +13,9 @@
 #include "vigil/value.h"
 #include "vigil/vm.h"
 
+#include "internal/vigil_internal.h"
 #include "internal/vigil_nanbox.h"
+#include "platform/platform.h"
 
 static bool get_string_arg(vigil_vm_t *vm, size_t base, size_t idx, const char **str, size_t *len)
 {
@@ -124,13 +126,166 @@ static vigil_status_t os_arch(vigil_vm_t *vm, size_t arg_count, vigil_error_t *e
 #endif
 }
 
+/* ── Error helpers ───────────────────────────────────────────────── */
+
+static vigil_status_t push_err(vigil_vm_t *vm, const char *msg, vigil_error_t *error)
+{
+    vigil_object_t *obj = NULL;
+    vigil_status_t s = vigil_error_object_new_cstr(vigil_vm_runtime(vm), msg, 0, &obj, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
+    vigil_value_t v;
+    vigil_value_init_object(&v, &obj);
+    s = vigil_vm_stack_push(vm, &v, error);
+    vigil_value_release(&v);
+    return s;
+}
+
+static vigil_status_t push_ok(vigil_vm_t *vm, vigil_error_t *error)
+{
+    return vigil_runtime_push_ok_error(vigil_vm_runtime(vm), vm, error);
+}
+
+/* ── setenv / unsetenv / environ ─────────────────────────────────── */
+
+/* os.setenv(key: string, value: string) -> error */
+static vigil_status_t os_setenv(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    const char *key, *val;
+    size_t key_len, val_len;
+
+    if (!get_string_arg(vm, base, 0, &key, &key_len) || !get_string_arg(vm, base, 1, &val, &val_len))
+    {
+        vigil_vm_stack_pop_n(vm, arg_count);
+        return push_err(vm, "setenv: invalid argument", error);
+    }
+
+    char key_buf[256], val_buf[4096];
+    if (key_len >= sizeof(key_buf))
+        key_len = sizeof(key_buf) - 1;
+    if (val_len >= sizeof(val_buf))
+        val_len = sizeof(val_buf) - 1;
+    memcpy(key_buf, key, key_len);
+    key_buf[key_len] = '\0';
+    memcpy(val_buf, val, val_len);
+    val_buf[val_len] = '\0';
+
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    if (vigil_platform_setenv(key_buf, val_buf, error) != VIGIL_STATUS_OK)
+        return push_err(vm, "setenv failed", error);
+    return push_ok(vm, error);
+}
+
+/* os.unsetenv(key: string) -> error */
+static vigil_status_t os_unsetenv(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    size_t base = vigil_vm_stack_depth(vm) - arg_count;
+    const char *key;
+    size_t key_len;
+
+    if (!get_string_arg(vm, base, 0, &key, &key_len))
+    {
+        vigil_vm_stack_pop_n(vm, arg_count);
+        return push_err(vm, "unsetenv: invalid argument", error);
+    }
+
+    char key_buf[256];
+    if (key_len >= sizeof(key_buf))
+        key_len = sizeof(key_buf) - 1;
+    memcpy(key_buf, key, key_len);
+    key_buf[key_len] = '\0';
+
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    if (vigil_platform_unsetenv(key_buf, error) != VIGIL_STATUS_OK)
+        return push_err(vm, "unsetenv failed", error);
+    return push_ok(vm, error);
+}
+
+/* os.environ() -> map[string]string */
+static vigil_status_t os_environ(vigil_vm_t *vm, size_t arg_count, vigil_error_t *error)
+{
+    vigil_vm_stack_pop_n(vm, arg_count);
+
+    vigil_runtime_t *rt = vigil_vm_runtime(vm);
+    vigil_object_t *map = NULL;
+    vigil_status_t s = vigil_map_object_new(rt, &map, error);
+    if (s != VIGIL_STATUS_OK)
+        return s;
+
+    char **env = NULL;
+    size_t env_count = 0;
+    s = vigil_platform_environ(&env, &env_count, error);
+    if (s != VIGIL_STATUS_OK)
+    {
+        vigil_object_release(&map);
+        return s;
+    }
+
+    for (size_t i = 0; i < env_count; i++)
+    {
+        const char *eq = strchr(env[i], '=');
+        if (!eq)
+        {
+            free(env[i]); /* alloc-check: exempt - platform-allocated */
+            continue;
+        }
+        vigil_object_t *ko = NULL, *vo = NULL;
+        vigil_value_t kv, vv;
+        s = vigil_string_object_new(rt, env[i], (size_t)(eq - env[i]), &ko, error);
+        if (s != VIGIL_STATUS_OK)
+        {
+            free(env[i]); /* alloc-check: exempt - platform-allocated */
+            break;
+        }
+        s = vigil_string_object_new(rt, eq + 1, strlen(eq + 1), &vo, error);
+        if (s != VIGIL_STATUS_OK)
+        {
+            vigil_object_release(&ko);
+            free(env[i]); /* alloc-check: exempt - platform-allocated */
+            break;
+        }
+        vigil_value_init_object(&kv, &ko);
+        vigil_value_init_object(&vv, &vo);
+        s = vigil_map_object_set(map, &kv, &vv, error);
+        vigil_value_release(&kv);
+        vigil_value_release(&vv);
+        free(env[i]); /* alloc-check: exempt - platform-allocated */
+        if (s != VIGIL_STATUS_OK)
+            break;
+    }
+
+    /* Free remaining entries on error */
+    if (s != VIGIL_STATUS_OK)
+    {
+        for (size_t j = 0; j < env_count; j++)
+            free(env[j]); /* alloc-check: exempt - platform-allocated */
+        free(env); /* alloc-check: exempt - platform-allocated */
+        vigil_object_release(&map);
+        return s;
+    }
+    free(env); /* alloc-check: exempt - platform-allocated */
+
+    vigil_value_t mv;
+    vigil_value_init_object(&mv, &map);
+    s = vigil_vm_stack_push(vm, &mv, error);
+    vigil_value_release(&mv);
+    return s;
+}
+
 /* ── Module descriptor ────────────────────────────────────────────── */
 
 static const int p_str[] = {VIGIL_TYPE_STRING};
+static const int p_str_str[] = {VIGIL_TYPE_STRING, VIGIL_TYPE_STRING};
 static const int p_i32[] = {VIGIL_TYPE_I32};
 
 static const vigil_native_module_function_t os_functions[] = {
     {"getenv", 6U, os_getenv, 1U, p_str, VIGIL_TYPE_STRING, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
+    {"setenv", 6U, os_setenv, 2U, p_str_str, VIGIL_TYPE_ERR, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
+    {"unsetenv", 8U, os_unsetenv, 1U, p_str, VIGIL_TYPE_ERR, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
+    {"environ", 7U, os_environ, 0U, NULL, VIGIL_TYPE_OBJECT, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
     {"exit", 4U, os_exit_fn, 1U, p_i32, VIGIL_TYPE_VOID, 0U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
     {"platform", 8U, os_platform, 0U, NULL, VIGIL_TYPE_STRING, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},
     {"arch", 4U, os_arch, 0U, NULL, VIGIL_TYPE_STRING, 1U, NULL, 0, NULL, NULL, 0U, NULL, NULL, NULL, NULL},


### PR DESCRIPTION
## Summary

Closes #432. Adds three functions to the `os` stdlib module for environment variable management.

## New functions

| Function | Signature | Description |
|----------|-----------|-------------|
| `os.setenv` | `(key: string, value: string) -> error` | Set an environment variable |
| `os.unsetenv` | `(key: string) -> error` | Remove an environment variable |
| `os.environ` | `() -> map[string]string` | Snapshot of all environment variables |

## Implementation

- POSIX: `setenv()` / `unsetenv()` / `extern char **environ`
- Win32: `SetEnvironmentVariableA()` / `GetEnvironmentStringsA()` + `FreeEnvironmentStringsA()`
- `os.environ()` returns a copy at call time, not a live view

## Files changed

- `src/stdlib/os.c` — 1 file, 181 insertions
