### PR TITLE
fix(examples): remove duplicate fn main from example test files

### DIFF
--- a/examples/vigil-cut/test/cut_test.vigil
+++ b/examples/vigil-cut/test/cut_test.vigil
@@ -20,6 +20,3 @@ fn test_cut_invalid_field(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}

--- a/examples/vigil-nl/test/nl_test.vigil
+++ b/examples/vigil-nl/test/nl_test.vigil
@@ -11,6 +11,3 @@ fn test_nl_basic(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}

--- a/examples/vigil-paste/test/paste_test.vigil
+++ b/examples/vigil-paste/test/paste_test.vigil
@@ -24,6 +24,3 @@ fn test_paste_single_file(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}

--- a/examples/vigil-sort/test/sort_test.vigil
+++ b/examples/vigil-sort/test/sort_test.vigil
@@ -14,6 +14,3 @@ fn test_sort_basic(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}

--- a/examples/vigil-tr/test/tr_test.vigil
+++ b/examples/vigil-tr/test/tr_test.vigil
@@ -17,6 +17,3 @@ fn test_tr_length_mismatch(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}

--- a/examples/vigil-uniq/test/uniq_test.vigil
+++ b/examples/vigil-uniq/test/uniq_test.vigil
@@ -14,6 +14,3 @@ fn test_uniq_basic(test.T t) -> void {
 }
 
 
-fn main() -> i32 {
-    return 0
-}


### PR DESCRIPTION
## Problem

6 example test suites fail because the test files declare `fn main()` which conflicts with the test runner's generated wrapper main.

## Fix

Remove `fn main() -> i32 { return 0 }` from 6 test files:
- vigil-cut, vigil-nl, vigil-paste, vigil-sort, vigil-tr, vigil-uniq

This matches the pattern used by the passing test suites (vigil-wc, vigil-cat, vigil-grep, vigil-tee) which don't have `fn main`.

## Remaining issues

After this fix, the tests still fail because they use `os.exec()` to shell out and run the vigil binary. `os.exec` is not in the `os` module's documented API (`os` only has getenv/setenv/exit/platform/arch). These integration tests need either:
1. `os.exec` to be implemented
2. Or the tests rewritten as unit tests that don't shell out

This is a separate issue from the duplicate main fix.

Refs #470