### PR TITLE
feat: vigil transpile — Phase 5 (closures, captures, globals)

### DIFF
--- a/integration_tests/test_transpile.py
+++ b/integration_tests/test_transpile.py
@@ -237,6 +237,16 @@ class TranspileConformanceTest(unittest.TestCase):
             "}\n"
         )
 
+    def test_global_variable(self) -> None:
+        self._conformance(
+            "i32 counter = 0\n"
+            "fn get_counter() -> i32 { return counter }\n"
+            "fn main() -> i32 {\n"
+            "    counter = 5\n"
+            "    return get_counter() - 5\n"
+            "}\n"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/transpile_c.c
+++ b/src/transpile_c.c
@@ -484,9 +484,23 @@ static vigil_status_t emit_instruction(vigil_transpile_ctx_t *ctx, const vigil_r
         /* Two-word instruction */
         if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_VALUE"); return VIGIL_STATUS_INTERNAL; }
         *ip += 1;
-        EMITF("    /* CALL_VALUE — delegated to runtime */\n");
+        EMITF("    /* CALL_VALUE -- delegated to runtime */\n");
         break;
     }
+
+    /* -- Phase 5: Globals, captures, closures -- */
+    case VREG_GET_GLOBAL:
+    case VREG_SET_GLOBAL:
+    case VREG_GET_CAPTURE:
+    case VREG_SET_CAPTURE:
+    case VREG_GET_FUNCTION:
+        EMITF("    vigil_tc_vm_op(tc, (uint64_t *)r, %u, %u, %u, %u, NULL);\n",
+              (unsigned)op, (unsigned)a, (unsigned)(bx >> 8), (unsigned)(bx & 0xFF));
+        break;
+    case VREG_NEW_CLOSURE:
+        EMITF("    vigil_tc_vm_op(tc, (uint64_t *)r, %u, %u, %u, %u, NULL);\n",
+              (unsigned)op, (unsigned)a, (unsigned)b, (unsigned)c);
+        break;
 
     default:
         EMITF("    /* unsupported opcode %u */\n", (unsigned)op);

--- a/src/transpile_rt.c
+++ b/src/transpile_rt.c
@@ -529,10 +529,71 @@ vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcod
         return vigil_instance_object_set_field(obj, (size_t)b, &val, error);
     }
     case VREG_CHAR_FROM_INT:
-    {
-        /* A B — R[A] = char_from_int(R[B]) */
         return tc_sync_and_call(tc, regs, b, 1, a, 1, vigil_vm_op_char_from_int, error);
+
+    /* ── Phase 5: Globals, captures, closures ────────────────── */
+    case VREG_GET_GLOBAL:
+    {
+        uint16_t gidx = (uint16_t)((uint16_t)b << 8 | (uint16_t)c);
+        vigil_value_t gval = 0;
+        if (!vigil_function_object_get_global(tc->function, (size_t)gidx, &gval))
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "invalid global index");
+            return VIGIL_STATUS_INTERNAL;
+        }
+        vigil_value_release(&regs[a]);
+        regs[a] = vigil_nanbox_is_int(gval) ? (uint64_t)vigil_nanbox_decode_int(gval) : gval;
+        return VIGIL_STATUS_OK;
     }
+    case VREG_SET_GLOBAL:
+    {
+        uint16_t gidx = (uint16_t)((uint16_t)b << 8 | (uint16_t)c);
+        vigil_value_t val = regs[a];
+        if (val != 0 && !vigil_nanbox_has_object(val))
+            val = vigil_nanbox_encode_int((int64_t)val);
+        return vigil_function_object_set_global(tc->function, (size_t)gidx, &val, error);
+    }
+    case VREG_GET_FUNCTION:
+    {
+        uint16_t fidx = (uint16_t)((uint16_t)b << 8 | (uint16_t)c);
+        const vigil_object_t *fn = vigil_function_object_sibling(tc->function, (size_t)fidx);
+        if (!fn)
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "invalid function index");
+            return VIGIL_STATUS_INTERNAL;
+        }
+        vigil_object_retain((vigil_object_t *)fn);
+        vigil_value_release(&regs[a]);
+        vigil_value_init_object(&regs[a], (vigil_object_t **)&fn);
+        return VIGIL_STATUS_OK;
+    }
+    case VREG_NEW_CLOSURE:
+    {
+        const vigil_object_t *fn = vigil_function_object_sibling(tc->function, (size_t)b);
+        vigil_object_t *closure = NULL;
+        vigil_value_t caps[256];
+        uint8_t ci;
+        if (!fn)
+        {
+            vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "invalid function index for closure");
+            return VIGIL_STATUS_INTERNAL;
+        }
+        for (ci = 0; ci < c; ci++)
+        {
+            uint64_t v = regs[a + ci];
+            caps[ci] = (v == 0 || vigil_nanbox_has_object(v)) ? v : vigil_nanbox_encode_int((int64_t)v);
+        }
+        status = vigil_closure_object_new(vm->runtime, (vigil_object_t *)fn, caps, (size_t)c, &closure, error);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+        vigil_value_release(&regs[a]);
+        vigil_value_init_object(&regs[a], &closure);
+        return VIGIL_STATUS_OK;
+    }
+    case VREG_GET_CAPTURE:
+    case VREG_SET_CAPTURE:
+        /* Captures require a closure callable — stub for now. */
+        return VIGIL_STATUS_OK;
 
     default:
         vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "transpile_rt: unsupported vm op");

--- a/tests/transpile_test.c
+++ b/tests/transpile_test.c
@@ -443,6 +443,33 @@ TEST(TranspileTest, ClassFieldEmitsVmOp)
     vigil_runtime_close(&runtime);
 }
 
+TEST(TranspileTest, GlobalVarEmitsVmOp)
+{
+    vigil_runtime_t *runtime = NULL;
+    vigil_string_t out;
+    vigil_error_t error = {0};
+
+    ASSERT_EQ(vigil_runtime_open(&runtime, NULL, &error), VIGIL_STATUS_OK);
+    vigil_string_init(&out, runtime);
+
+    ASSERT_EQ(CompileAndTranspile(runtime,
+                                  "i32 counter = 0\n"
+                                  "fn get_counter() -> i32 { return counter }\n"
+                                  "fn main() -> i32 {\n"
+                                  "    counter = 5\n"
+                                  "    return get_counter() - 5\n"
+                                  "}\n",
+                                  &out, &error),
+              VIGIL_STATUS_OK);
+
+    const char *c = vigil_string_c_str(&out);
+    /* GET_GLOBAL = opcode 76, SET_GLOBAL = opcode 77 */
+    EXPECT_TRUE(strstr(c, "vigil_tc_vm_op") != NULL);
+
+    vigil_string_free(&out);
+    vigil_runtime_close(&runtime);
+}
+
 /* ── Registration ────────────────────────────────────────────────── */
 
 void register_transpile_tests(void)
@@ -464,4 +491,5 @@ void register_transpile_tests(void)
     REGISTER_TEST(TranspileTest, GeneratedCodeIncludesTranspileRt);
     REGISTER_TEST(TranspileTest, ArrayNewEmitsVmOp);
     REGISTER_TEST(TranspileTest, ClassFieldEmitsVmOp);
+    REGISTER_TEST(TranspileTest, GlobalVarEmitsVmOp);
 }


### PR DESCRIPTION
## Summary

Implements Phase 5 of the Vigil-to-C transpiler from #476: global variables, function references, and closures.

### Opcodes added

- `VREG_GET_GLOBAL` / `VREG_SET_GLOBAL`: read/write module-level globals via `vigil_function_object_get/set_global`, with automatic nanbox int↔raw conversion
- `VREG_GET_FUNCTION`: get function reference as a value via `vigil_function_object_sibling`
- `VREG_NEW_CLOSURE`: create closure object with nanbox-encoded capture values via `vigil_closure_object_new`
- `VREG_GET_CAPTURE` / `VREG_SET_CAPTURE`: stubs (require closure callable context not yet available in transpiled code)

### Tests
- Unit: 18 total (1 new — `GlobalVarEmitsVmOp`)
- Integration: 13 total (1 new — `test_global_variable` conformance)

Refs: #476