### PR TITLE
ci: make complexity and sonarqube checks informational

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -66,6 +66,7 @@ jobs:
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Check lizard complexity
+        continue-on-error: true
         run: >
           python3 scripts/check_complexity.py
           --candidate-root $PWD
@@ -76,6 +77,7 @@ jobs:
           --baseline-report complexity-artifacts/lizard-main.csv
 
       - name: Run clang-tidy on PR head
+        continue-on-error: true
         env:
           CLANG_TIDY_BIN: /usr/bin/clang-tidy-18
           CLANG_TIDY_CONFIG_FILE: ${{ github.workspace }}/.clang-tidy
@@ -86,6 +88,7 @@ jobs:
           $PWD/complexity-artifacts/clang-tidy-pr.log
 
       - name: Run clang-tidy on origin/main
+        continue-on-error: true
         env:
           CLANG_TIDY_BIN: /usr/bin/clang-tidy-18
           CLANG_TIDY_CONFIG_FILE: ${{ github.workspace }}/.clang-tidy
@@ -96,6 +99,7 @@ jobs:
           $PWD/complexity-artifacts/clang-tidy-main.log
 
       - name: Check clang-tidy diagnostics
+        continue-on-error: true
         run: >
           python3 scripts/check_clang_tidy.py
           --baseline-log complexity-artifacts/clang-tidy-main.log

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -63,6 +63,7 @@ jobs:
           --sonarqube sonarqube-coverage.xml
 
       - name: SonarQube Scan
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Adds `continue-on-error: true` to the analysis steps in the complexity and sonarqube workflows so they report results as informational without failing the PR check status.

**complexity.yml:** lizard check, clang-tidy runs, and clang-tidy diagnostics check all marked informational.

**sonarqube.yml:** SonarQube scan step marked informational.

Note: The `SonarCloud Code Analysis` check that appears on PRs is a separate GitHub App quality gate controlled in SonarCloud project settings — it cannot be made informational from the workflow file alone.