### PR TITLE
perf: disable Intel CET for VM dispatch loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ ffi.o
 *.o
 build-prof/
 build-main/
+build-optest/
+profile_results/

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -90,5 +90,12 @@ if(VIGIL_HAS_DESKTOP_PLATFORM)
     target_compile_definitions(vigil_core PRIVATE VIGIL_HAS_DESKTOP_PLATFORM)
 endif()
 
+# Disable Intel CET (endbr64) for the VM dispatch loop. Every computed-goto
+# target gets an endbr64 that costs 6-10% of dispatch overhead. CET provides
+# no security value for a VM dispatch loop with known jump targets.
+if(NOT MSVC AND NOT EMSCRIPTEN)
+    set_source_files_properties(src/regvm.c PROPERTIES COMPILE_OPTIONS "-fcf-protection=none")
+endif()
+
 # Objects may end up in a shared library, so they need PIC on Linux.
 set_target_properties(vigil_core PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Summary

Part of #450. Disables Intel Control-flow Enforcement Technology (CET) for `regvm.c` only.

## Change

```cmake
set_source_files_properties(src/regvm.c PROPERTIES COMPILE_OPTIONS "-fcf-protection=none")
```

## Why

Every computed-goto label in the VM dispatch loop gets an `endbr64` instruction (Intel CET indirect branch target). Perf annotate data from #436 shows these account for 6-10% of samples in the dispatch loop:

```
6.06%  endbr64    (opcode handler landing pad)
4.64%  endbr64    (different handler)
4.19%  jmp *(...)  (the dispatch jump itself)
```

CET provides no security value for a VM dispatch loop where every indirect jump target is a known opcode handler compiled into the same translation unit.

## Scope

- Only affects `regvm.c`, not the rest of the project
- Only on GCC/Clang (guarded with `NOT MSVC AND NOT EMSCRIPTEN`)
- Expected ~6-10% reduction in dispatch overhead on Intel x86_64 (no effect on ARM/Apple Silicon)

## Deferred

The comparison-jump fusion (VREG_LT + VREG_TEST -> VREG_LT_I32_JMP) is deferred. Investigation revealed the regvm lowering's `in_chain` logic for `&&`/`||` short-circuit evaluation deliberately falls back to separate CMP+TEST+JMP to maintain stack depth invariants. Fixing this requires careful rework of the stack depth tracking in the lowering pass.
