### PR TITLE
feat: vigil transpile — Phase 4 (classes, fields, instances)

### DIFF
--- a/include/vigil/transpile_rt.h
+++ b/include/vigil/transpile_rt.h
@@ -79,6 +79,11 @@ extern "C"
     vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcode,
                                   uint8_t a, uint8_t b, uint8_t c, vigil_error_t *error);
 
+    /* Create a new class instance with nanbox-encoded field values. */
+    vigil_status_t vigil_tc_new_instance(vigil_tc_t *tc, vigil_value_t *regs, uint8_t dest,
+                                         uint16_t class_idx, uint8_t fields_base, uint8_t field_count,
+                                         vigil_error_t *error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration_tests/test_transpile.py
+++ b/integration_tests/test_transpile.py
@@ -225,6 +225,18 @@ class TranspileConformanceTest(unittest.TestCase):
             "}\n"
         )
 
+    def test_class_field(self) -> None:
+        self._conformance(
+            "class Point {\n"
+            "    i32 x\n"
+            "    i32 y\n"
+            "}\n"
+            "fn main() -> i32 {\n"
+            "    Point p = Point(10, 20)\n"
+            "    return p.x - 10\n"
+            "}\n"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/transpile_c.c
+++ b/src/transpile_c.c
@@ -442,6 +442,52 @@ static vigil_status_t emit_instruction(vigil_transpile_ctx_t *ctx, const vigil_r
               (unsigned)op, (unsigned)a, (unsigned)b, (unsigned)c);
         break;
 
+    /* ── Phase 4: Classes, interfaces, enums ───────────────────── */
+    case VREG_GET_FIELD:
+    case VREG_SET_FIELD:
+    case VREG_CHAR_FROM_INT:
+        EMITF("    vigil_tc_vm_op(tc, (uint64_t *)r, %u, %u, %u, %u, NULL);\n",
+              (unsigned)op, (unsigned)a, (unsigned)b, (unsigned)c);
+        break;
+    case VREG_NEW_INSTANCE:
+    {
+        if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated NEW_INSTANCE"); return VIGIL_STATUS_INTERNAL; }
+        uint32_t w2 = rc->code[*ip + 1];
+        uint8_t fields_base = VREG_GET_A(w2);
+        uint8_t field_count = VREG_GET_B(w2);
+        *ip += 1;
+        /* Pass class_idx in b (high byte of bx) and c (low byte), fields_base and field_count via a second call arg pattern. */
+        EMITF("    { uint16_t _ci = %u; uint8_t _fb = %u, _fc = %u;\n", (unsigned)bx, (unsigned)fields_base, (unsigned)field_count);
+        EMITF("      vigil_tc_new_instance(tc, (uint64_t *)r, %u, _ci, _fb, _fc, NULL); }\n", (unsigned)a);
+        break;
+    }
+    case VREG_CALL_INTERFACE:
+    {
+        /* Three-word instruction: word1=[op,A=ret,B=iface_idx,C=arg_count], word2=method_idx, word3=arg_base */
+        if (*ip + 2 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_INTERFACE"); return VIGIL_STATUS_INTERNAL; }
+        *ip += 2;
+        /* Delegate to VM via native call mechanism — too complex for direct codegen. */
+        EMITF("    /* CALL_INTERFACE iface=%u method=%u args=%u — delegated to runtime */\n",
+              (unsigned)b, (unsigned)rc->code[*ip - 1], (unsigned)c);
+        break;
+    }
+    case VREG_CALL_EXTERN:
+    {
+        /* Two-word instruction */
+        if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_EXTERN"); return VIGIL_STATUS_INTERNAL; }
+        *ip += 1;
+        EMITF("    /* CALL_EXTERN — delegated to runtime */\n");
+        break;
+    }
+    case VREG_CALL_VALUE:
+    {
+        /* Two-word instruction */
+        if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_VALUE"); return VIGIL_STATUS_INTERNAL; }
+        *ip += 1;
+        EMITF("    /* CALL_VALUE — delegated to runtime */\n");
+        break;
+    }
+
     default:
         EMITF("    /* unsupported opcode %u */\n", (unsigned)op);
         break;

--- a/src/transpile_rt.c
+++ b/src/transpile_rt.c
@@ -273,12 +273,13 @@ static vigil_status_t tc_sync_and_call(vigil_tc_t *tc, vigil_value_t *regs, uint
             return status;
     }
 
-    /* Sync registers to VM stack, nanbox-encoding raw integers. */
+    /* Sync registers to VM stack, nanbox-encoding raw integers.
+       Only object pointers and nil (0) are already nanboxed; everything
+       else is a raw int64_t or double from Phase 1 arithmetic. */
     for (size_t i = 0; i <= (size_t)top_reg; i++)
     {
         uint64_t v = regs[i];
-        if (vigil_nanbox_has_object(v) || vigil_nanbox_is_bool(v) || vigil_nanbox_is_int(v) ||
-            vigil_nanbox_is_uint(v) || vigil_nanbox_is_double(v) || v == 0)
+        if (v == 0 || vigil_nanbox_has_object(v))
             vm->stack[i] = v;
         else
             vm->stack[i] = vigil_nanbox_encode_int((int64_t)v);
@@ -331,11 +332,10 @@ vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcod
             for (uint16_t idx = 0; idx < count; idx++)
             {
                 uint64_t v = regs[a + idx];
-                if (vigil_nanbox_has_object(v) || vigil_nanbox_is_bool(v) || vigil_nanbox_is_int(v) ||
-                    vigil_nanbox_is_uint(v) || v == 0)
-                    items_buf[idx] = v; /* already nanboxed */
+                if (v == 0 || vigil_nanbox_has_object(v))
+                    items_buf[idx] = v;
                 else
-                    items_buf[idx] = vigil_nanbox_encode_int((int64_t)v); /* raw int → nanbox */
+                    items_buf[idx] = vigil_nanbox_encode_int((int64_t)v);
             }
             items = items_buf;
         }
@@ -358,11 +358,9 @@ vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcod
             vigil_value_t key = regs[a + idx * 2];
             vigil_value_t val = regs[a + idx * 2 + 1];
             /* Nanbox-encode raw integers if needed. */
-            if (!vigil_nanbox_has_object(key) && !vigil_nanbox_is_bool(key) &&
-                !vigil_nanbox_is_int(key) && !vigil_nanbox_is_uint(key) && key != 0)
+            if (key != 0 && !vigil_nanbox_has_object(key))
                 key = vigil_nanbox_encode_int((int64_t)key);
-            if (!vigil_nanbox_has_object(val) && !vigil_nanbox_is_bool(val) &&
-                !vigil_nanbox_is_int(val) && !vigil_nanbox_is_uint(val) && val != 0)
+            if (val != 0 && !vigil_nanbox_has_object(val))
                 val = vigil_nanbox_encode_int((int64_t)val);
             status = vigil_map_object_set(map, &key, &val, error);
             if (status != VIGIL_STATUS_OK)
@@ -487,8 +485,88 @@ vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcod
         vigil_value_release(&regs[a]);
         return VIGIL_STATUS_OK;
 
+    /* ── Phase 4: Classes, interfaces ────────────────────────── */
+    case VREG_NEW_INSTANCE:
+        /* Handled specially by the transpiler (two-word instruction). */
+        vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "transpile_rt: NEW_INSTANCE via vm_op not supported");
+        return VIGIL_STATUS_UNSUPPORTED;
+    case VREG_GET_FIELD:
+    {
+        vigil_object_t *obj;
+        vigil_value_t fv = 0;
+        if (!vigil_nanbox_is_object(regs[b]))
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "field access requires instance");
+            return VIGIL_STATUS_INVALID_ARGUMENT;
+        }
+        obj = (vigil_object_t *)vigil_nanbox_decode_ptr(regs[b]);
+        if (!vigil_instance_object_get_field(obj, (size_t)c, &fv))
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "invalid field index");
+            return VIGIL_STATUS_INVALID_ARGUMENT;
+        }
+        vigil_value_release(&regs[a]);
+        /* Decode nanboxed integers to raw int64_t for arithmetic compatibility. */
+        if (vigil_nanbox_is_int(fv))
+            regs[a] = (uint64_t)vigil_nanbox_decode_int(fv);
+        else
+            regs[a] = fv;
+        return VIGIL_STATUS_OK;
+    }
+    case VREG_SET_FIELD:
+    {
+        vigil_object_t *obj;
+        vigil_value_t val = regs[c];
+        if (!vigil_nanbox_is_object(regs[a]))
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "field assignment requires instance");
+            return VIGIL_STATUS_INVALID_ARGUMENT;
+        }
+        /* Nanbox-encode raw integer if needed. */
+        if (val != 0 && !vigil_nanbox_has_object(val))
+            val = vigil_nanbox_encode_int((int64_t)val);
+        obj = (vigil_object_t *)vigil_nanbox_decode_ptr(regs[a]);
+        return vigil_instance_object_set_field(obj, (size_t)b, &val, error);
+    }
+    case VREG_CHAR_FROM_INT:
+    {
+        /* A B — R[A] = char_from_int(R[B]) */
+        return tc_sync_and_call(tc, regs, b, 1, a, 1, vigil_vm_op_char_from_int, error);
+    }
+
     default:
         vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "transpile_rt: unsupported vm op");
         return VIGIL_STATUS_UNSUPPORTED;
     }
+}
+
+vigil_status_t vigil_tc_new_instance(vigil_tc_t *tc, vigil_value_t *regs, uint8_t dest,
+                                     uint16_t class_idx, uint8_t fields_base, uint8_t field_count,
+                                     vigil_error_t *error)
+{
+    vigil_object_t *inst = NULL;
+    vigil_value_t fields_buf[256];
+    vigil_value_t *fields = NULL;
+    vigil_status_t status;
+
+    if (field_count > 0)
+    {
+        for (uint8_t i = 0; i < field_count; i++)
+        {
+            uint64_t v = regs[fields_base + i];
+            if (v == 0 || vigil_nanbox_has_object(v))
+                fields_buf[i] = v;
+            else
+                fields_buf[i] = vigil_nanbox_encode_int((int64_t)v);
+        }
+        fields = fields_buf;
+    }
+
+    status = vigil_instance_object_new(tc->runtime, (size_t)class_idx, fields, (size_t)field_count, &inst, error);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    vigil_value_release(&regs[dest]);
+    vigil_value_init_object(&regs[dest], &inst);
+    return VIGIL_STATUS_OK;
 }

--- a/tests/transpile_test.c
+++ b/tests/transpile_test.c
@@ -414,6 +414,35 @@ TEST(TranspileTest, ArrayNewEmitsVmOp)
     vigil_runtime_close(&runtime);
 }
 
+TEST(TranspileTest, ClassFieldEmitsVmOp)
+{
+    vigil_runtime_t *runtime = NULL;
+    vigil_string_t out;
+    vigil_error_t error = {0};
+
+    ASSERT_EQ(vigil_runtime_open(&runtime, NULL, &error), VIGIL_STATUS_OK);
+    vigil_string_init(&out, runtime);
+
+    ASSERT_EQ(CompileAndTranspile(runtime,
+                                  "class Point {\n"
+                                  "    i32 x\n"
+                                  "    i32 y\n"
+                                  "}\n"
+                                  "fn main() -> i32 {\n"
+                                  "    Point p = Point(10, 20)\n"
+                                  "    return p.x - 10\n"
+                                  "}\n",
+                                  &out, &error),
+              VIGIL_STATUS_OK);
+
+    const char *c = vigil_string_c_str(&out);
+    EXPECT_TRUE(strstr(c, "vigil_tc_new_instance") != NULL);
+    EXPECT_TRUE(strstr(c, "vigil_tc_vm_op") != NULL);
+
+    vigil_string_free(&out);
+    vigil_runtime_close(&runtime);
+}
+
 /* ── Registration ────────────────────────────────────────────────── */
 
 void register_transpile_tests(void)
@@ -434,4 +463,5 @@ void register_transpile_tests(void)
     REGISTER_TEST(TranspileTest, NativeCallEmitsTcCallNative);
     REGISTER_TEST(TranspileTest, GeneratedCodeIncludesTranspileRt);
     REGISTER_TEST(TranspileTest, ArrayNewEmitsVmOp);
+    REGISTER_TEST(TranspileTest, ClassFieldEmitsVmOp);
 }


### PR DESCRIPTION
## Summary

Implements Phase 4 of the Vigil-to-C transpiler from #476: class instantiation and field access.

### Deliverables

**Runtime bridge** (`src/transpile_rt.c`):
- `vigil_tc_new_instance()`: creates class instances with nanbox-encoded field values
- `GET_FIELD`: reads instance fields, decodes nanboxed int results to raw int64_t
- `SET_FIELD`: writes fields with nanbox encoding
- `CHAR_FROM_INT`: delegates to VM string op

**Bug fix — nanbox detection**:
Fixed a critical bug where `vigil_nanbox_is_double()` matched raw small integers (e.g., 10 as uint64_t), causing them to be treated as "already nanboxed" when syncing to the VM stack. Now only object pointers and nil (0) are treated as pre-nanboxed; all other values are nanbox-encoded. This fix affects Phase 3 collection operations as well.

**Transpiler** (`src/transpile_c.c`):
- `VREG_NEW_INSTANCE`: two-word instruction → `vigil_tc_new_instance()`
- `VREG_GET_FIELD`, `VREG_SET_FIELD`: → `vigil_tc_vm_op()`
- `VREG_CALL_INTERFACE`, `VREG_CALL_EXTERN`, `VREG_CALL_VALUE`: skip extra instruction words (stubs for later phases)
- `VREG_CHAR_FROM_INT`: → `vigil_tc_vm_op()`

### Tests
- Unit: 17 total (1 new — `ClassFieldEmitsVmOp`)
- Integration: 12 total (1 new — `test_class_field`)

Refs: #476