### PR TITLE
perf: reduce MOVE dispatches 50%, add CMPI fusion — fib(35) 0.70s → 0.58s

### DIFF
--- a/src/internal/vigil_regvm.h
+++ b/src/internal/vigil_regvm.h
@@ -237,6 +237,7 @@ typedef enum vigil_reg_op
     VREG_SUBI = 136, /* A B C   R[A] = R[B] -i32 imm8(C) */
     VREG_ADDI_I64 = 137, /* A B C   R[A] = R[B] +i64 imm8(C) */
     VREG_SUBI_I64 = 138, /* A B C   R[A] = R[B] -i64 imm8(C) */
+    VREG_LT_I32_IMM_JMP = 139, /* A C + JMP   if R[A] <i32 imm8(C), skip following JMP */
 
     VREG_OP_COUNT
 } vigil_reg_op_t;

--- a/src/regvm.c
+++ b/src/regvm.c
@@ -333,6 +333,24 @@ static uint8_t vs_push_result(vstack_t *vs, uint8_t preferred)
     return vs_push_at(vs, vs_result_base(vs, preferred));
 }
 
+static int vs_top_is_contiguous(const vstack_t *vs, uint32_t count)
+{
+    uint8_t base;
+    uint32_t i;
+
+    if (vs == NULL || count == 0U || count > (uint32_t)vs->top)
+        return 0;
+
+    base = vs->regs[vs->top - (int)count];
+    for (i = 1U; i < count; i++)
+    {
+        if (vs->regs[vs->top - (int)count + (int)i] != (uint8_t)(base + (uint8_t)i))
+            return 0;
+    }
+
+    return 1;
+}
+
 static int vs_uses_reg(const vstack_t *vs, uint8_t reg)
 {
     size_t i;
@@ -2109,6 +2127,7 @@ vigil_status_t vigil_reg_translate(const vigil_chunk_t *stack_chunk, vigil_reg_c
             size_t target = ip + (size_t)off;
             size_t direct_target = target;
             int in_chain = 0;
+            int fused_cmp_imm = 0;
 
             /* Detect &&/|| short-circuit chains where the bool must stay
                on the stack for the next comparison in the chain. */
@@ -2207,7 +2226,29 @@ vigil_status_t vigil_reg_translate(const vigil_chunk_t *stack_chunk, vigil_reg_c
             {
                 NORMALIZE_TO_TARGET(direct_target);
 
-                TR_EMIT(vigil_reg_abc(map_cmp_jmp(op), ra, rb, 0));
+                if (op == VIGIL_OPCODE_LESS_I32_JUMP_IF_FALSE && rb >= vs.local_count && rc->code_count > 0U &&
+                    prev_op == VIGIL_OPCODE_CONSTANT && prev_start_ip != (size_t)-1 &&
+                    !jump_target_contains(jt, jt_count, prev_start_ip))
+                {
+                    vigil_reg_instr_t prev_instr = rc->code[rc->code_count - 1U];
+                    if (VREG_GET_OP(prev_instr) == VREG_LOAD_K && VREG_GET_A(prev_instr) == rb)
+                    {
+                        int8_t imm = 0;
+                        if (regvm_constant_as_i8(stack_chunk, VREG_GET_Bx(prev_instr), &imm))
+                        {
+                            rc->code_count -= 1U;
+                            if (omap.count > 0U && omap.stack_offsets[omap.count - 1U] == start_ip &&
+                                omap.reg_indices[omap.count - 1U] >= 1U)
+                            {
+                                omap.reg_indices[omap.count - 1U] -= 1U;
+                            }
+                            TR_EMIT(vigil_reg_abc(VREG_LT_I32_IMM_JMP, ra, 0, (uint8_t)imm));
+                            fused_cmp_imm = 1;
+                        }
+                    }
+                }
+                if (!fused_cmp_imm)
+                    TR_EMIT(vigil_reg_abc(map_cmp_jmp(op), ra, rb, 0));
                 jpatch_add(&patches, rc->code_count, direct_target, 0, vs.top);
                 RECORD_DEPTH(direct_target, vs.top);
                 TR_EMIT(vigil_reg_asbx(VREG_JMP, 0, 0));
@@ -2246,18 +2287,19 @@ vigil_status_t vigil_reg_translate(const vigil_chunk_t *stack_chunk, vigil_reg_c
 #define PACK_CALL_ARGS(n)                                                                                              \
     do                                                                                                                 \
     {                                                                                                                  \
-        if ((n) > 0)                                                                                                   \
+        uint32_t _count = (uint32_t)(n);                                                                               \
+        if (_count > 0U && !vs_top_is_contiguous(&vs, _count))                                                         \
         {                                                                                                              \
             uint8_t _base = vs.next_reg;                                                                               \
-            for (uint32_t _ai = 0; _ai < (uint32_t)(n); _ai++)                                                         \
+            for (uint32_t _ai = 0; _ai < _count; _ai++)                                                                \
             {                                                                                                          \
                 uint8_t _exp = (uint8_t)(_base + (uint8_t)_ai);                                                        \
-                uint8_t _act = vs.regs[vs.top - (int)(n) + (int)_ai];                                                  \
+                uint8_t _act = vs.regs[vs.top - (int)_count + (int)_ai];                                               \
                 if (_act != _exp)                                                                                      \
                     TR_EMIT(vigil_reg_abc(VREG_MOVE, _exp, _act, 0));                                                  \
-                vs.regs[vs.top - (int)(n) + (int)_ai] = _exp;                                                          \
+                vs.regs[vs.top - (int)_count + (int)_ai] = _exp;                                                       \
             }                                                                                                          \
-            vs.next_reg = (uint8_t)(_base + (uint8_t)(n));                                                             \
+            vs.next_reg = (uint8_t)(_base + (uint8_t)_count);                                                          \
         }                                                                                                              \
     } while (0)
 
@@ -3524,6 +3566,7 @@ vigil_status_t vigil_regvm_execute(vigil_vm_t *vm, const vigil_reg_chunk_t *rc, 
             [VREG_JMP] = &&r_JMP,
             [VREG_TEST] = &&r_TEST,
             [VREG_LT_I32_JMP] = &&r_LT_I32_JMP,
+            [VREG_LT_I32_IMM_JMP] = &&r_LT_I32_IMM_JMP,
             [VREG_LE_I32_JMP] = &&r_LE_I32_JMP,
             [VREG_GT_I32_JMP] = &&r_GT_I32_JMP,
             [VREG_GE_I32_JMP] = &&r_GE_I32_JMP,
@@ -4133,6 +4176,17 @@ r_dispatch_switch_check:
     {
         vigil_reg_instr_t i = code[ip];
         if (vigil_nanbox_decode_i32(R[VREG_GET_A(i)]) < vigil_nanbox_decode_i32(R[VREG_GET_B(i)]))
+        {
+            ip += 2;
+            RDISPATCH(); /* skip jump */
+        }
+        ip++;
+        RDISPATCH(); /* execute jump */
+    }
+    RCASE(LT_I32_IMM_JMP)
+    {
+        vigil_reg_instr_t i = code[ip];
+        if (vigil_nanbox_decode_i32(R[VREG_GET_A(i)]) < (int32_t)(int8_t)VREG_GET_C(i))
         {
             ip += 2;
             RDISPATCH(); /* skip jump */

--- a/tests/vm_test.c
+++ b/tests/vm_test.c
@@ -298,6 +298,80 @@ static size_t CountRegOpcode(const vigil_reg_chunk_t *chunk, uint8_t opcode)
 
     return count;
 }
+
+static const vigil_object_t *FindCompiledFunctionByName(const CompiledMainFixture *fixture, const char *name)
+{
+    size_t index;
+
+    if (fixture == NULL || fixture->function == NULL || name == NULL)
+        return NULL;
+
+    if (strcmp(vigil_function_object_name(fixture->function), name) == 0)
+        return fixture->function;
+
+    for (index = 0U;; index += 1U)
+    {
+        const vigil_object_t *candidate = vigil_function_object_sibling(fixture->function, index);
+        if (candidate == NULL)
+            return NULL;
+        if (strcmp(vigil_function_object_name(candidate), name) == 0)
+            return candidate;
+    }
+}
+
+static int HasSingleArgCallPackMove(const vigil_reg_chunk_t *chunk)
+{
+    size_t ip = 0U;
+    size_t prev_ip = (size_t)-1;
+
+    if (chunk == NULL)
+        return 0;
+
+    while (ip < chunk->code_count)
+    {
+        vigil_reg_instr_t instr = chunk->code[ip];
+        uint8_t op = VREG_GET_OP(instr);
+        uint8_t arg_base = 0U;
+        int check_move = 0;
+        size_t step = RegInstructionWordCount(chunk, ip);
+
+        switch (op)
+        {
+        case VREG_CALL:
+        case VREG_CALL_NATIVE:
+        case VREG_CALL_EXTERN:
+        case VREG_TAIL_CALL:
+            if (VREG_GET_C(instr) == 1U)
+            {
+                arg_base = VREG_GET_A(instr);
+                check_move = 1;
+            }
+            break;
+        case VREG_CALL_SELF:
+            if (VREG_GET_B(instr) == 1U && ip + 1U < chunk->code_count)
+            {
+                arg_base = (uint8_t)(chunk->code[ip + 1U] & 0xFFU);
+                check_move = 1;
+            }
+            break;
+        default:
+            break;
+        }
+
+        if (check_move && prev_ip != (size_t)-1 && VREG_GET_OP(chunk->code[prev_ip]) == VREG_MOVE &&
+            VREG_GET_A(chunk->code[prev_ip]) == arg_base)
+        {
+            return 1;
+        }
+
+        prev_ip = ip;
+        if (step == 0U || step > chunk->code_count - ip)
+            step = 1U;
+        ip += step;
+    }
+
+    return 0;
+}
 #endif /* !_WIN32 */
 
 static vigil_status_t RunBinaryIntOpcode(vigil_opcode_t opcode, int64_t left_value, int64_t right_value,
@@ -630,7 +704,8 @@ TEST(VigilVmTest, FusesPlainI32CompareJumpWithoutChainFallback)
                                            &error),
               VIGIL_STATUS_OK);
     ASSERT_NE(reg_chunk, NULL);
-    EXPECT_TRUE(CountRegOpcode(reg_chunk, VREG_LT_I32_JMP) >= 1U);
+    EXPECT_TRUE(CountRegOpcode(reg_chunk, VREG_LT_I32_IMM_JMP) >= 1U);
+    EXPECT_EQ(CountRegOpcode(reg_chunk, VREG_LT_I32_JMP), 0U);
     EXPECT_EQ(CountRegOpcode(reg_chunk, VREG_TEST), 0U);
 
     CloseCompiledMainFixture(&fixture);
@@ -700,6 +775,42 @@ TEST(VigilVmTest, FusesI64ImmediateAddAndSub)
     EXPECT_EQ(add_i64_imm_count + add_i64_count, 1U);
     EXPECT_EQ(sub_i64_imm_count, 1U);
     EXPECT_EQ(sub_i64_count, 0U);
+
+    CloseCompiledMainFixture(&fixture);
+}
+
+TEST(VigilVmTest, AvoidsSingleArgCallPackingMove)
+{
+    static const char source[] = "fn fib(i32 n) -> i32 {"
+                                 "    if n < 2 {"
+                                 "        return n;"
+                                 "    }"
+                                 "    return fib(n - 1);"
+                                 "}"
+                                 "fn main() -> i32 {"
+                                 "    return fib(6);"
+                                 "}";
+    CompiledMainFixture fixture;
+    vigil_error_t error = {0};
+    const vigil_object_t *fib_function = NULL;
+    const vigil_reg_chunk_t *reg_chunk = NULL;
+    vigil_chunk_t *chunk = NULL;
+
+    ASSERT_EQ(OpenCompiledMainFixture(source, &fixture, &error), VIGIL_STATUS_OK);
+    ASSERT_EQ(vigil_diagnostic_list_count(&fixture.diagnostics), 0U);
+
+    fib_function = FindCompiledFunctionByName(&fixture, "fib");
+    ASSERT_NE(fib_function, NULL);
+    chunk = (vigil_chunk_t *)vigil_function_object_chunk(fib_function);
+    ASSERT_NE(chunk, NULL);
+    ASSERT_EQ(vigil_chunk_ensure_reg_cache(chunk, (uint8_t)vigil_function_object_arity(fib_function), &reg_chunk,
+                                           &error),
+              VIGIL_STATUS_OK);
+    ASSERT_NE(reg_chunk, NULL);
+    EXPECT_TRUE(CountRegOpcode(reg_chunk, VREG_CALL_SELF) + CountRegOpcode(reg_chunk, VREG_CALL) +
+                    CountRegOpcode(reg_chunk, VREG_TAIL_CALL) >=
+                1U);
+    EXPECT_FALSE(HasSingleArgCallPackMove(reg_chunk));
 
     CloseCompiledMainFixture(&fixture);
 }
@@ -2408,6 +2519,7 @@ void register_vm_tests(void)
     REGISTER_TEST(VigilVmTest, FusesPlainI32CompareJumpWithoutChainFallback);
     REGISTER_TEST(VigilVmTest, FusesI32ImmediateAddAndSub);
     REGISTER_TEST(VigilVmTest, FusesI64ImmediateAddAndSub);
+    REGISTER_TEST(VigilVmTest, AvoidsSingleArgCallPackingMove);
 #endif
     REGISTER_TEST(VigilVmTest, ComparesDifferentObjectTypesByValue);
     REGISTER_TEST(VigilVmTest, RejectsToStringOnNonStringObject);


### PR DESCRIPTION
## Summary

Continues #453. Two optimizations that reduce fib(35) from 0.70s to 0.58s (17% speedup, cumulative 33% from baseline 0.87s).

## Benchmark results

| Language | fib(35) | vs Vigil |
|----------|---------|----------|
| Lua 5.4.7 | 0.53s | 1.09x faster |
| **Vigil (this PR)** | **0.58s** | baseline |
| Vigil (before) | 0.70s | 1.21x slower |
| Vigil (original) | 0.87s | 1.50x slower |
| Python 3.12 | 0.92s | 1.59x slower |

**Gap to Lua narrowed from 1.62x to 1.09x.**

## Opcode profile changes (fib(35))

| Opcode | Before | After | Change |
|--------|--------|-------|--------|
| MOVE | 59,721,408 | 29,860,704 | **-50%** |
| LOAD_K | 29,860,704 | 1 | **-99.99%** |
| LT_I32_JMP | 29,860,703 | 0 | replaced by CMPI |
| LT_I32_IMM_JMP (new) | 0 | 29,860,703 | fused compare-immediate |
| Total dispatches | ~209M | ~149M | **-29%** |

## Changes

### 1. Call-arg packing skip
When call arguments are already in contiguous registers (common for single-arg recursive calls like `fib(n-1)`), skip the remap/MOVE step entirely. Eliminates ~30M MOVEs on fib(35).

### 2. VREG_LT_I32_IMM_JMP
New opcode that compares a register against an i8 immediate and conditionally jumps. Fuses `LOAD_K + LT_I32_JMP` for patterns like `n < 2`. Eliminates ~30M LOAD_K dispatches.

## Validation
- All tests pass
- Release benchmark: 0.58s best-of-5 (target was < 0.60s) ✅
