### PR TITLE
fix(regvm): fix stack depth mismatch with fused compare+jump inside loops

### DIFF
--- a/src/regvm.c
+++ b/src/regvm.c
@@ -820,6 +820,12 @@ static size_t *collect_jump_targets(const uint8_t *code, size_t code_size, size_
             uint32_t off = (uint32_t)code[ip + 1] | ((uint32_t)code[ip + 2] << 8) | ((uint32_t)code[ip + 3] << 16) |
                            ((uint32_t)code[ip + 4] << 24);
             target = ip + 5 + (size_t)off;
+            /* The fused compare+jump consumes the comparison operands
+               directly.  If the raw target is a POP (which the original
+               non-fused sequence used to discard the boolean result),
+               advance past it — the POP is dead code for the fused path. */
+            if (target < code_size && code[target] == VIGIL_OPCODE_POP)
+                target += 1U;
             has_target = 1;
         }
         else if (op == VIGIL_OPCODE_FORLOOP_I32 || op == VIGIL_OPCODE_FORLOOP_I64)


### PR DESCRIPTION
## Problem

`if` statements inside `for` loops crash with `regvm jump target stack depth mismatch`.

Minimal reproduction:
```vigil
fn main() -> i32 {
    for (i32 i = 0; i < 2; i++) {
        if i > 0 { }
    }
    return 0
}
```

## Root Cause

`collect_jump_targets()` registered the raw target of fused compare+jump opcodes (e.g., `LESS_I32_JUMP_IF_FALSE`), which points to a POP instruction. The translator's codegen correctly skips this POP via `direct_target`, but the jump target list still included the POP's offset. This caused the translator to process the POP during sequential fall-through with an incorrect stack depth.

## Fix

In `collect_jump_targets()`, advance the target past the POP for fused compare+jump opcodes, matching the `direct_target` logic already used in the translator. **6 lines changed.**

## Affected Examples

- `examples/collections.vigil` — now runs correctly
- `examples/syntax_validation_stress.vigil` — now runs correctly (194/194 tests pass)

## Testing

- All 34 integration tests pass
- All unit tests pass (1161/1161)
- AOT and interpreter produce identical output

Fixes #473, Refs #470