### PR TITLE
feat: vigil transpile — Phase 6 (CALL_VALUE, CALL_EXTERN, stdlib calls)

### DIFF
--- a/include/vigil/transpile_rt.h
+++ b/include/vigil/transpile_rt.h
@@ -84,6 +84,15 @@ extern "C"
                                          uint16_t class_idx, uint8_t fields_base, uint8_t field_count,
                                          vigil_error_t *error);
 
+    /* Call a function value (closure/function object in a register). */
+    vigil_status_t vigil_tc_call_value(vigil_tc_t *tc, vigil_value_t *regs, uint8_t ret,
+                                       uint16_t arg_count, uint8_t arg_base, vigil_error_t *error);
+
+    /* Call an extern function by descriptor constant index. */
+    vigil_status_t vigil_tc_call_extern(vigil_tc_t *tc, vigil_value_t *regs, uint8_t ret,
+                                        uint8_t const_idx, uint8_t arg_count, uint8_t arg_base,
+                                        vigil_error_t *error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration_tests/test_transpile.py
+++ b/integration_tests/test_transpile.py
@@ -247,6 +247,17 @@ class TranspileConformanceTest(unittest.TestCase):
             "}\n"
         )
 
+    def test_function_value(self) -> None:
+        self._conformance(
+            "fn add(i32 a, i32 b) -> i32 { return a + b }\n"
+            "fn apply(fn(i32, i32) -> i32 f, i32 x, i32 y) -> i32 {\n"
+            "    return f(x, y)\n"
+            "}\n"
+            "fn main() -> i32 {\n"
+            "    return apply(add, 10, 20) - 30\n"
+            "}\n"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -3694,6 +3694,7 @@ static int transpile_write_project(const char *output_dir, const vigil_string_t 
             "    if (vigil_runtime_open(&runtime, NULL, &error) != 0) return 1;\n"
             "    if (vigil_vm_open(&vm, runtime, NULL, &error) != 0)\n"
             "    { vigil_runtime_close(&runtime); return 1; }\n"
+            "    vigil_vm_set_aot_enabled(vm, 0);\n"
             "    vigil_source_registry_init(&registry, runtime);\n"
             "    vigil_diagnostic_list_init(&diagnostics, runtime);\n"
             "    vigil_source_registry_register_cstr(&registry, \"main.vigil\", vigil_source, &sid, &error);\n"

--- a/src/transpile_c.c
+++ b/src/transpile_c.c
@@ -463,28 +463,33 @@ static vigil_status_t emit_instruction(vigil_transpile_ctx_t *ctx, const vigil_r
     }
     case VREG_CALL_INTERFACE:
     {
-        /* Three-word instruction: word1=[op,A=ret,B=iface_idx,C=arg_count], word2=method_idx, word3=arg_base */
+        /* Three-word: word1=[op,A=ret,B=iface_idx,C=arg_count], word2=method_idx, word3=arg_base */
         if (*ip + 2 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_INTERFACE"); return VIGIL_STATUS_INTERNAL; }
+        uint32_t method_idx = rc->code[*ip + 1];
+        uint8_t arg_base_r = (uint8_t)(rc->code[*ip + 2] & 0xFF);
         *ip += 2;
-        /* Delegate to VM via native call mechanism — too complex for direct codegen. */
-        EMITF("    /* CALL_INTERFACE iface=%u method=%u args=%u — delegated to runtime */\n",
-              (unsigned)b, (unsigned)rc->code[*ip - 1], (unsigned)c);
+        EMITF("    /* CALL_INTERFACE iface=%u method=%u args=%u base=%u -- delegated to runtime */\n",
+              (unsigned)b, (unsigned)method_idx, (unsigned)c, (unsigned)arg_base_r);
         break;
     }
     case VREG_CALL_EXTERN:
     {
-        /* Two-word instruction */
+        /* A=ret, B=const_idx, C=arg_count. Next word = arg_base. */
         if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_EXTERN"); return VIGIL_STATUS_INTERNAL; }
+        uint8_t arg_base_r = (uint8_t)(rc->code[*ip + 1] & 0xFF);
         *ip += 1;
-        EMITF("    /* CALL_EXTERN — delegated to runtime */\n");
+        EMITF("    vigil_tc_call_extern(tc, (uint64_t *)r, %u, %u, %u, %u, NULL);\n",
+              (unsigned)a, (unsigned)b, (unsigned)c, (unsigned)arg_base_r);
         break;
     }
     case VREG_CALL_VALUE:
     {
-        /* Two-word instruction */
+        /* A=ret, Bx=arg_count. Next word = arg_base. */
         if (*ip + 1 >= rc->code_count) { vigil_error_set_literal(ctx->error, VIGIL_STATUS_INTERNAL, "transpile: truncated CALL_VALUE"); return VIGIL_STATUS_INTERNAL; }
+        uint8_t arg_base_r = (uint8_t)(rc->code[*ip + 1] & 0xFF);
         *ip += 1;
-        EMITF("    /* CALL_VALUE -- delegated to runtime */\n");
+        EMITF("    vigil_tc_call_value(tc, (uint64_t *)r, %u, %u, %u, NULL);\n",
+              (unsigned)a, (unsigned)bx, (unsigned)arg_base_r);
         break;
     }
 

--- a/src/transpile_rt.c
+++ b/src/transpile_rt.c
@@ -592,7 +592,7 @@ vigil_status_t vigil_tc_vm_op(vigil_tc_t *tc, vigil_value_t *regs, uint8_t opcod
     }
     case VREG_GET_CAPTURE:
     case VREG_SET_CAPTURE:
-        /* Captures require a closure callable — stub for now. */
+        /* Captures require a closure callable -- stub for now. */
         return VIGIL_STATUS_OK;
 
     default:
@@ -629,5 +629,112 @@ vigil_status_t vigil_tc_new_instance(vigil_tc_t *tc, vigil_value_t *regs, uint8_
 
     vigil_value_release(&regs[dest]);
     vigil_value_init_object(&regs[dest], &inst);
+    return VIGIL_STATUS_OK;
+}
+
+vigil_status_t vigil_tc_call_value(vigil_tc_t *tc, vigil_value_t *regs, uint8_t ret,
+                                   uint16_t arg_count, uint8_t arg_base, vigil_error_t *error)
+{
+    vigil_vm_t *vm = tc->vm;
+    vigil_status_t status;
+    size_t total = (size_t)arg_count + 1U;
+    size_t i;
+
+    status = tc_ensure_frame(tc, error);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    if (vm->stack_capacity < (size_t)arg_base + total)
+    {
+        status = vigil_vm_grow_stack(vm, (size_t)arg_base + total, error);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+    }
+
+    /* Sync registers: callee at arg_base, then args. */
+    for (i = 0; i < total; i++)
+    {
+        uint64_t v = regs[arg_base + i];
+        vm->stack[arg_base + i] = (v == 0 || vigil_nanbox_has_object(v)) ? v : vigil_nanbox_encode_int((int64_t)v);
+    }
+    vm->stack_count = (size_t)arg_base + total;
+
+    /* Extract callee, shift args down. */
+    vigil_value_t callee_val = vm->stack[arg_base];
+    if (!vigil_nanbox_is_object(callee_val))
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INVALID_ARGUMENT, "call_value: not a callable");
+        return VIGIL_STATUS_INVALID_ARGUMENT;
+    }
+    vigil_object_t *callee = (vigil_object_t *)vigil_nanbox_decode_ptr(callee_val);
+    vigil_value_release(&vm->stack[arg_base]);
+    if (arg_count > 0)
+        memmove(&vm->stack[arg_base], &vm->stack[arg_base + 1], (size_t)arg_count * sizeof(vigil_value_t));
+    vm->stack_count -= 1U;
+
+    status = vigil_vm_execute_call(vm, callee, (size_t)arg_count, error);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    /* Copy results back. */
+    for (i = (size_t)arg_base; i < vm->stack_count && i < (size_t)arg_base + total; i++)
+    {
+        vigil_value_t rv = vm->stack[i];
+        regs[ret + (i - (size_t)arg_base)] = vigil_nanbox_is_int(rv) ? (uint64_t)vigil_nanbox_decode_int(rv) : rv;
+    }
+    return VIGIL_STATUS_OK;
+}
+
+vigil_status_t vigil_tc_call_extern(vigil_tc_t *tc, vigil_value_t *regs, uint8_t ret,
+                                    uint8_t const_idx, uint8_t arg_count, uint8_t arg_base,
+                                    vigil_error_t *error)
+{
+    vigil_vm_t *vm = tc->vm;
+    vigil_status_t status;
+    size_t i;
+
+    if ((size_t)const_idx >= tc->constant_count)
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_INTERNAL, "call_extern: invalid constant index");
+        return VIGIL_STATUS_INTERNAL;
+    }
+
+    status = tc_ensure_frame(tc, error);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    if (vm->stack_capacity < (size_t)arg_base + (size_t)arg_count)
+    {
+        status = vigil_vm_grow_stack(vm, (size_t)arg_base + (size_t)arg_count, error);
+        if (status != VIGIL_STATUS_OK)
+            return status;
+    }
+
+    for (i = 0; i < (size_t)arg_count; i++)
+    {
+        uint64_t v = regs[arg_base + i];
+        vm->stack[arg_base + i] = (v == 0 || vigil_nanbox_has_object(v)) ? v : vigil_nanbox_encode_int((int64_t)v);
+    }
+    vm->stack_count = (size_t)arg_base + (size_t)arg_count;
+
+    const vigil_value_t *desc_val = &tc->constants[const_idx];
+    if (!vigil_nanbox_has_object(*desc_val))
+    {
+        vigil_error_set_literal(error, VIGIL_STATUS_UNSUPPORTED, "call_extern: not an object constant");
+        return VIGIL_STATUS_UNSUPPORTED;
+    }
+    vigil_object_t *desc_obj = (vigil_object_t *)vigil_nanbox_decode_ptr(*desc_val);
+    const char *desc = vigil_string_object_c_str(desc_obj);
+    size_t desc_len = vigil_string_object_length(desc_obj);
+
+    status = vigil_vm_call_extern_fn(vm, desc, desc_len, (size_t)arg_count, error);
+    if (status != VIGIL_STATUS_OK)
+        return status;
+
+    for (i = (size_t)arg_base; i < vm->stack_count; i++)
+    {
+        vigil_value_t rv = vm->stack[i];
+        regs[ret + (i - (size_t)arg_base)] = vigil_nanbox_is_int(rv) ? (uint64_t)vigil_nanbox_decode_int(rv) : rv;
+    }
     return VIGIL_STATUS_OK;
 }


### PR DESCRIPTION
## Summary

Implements Phase 6 of the Vigil-to-C transpiler from #476: complete call opcode support.

### Deliverables

- `VREG_CALL_VALUE`: calls function values (closures, function references) via `vigil_tc_call_value()` — syncs registers to VM stack, extracts callee object, shifts args, delegates to `vigil_vm_execute_call`
- `VREG_CALL_EXTERN`: calls extern functions by descriptor string from constant pool via `vigil_tc_call_extern()` → `vigil_vm_call_extern_fn`
- `VREG_CALL_INTERFACE`: properly skips all 3 instruction words (stub — full interface dispatch in future work)
- AOT disabled in generated main to avoid pre-existing MIR ASAN crash

Note: `VREG_CALL_NATIVE` was already implemented in Phase 2, and `VREG_CHAR_FROM_INT` in Phase 4. Runtime source copying (the other Phase 6 deliverable) is deferred to Phase 8 which handles the full CI/conformance infrastructure.

### Tests
- Integration: 14 total (1 new — `test_function_value` conformance verifying indirect function calls through function value parameters)

Refs: #476